### PR TITLE
fix: pass memory config to MemoryIndexManager

### DIFF
--- a/src/core/a2a-mcp.ts
+++ b/src/core/a2a-mcp.ts
@@ -685,10 +685,17 @@ export function getA2AMcpServer(sessionName: string): any {
   const getMemoryManager = async () => {
     if (!memoryManager) {
       const sessionDir = join(SESSIONS_DIR, sessionName);
+      // Get memory config from central config
+      const mainConfig = centralConfig.get();
+      const memoryConfig = (mainConfig as any).memory || {};
+
       memoryManager = await MemoryIndexManager.create({
         globalDir: GLOBAL_IDENTITY_DIR,
         sessionDir: sessionDir,
         config: {
+          provider: memoryConfig.provider || "auto",
+          model: memoryConfig.model || "text-embedding-3-small",
+          remote: memoryConfig.remote,
           store: {
             path: join(WOPR_HOME, "memory", "index.sqlite"),
             vector: { enabled: true },


### PR DESCRIPTION
## Summary
- Pass memory.provider, memory.model, memory.remote from WOPR config to MemoryIndexManager
- Enables OpenAI embeddings to work via config instead of only env vars

## Test plan
- [x] Set memory.provider=openai, memory.remote.apiKey via config
- [ ] Verify memory_search uses vector embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)