### PR TITLE
feat(memory): add temporal filtering to memory_search

### DIFF
--- a/src/core/a2a-mcp.ts
+++ b/src/core/a2a-mcp.ts
@@ -13,7 +13,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 
 import { exec } from "child_process";
 import { promisify } from "util";
 import { SESSIONS_DIR, GLOBAL_IDENTITY_DIR, WOPR_HOME } from "../paths.js";
-import { MemoryIndexManager } from "../memory/index.js";
+import { MemoryIndexManager, parseTemporalFilter } from "../memory/index.js";
 import { config as centralConfig } from "./config.js";
 import {
   getCrons,
@@ -709,18 +709,26 @@ export function getA2AMcpServer(sessionName: string): any {
   tools.push(
     tool(
       "memory_search",
-      "Semantically search memory files using vector embeddings and hybrid BM25 keyword search. Searches both global identity and session-specific files.",
+      "Semantically search memory files using vector embeddings and hybrid BM25 keyword search. Searches both global identity and session-specific files. Supports temporal filtering.",
       {
         query: z.string().describe("Search query - uses semantic similarity to find relevant content"),
         maxResults: z.number().optional().describe("Maximum results (default: 10)"),
-        minScore: z.number().optional().describe("Minimum relevance score 0-1 (default: 0.35)")
+        minScore: z.number().optional().describe("Minimum relevance score 0-1 (default: 0.35)"),
+        temporal: z.string().optional().describe("Time filter: relative (\"24h\", \"7d\", \"2w\", \"1m\", \"last 3 days\") or date range (\"2026-01-01\", \"2026-01-01 to 2026-01-05\")")
       },
       async (args) => {
-        const { query, maxResults = 10, minScore = 0.35 } = args;
+        const { query, maxResults = 10, minScore = 0.35, temporal: temporalExpr } = args;
+
+        // Parse temporal filter if provided
+        const parsedTemporal = temporalExpr ? parseTemporalFilter(temporalExpr) : null;
+        if (temporalExpr && !parsedTemporal) {
+          return { content: [{ type: "text", text: `Invalid temporal filter "${temporalExpr}". Examples: "24h", "7d", "last 3 days", "2026-01-01", "2026-01-01 to 2026-01-05"` }] };
+        }
+        const temporal = parsedTemporal ?? undefined;
 
         try {
           const manager = await getMemoryManager();
-          let results = await manager.search(query, { maxResults: maxResults * 2, minScore });
+          let results = await manager.search(query, { maxResults: maxResults * 2, minScore, temporal });
 
           // Filter session transcript results based on indexable permissions
           const ctx = getContext(sessionName);
@@ -743,14 +751,16 @@ export function getA2AMcpServer(sessionName: string): any {
           }).slice(0, maxResults);
 
           if (results.length === 0) {
-            return { content: [{ type: "text", text: `No matches found for "${query}"` }] };
+            const temporalNote = temporalExpr ? ` within time range "${temporalExpr}"` : "";
+            return { content: [{ type: "text", text: `No matches found for "${query}"${temporalNote}` }] };
           }
 
           const formatted = results.map((r, i) =>
             `[${i + 1}] ${r.source}/${r.path}:${r.startLine}-${r.endLine} (score: ${r.score.toFixed(2)})\n${r.snippet}`
           ).join("\n\n---\n\n");
 
-          return { content: [{ type: "text", text: `Found ${results.length} results:\n\n${formatted}` }] };
+          const temporalNote = temporalExpr ? ` (filtered by: ${temporalExpr})` : "";
+          return { content: [{ type: "text", text: `Found ${results.length} results${temporalNote}:\n\n${formatted}` }] };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           // Fallback to keyword-only search if embeddings fail

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -6,7 +6,9 @@ export {
   type MemoryConfig,
   type MemorySearchResult,
   type MemorySource,
+  type TemporalFilter,
   DEFAULT_MEMORY_CONFIG,
+  parseTemporalFilter,
 } from "./types.js";
 export { type EmbeddingProvider } from "./embeddings.js";
 export { saveSessionToMemory, createSessionDestroyHandler } from "./session-hook.js";

--- a/src/memory/search.ts
+++ b/src/memory/search.ts
@@ -1,6 +1,7 @@
 // Search functions for vector and keyword search - adapted from OpenClaw
 import type { DatabaseSync } from "node:sqlite";
 import { cosineSimilarity, parseEmbedding, truncateUtf16Safe } from "./internal.js";
+import type { TemporalFilter } from "./types.js";
 
 const vectorToBlob = (embedding: number[]): Buffer =>
   Buffer.from(new Float32Array(embedding).buffer);
@@ -17,6 +18,39 @@ export type SearchRowResult = {
   source: SearchSource;
 };
 
+/**
+ * Build SQL WHERE clause for temporal filtering
+ * Uses the chunks.updated_at column (ms since epoch)
+ */
+export function buildTemporalFilter(
+  temporal: TemporalFilter | undefined,
+  alias?: string
+): { sql: string; params: number[] } {
+  if (!temporal) {
+    return { sql: "", params: [] };
+  }
+
+  const column = alias ? `${alias}.updated_at` : "updated_at";
+  const clauses: string[] = [];
+  const params: number[] = [];
+
+  if (temporal.after !== undefined) {
+    clauses.push(`${column} >= ?`);
+    params.push(temporal.after);
+  }
+
+  if (temporal.before !== undefined) {
+    clauses.push(`${column} <= ?`);
+    params.push(temporal.before);
+  }
+
+  if (clauses.length === 0) {
+    return { sql: "", params: [] };
+  }
+
+  return { sql: ` AND ${clauses.join(" AND ")}`, params };
+}
+
 export async function searchVector(params: {
   db: DatabaseSync;
   vectorTable: string;
@@ -27,10 +61,14 @@ export async function searchVector(params: {
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
   sourceFilterVec: { sql: string; params: SearchSource[] };
   sourceFilterChunks: { sql: string; params: SearchSource[] };
+  temporalFilter?: { sql: string; params: number[] };
 }): Promise<SearchRowResult[]> {
   if (params.queryVec.length === 0 || params.limit <= 0) {
     return [];
   }
+  const temporalSql = params.temporalFilter?.sql ?? "";
+  const temporalParams = params.temporalFilter?.params ?? [];
+
   if (await params.ensureVectorReady(params.queryVec.length)) {
     const rows = params.db
       .prepare(
@@ -39,7 +77,7 @@ export async function searchVector(params: {
           `       vec_distance_cosine(v.embedding, ?) AS dist\n` +
           `  FROM ${params.vectorTable} v\n` +
           `  JOIN chunks c ON c.id = v.id\n` +
-          ` WHERE c.model = ?${params.sourceFilterVec.sql}\n` +
+          ` WHERE c.model = ?${params.sourceFilterVec.sql}${temporalSql}\n` +
           ` ORDER BY dist ASC\n` +
           ` LIMIT ?`,
       )
@@ -47,6 +85,7 @@ export async function searchVector(params: {
         vectorToBlob(params.queryVec),
         params.providerModel,
         ...params.sourceFilterVec.params,
+        ...temporalParams,
         params.limit,
       ) as Array<{
       id: string;
@@ -72,6 +111,7 @@ export async function searchVector(params: {
     db: params.db,
     providerModel: params.providerModel,
     sourceFilter: params.sourceFilterChunks,
+    temporalFilter: params.temporalFilter,
   });
   const scored = candidates
     .map((chunk) => ({
@@ -97,6 +137,7 @@ export function listChunks(params: {
   db: DatabaseSync;
   providerModel: string;
   sourceFilter: { sql: string; params: SearchSource[] };
+  temporalFilter?: { sql: string; params: number[] };
 }): Array<{
   id: string;
   path: string;
@@ -106,13 +147,16 @@ export function listChunks(params: {
   embedding: number[];
   source: SearchSource;
 }> {
+  const temporalSql = params.temporalFilter?.sql ?? "";
+  const temporalParams = params.temporalFilter?.params ?? [];
+
   const rows = params.db
     .prepare(
       `SELECT id, path, start_line, end_line, text, embedding, source\n` +
         `  FROM chunks\n` +
-        ` WHERE model = ?${params.sourceFilter.sql}`,
+        ` WHERE model = ?${params.sourceFilter.sql}${temporalSql}`,
     )
-    .all(params.providerModel, ...params.sourceFilter.params) as Array<{
+    .all(params.providerModel, ...params.sourceFilter.params, ...temporalParams) as Array<{
     id: string;
     path: string;
     start_line: number;
@@ -143,6 +187,7 @@ export async function searchKeyword(params: {
   sourceFilter: { sql: string; params: SearchSource[] };
   buildFtsQuery: (raw: string) => string | null;
   bm25RankToScore: (rank: number) => number;
+  temporalFilter?: { sql: string; params: number[] };
 }): Promise<Array<SearchRowResult & { textScore: number }>> {
   if (params.limit <= 0) {
     return [];
@@ -152,16 +197,14 @@ export async function searchKeyword(params: {
     return [];
   }
 
-  const rows = params.db
-    .prepare(
-      `SELECT id, path, source, start_line, end_line, text,\n` +
-        `       bm25(${params.ftsTable}) AS rank\n` +
-        `  FROM ${params.ftsTable}\n` +
-        ` WHERE ${params.ftsTable} MATCH ? AND model = ?${params.sourceFilter.sql}\n` +
-        ` ORDER BY rank ASC\n` +
-        ` LIMIT ?`,
-    )
-    .all(ftsQuery, params.providerModel, ...params.sourceFilter.params, params.limit) as Array<{
+  const temporalSql = params.temporalFilter?.sql ?? "";
+  const temporalParams = params.temporalFilter?.params ?? [];
+
+  // If temporal filter is set, join with chunks table to get updated_at
+  // FTS5 virtual tables don't support additional columns
+  const hasTemporal = temporalSql.length > 0;
+
+  let rows: Array<{
     id: string;
     path: string;
     source: SearchSource;
@@ -170,6 +213,32 @@ export async function searchKeyword(params: {
     text: string;
     rank: number;
   }>;
+
+  if (hasTemporal) {
+    // Join with chunks table to filter by updated_at
+    rows = params.db
+      .prepare(
+        `SELECT f.id, f.path, f.source, f.start_line, f.end_line, f.text,\n` +
+          `       bm25(${params.ftsTable}) AS rank\n` +
+          `  FROM ${params.ftsTable} f\n` +
+          `  JOIN chunks c ON c.id = f.id\n` +
+          ` WHERE ${params.ftsTable} MATCH ? AND f.model = ?${params.sourceFilter.sql}${temporalSql.replace(/\bupdated_at\b/g, "c.updated_at")}\n` +
+          ` ORDER BY rank ASC\n` +
+          ` LIMIT ?`,
+      )
+      .all(ftsQuery, params.providerModel, ...params.sourceFilter.params, ...temporalParams, params.limit) as typeof rows;
+  } else {
+    rows = params.db
+      .prepare(
+        `SELECT id, path, source, start_line, end_line, text,\n` +
+          `       bm25(${params.ftsTable}) AS rank\n` +
+          `  FROM ${params.ftsTable}\n` +
+          ` WHERE ${params.ftsTable} MATCH ? AND model = ?${params.sourceFilter.sql}\n` +
+          ` ORDER BY rank ASC\n` +
+          ` LIMIT ?`,
+      )
+      .all(ftsQuery, params.providerModel, ...params.sourceFilter.params, params.limit) as typeof rows;
+  }
 
   return rows.map((row) => {
     const textScore = params.bm25RankToScore(row.rank);

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -2,6 +2,131 @@
 
 export type MemorySource = "global" | "session" | "sessions";
 
+/**
+ * Temporal filter for memory search
+ * Supports both relative ("24h", "7d", "2w") and absolute dates
+ */
+export type TemporalFilter = {
+  /** Start timestamp (inclusive) - ms since epoch */
+  after?: number;
+  /** End timestamp (inclusive) - ms since epoch */
+  before?: number;
+};
+
+/**
+ * Parse a temporal expression into a TemporalFilter
+ *
+ * Supports:
+ * - Relative: "24h", "7d", "2w", "1m" (hours, days, weeks, months)
+ * - Absolute: "2026-01-01", "2026-01-01T12:00:00"
+ * - Range: "2026-01-01-2026-01-05" or "2026-01-01 to 2026-01-05"
+ *
+ * Returns null if the expression can't be parsed
+ */
+export function parseTemporalFilter(expr: string): TemporalFilter | null {
+  if (!expr || typeof expr !== "string") {
+    return null;
+  }
+
+  const trimmed = expr.trim().toLowerCase();
+
+  // Check for relative time expressions: "24h", "7d", "2w", "1m"
+  const relativeMatch = trimmed.match(/^(\d+)(h|d|w|m)$/);
+  if (relativeMatch) {
+    const amount = parseInt(relativeMatch[1], 10);
+    const unit = relativeMatch[2];
+    const now = Date.now();
+
+    let msAgo: number;
+    switch (unit) {
+      case "h":
+        msAgo = amount * 60 * 60 * 1000;
+        break;
+      case "d":
+        msAgo = amount * 24 * 60 * 60 * 1000;
+        break;
+      case "w":
+        msAgo = amount * 7 * 24 * 60 * 60 * 1000;
+        break;
+      case "m":
+        msAgo = amount * 30 * 24 * 60 * 60 * 1000; // ~30 days
+        break;
+      default:
+        return null;
+    }
+
+    return { after: now - msAgo };
+  }
+
+  // Check for "last X hours/days/weeks" format
+  const lastMatch = trimmed.match(/^last\s+(\d+)\s+(hours?|days?|weeks?|months?)$/);
+  if (lastMatch) {
+    const amount = parseInt(lastMatch[1], 10);
+    const unit = lastMatch[2];
+    const now = Date.now();
+
+    let msAgo: number;
+    if (unit.startsWith("hour")) {
+      msAgo = amount * 60 * 60 * 1000;
+    } else if (unit.startsWith("day")) {
+      msAgo = amount * 24 * 60 * 60 * 1000;
+    } else if (unit.startsWith("week")) {
+      msAgo = amount * 7 * 24 * 60 * 60 * 1000;
+    } else if (unit.startsWith("month")) {
+      msAgo = amount * 30 * 24 * 60 * 60 * 1000;
+    } else {
+      return null;
+    }
+
+    return { after: now - msAgo };
+  }
+
+  // Check for date range: "2026-01-01-2026-01-05" or "2026-01-01 to 2026-01-05"
+  const rangeMatch = trimmed.match(
+    /^(\d{4}-\d{2}-\d{2})(?:T[\d:]+)?(?:\s*(?:-|to)\s*)(\d{4}-\d{2}-\d{2})(?:T[\d:]+)?$/
+  );
+  if (rangeMatch) {
+    const startDate = new Date(rangeMatch[1]);
+    const endDate = new Date(rangeMatch[2]);
+    // Set end date to end of day
+    endDate.setHours(23, 59, 59, 999);
+
+    if (!isNaN(startDate.getTime()) && !isNaN(endDate.getTime())) {
+      return {
+        after: startDate.getTime(),
+        before: endDate.getTime(),
+      };
+    }
+  }
+
+  // Check for single date: "2026-01-01" (entire day)
+  const singleDateMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})$/);
+  if (singleDateMatch) {
+    const startDate = new Date(singleDateMatch[1]);
+    const endDate = new Date(singleDateMatch[1]);
+    endDate.setHours(23, 59, 59, 999);
+
+    if (!isNaN(startDate.getTime())) {
+      return {
+        after: startDate.getTime(),
+        before: endDate.getTime(),
+      };
+    }
+  }
+
+  // Check for ISO datetime: "2026-01-01T12:00:00"
+  const isoMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2}T[\d:]+)$/);
+  if (isoMatch) {
+    const date = new Date(isoMatch[1]);
+    if (!isNaN(date.getTime())) {
+      // Single datetime - treat as "since this time"
+      return { after: date.getTime() };
+    }
+  }
+
+  return null;
+}
+
 export type MemorySearchResult = {
   path: string;
   startLine: number;


### PR DESCRIPTION
## Summary

- Adds `temporal` parameter to `memory_search` tool for time-based filtering
- Supports relative time expressions (`24h`, `7d`, `last 3 days`)
- Supports absolute dates and date ranges (`2026-01-01`, `2026-01-01 to 2026-01-05`)
- Filters by `chunks.updated_at` timestamp
- Works with both vector search and BM25 keyword search

## Usage Examples

```
memory_search query="authentication" temporal="24h"
memory_search query="JWT tokens" temporal="last 7 days"
memory_search query="bug fix" temporal="2026-01-02 to 2026-01-03"
```

## Supported Formats

| Format | Example | Description |
|--------|---------|-------------|
| Relative short | `24h`, `7d`, `2w`, `1m` | Hours, days, weeks, months ago |
| Relative verbose | `last 3 days` | Natural language |
| Single date | `2026-01-01` | Entire day |
| Date range | `2026-01-01 to 2026-01-05` | Inclusive range |
| ISO datetime | `2026-01-01T12:00:00` | Since specific time |

## Test plan

- [ ] Search with `temporal="24h"` returns only recent results
- [ ] Search with invalid temporal expression returns helpful error message
- [ ] Search without temporal parameter works as before (no regression)
- [ ] Date range filtering works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)