### PR TITLE
fix: use createRequire for node:sqlite in ESM

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -1,9 +1,12 @@
 // MemoryIndexManager - adapted from OpenClaw for WOPR
 import type { DatabaseSync } from "node:sqlite";
+import { createRequire } from "node:module";
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+
+const require = createRequire(import.meta.url);
 import { WOPR_HOME } from "../paths.js";
 import {
   createEmbeddingProvider,


### PR DESCRIPTION
## Summary
- Dynamic `require()` doesn't work in ESM modules
- Use `createRequire` from `node:module` to enable `require("node:sqlite")`
- Fixes memory embeddings initialization failure

## Test plan
- [x] Build succeeds
- [ ] Memory search works after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)