### PR TITLE
feat: Support V2 Session API for Providers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -829,6 +829,31 @@ export interface WOPRPluginContext {
 
   // Access to plugin directory
   getPluginDir(): string;
+
+  // =========================================================================
+  // V2 Session API - for injecting into active sessions without queuing
+  // =========================================================================
+
+  /**
+   * Check if a session has an active V2 streaming response in progress.
+   * When true, injectIntoActiveSession() can be used to inject messages
+   * without waiting for the current response to complete.
+   *
+   * Note: This is async to ensure provider cache is populated before checking.
+   */
+  hasActiveSession?(session: string): Promise<boolean>;
+
+  /**
+   * Inject a message into an actively streaming session.
+   * The message is sent via session.send() and responses flow through
+   * the existing stream - no new stream is created.
+   *
+   * @throws Error if no active session exists (use hasActiveSession() first)
+   */
+  injectIntoActiveSession?(session: string, message: string, options?: {
+    from?: string;
+    channel?: ChannelRef;
+  }): Promise<void>;
 }
 
 export type InjectionHandler = (


### PR DESCRIPTION
## Summary

Adds support for provider V2 session API in WOPR core, enabling providers to maintain persistent sessions that support message injection.

## Changes

### `src/types/provider.ts`
Extended `ModelClient` interface with optional V2 methods:
- `queryV2()` - Session-tracked query with injection support
- `hasActiveSession()` - Check if session is actively streaming
- `sendToActiveSession()` - Inject message into active session
- `getActiveSessionStream()` - Get stream generator for active session
- `closeSession()` - Explicitly close a session

### `src/core/sessions.ts`
Updated `createQuery()` helper to:
- Check if provider supports `queryV2()`
- Pass `sessionKey` (WOPR's session identifier) to enable session tracking
- Fall back to V1 `query()` for providers that don't support V2

## Benefits

With V2 session support:
1. Providers can maintain persistent sessions across multiple injects
2. New messages can be injected into active sessions without canceling streams
3. Better conversation context preservation
4. Improved UX for multi-turn conversations

## Related PRs

- wopr-network/wopr-plugin-provider-anthropic#1 - Anthropic provider V2 implementation

## Testing

- [ ] Providers without V2 continue to work (backward compatible)
- [ ] Anthropic provider V2 sessions are used when available
- [ ] Session reuse works across multiple injects

🤖 Generated with [Claude Code](https://claude.com/claude-code)