### PR TITLE
feat(onboard): add external access and GitHub integration steps

### DIFF
--- a/src/commands/onboard/index.ts
+++ b/src/commands/onboard/index.ts
@@ -17,6 +17,8 @@ import { workspaceStep } from "./steps/05-workspace.js";
 import { providersStep } from "./steps/06-providers.js";
 import { channelsStep } from "./steps/07-channels.js";
 import { voiceStep } from "./steps/07b-voice.js";
+import { externalStep } from "./steps/07c-external.js";
+import { githubStep } from "./steps/07d-github.js";
 import { skillsStep } from "./steps/08-skills.js";
 import { daemonStep } from "./steps/09-daemon.js";
 import { finalizeStep } from "./steps/10-finalize.js";
@@ -30,7 +32,9 @@ const steps = [
   workspaceStep,
   providersStep,
   channelsStep,
-  voiceStep,  // Voice setup after channels
+  voiceStep,      // Voice setup after channels
+  externalStep,   // External access (Tailscale Funnel)
+  githubStep,     // GitHub webhook integration
   skillsStep,
   daemonStep,
   finalizeStep,

--- a/src/commands/onboard/steps/07c-external.ts
+++ b/src/commands/onboard/steps/07c-external.ts
@@ -1,0 +1,150 @@
+/**
+ * Step 7c: External Access (Tailscale Funnel)
+ *
+ * Sets up external webhook access via Tailscale Funnel.
+ */
+import { confirm, note, spinner, pc } from "../prompts.js";
+import { execSync } from "node:child_process";
+import type { OnboardContext, OnboardStep } from "../types.js";
+
+function exec(cmd: string): { stdout: string; success: boolean } {
+  try {
+    const stdout = execSync(cmd, { encoding: "utf-8", timeout: 10000 }).trim();
+    return { stdout, success: true };
+  } catch {
+    return { stdout: "", success: false };
+  }
+}
+
+function checkTailscale(): { installed: boolean; connected: boolean; hostname?: string } {
+  // Check if installed
+  const which = exec("which tailscale");
+  if (!which.success) {
+    return { installed: false, connected: false };
+  }
+
+  // Check if connected
+  const status = exec("tailscale status --json");
+  if (!status.success) {
+    return { installed: true, connected: false };
+  }
+
+  try {
+    const parsed = JSON.parse(status.stdout);
+    if (parsed.BackendState !== "Running") {
+      return { installed: true, connected: false };
+    }
+    const hostname = parsed.Self?.DNSName?.replace(/\.$/, "") || undefined;
+    return { installed: true, connected: true, hostname };
+  } catch {
+    return { installed: true, connected: false };
+  }
+}
+
+export const externalStep: OnboardStep = async (ctx: OnboardContext) => {
+  // Skip if user doesn't want external access
+  const wantExternal = await confirm({
+    message: "Set up external webhook access (for GitHub, etc)?",
+    initialValue: false,
+  });
+
+  if (!wantExternal) {
+    await note([
+      "Skipping external access setup.",
+      "",
+      "You can set this up later:",
+      pc.cyan("  wopr funnel expose 7438"),
+    ].join("\n"), "External Access");
+    return {};
+  }
+
+  // Check Tailscale status
+  const s = await spinner();
+  s.start("Checking Tailscale...");
+
+  const ts = checkTailscale();
+
+  if (!ts.installed) {
+    s.stop("Tailscale not installed");
+    await note([
+      "Tailscale is required for external webhook access.",
+      "",
+      "Install Tailscale:",
+      pc.cyan("  curl -fsSL https://tailscale.com/install.sh | sh"),
+      "",
+      "Or visit: https://tailscale.com/download",
+      "",
+      "After installing, run:",
+      pc.cyan("  tailscale up"),
+      pc.cyan("  wopr onboard  # re-run this wizard"),
+    ].join("\n"), "Tailscale Required");
+    return {};
+  }
+
+  if (!ts.connected) {
+    s.stop("Tailscale not connected");
+    await note([
+      "Tailscale is installed but not connected.",
+      "",
+      "Connect to your tailnet:",
+      pc.cyan("  tailscale up"),
+      "",
+      "Then re-run this wizard:",
+      pc.cyan("  wopr onboard"),
+    ].join("\n"), "Tailscale Not Connected");
+    return {};
+  }
+
+  s.stop(`Tailscale connected: ${ts.hostname}`);
+
+  // Enable funnel
+  s.start("Enabling Tailscale Funnel...");
+
+  // Check if funnel is enabled in ACL
+  const funnelTest = exec("tailscale funnel status");
+  if (!funnelTest.success && funnelTest.stdout.includes("not enabled")) {
+    s.stop("Funnel not enabled");
+    await note([
+      "Tailscale Funnel needs to be enabled in your tailnet.",
+      "",
+      "1. Go to https://login.tailscale.com/admin/acls",
+      "2. Add this to your ACL policy:",
+      pc.cyan(`  "nodeAttrs": [
+    {
+      "target": ["*"],
+      "attr": ["funnel"]
+    }
+  ]`),
+      "",
+      "Then re-run this wizard.",
+    ].join("\n"), "Enable Funnel");
+    return {};
+  }
+
+  // Start funnel for webhook port
+  const webhookPort = 7438;
+  exec(`tailscale funnel ${webhookPort}`);
+
+  s.stop("Funnel enabled!");
+
+  const webhookUrl = `https://${ts.hostname}/hooks`;
+
+  await note([
+    "External access configured!",
+    "",
+    `Webhook URL: ${pc.green(webhookUrl)}`,
+    "",
+    "This URL is now publicly accessible and can receive",
+    "webhooks from GitHub, Stripe, or any external service.",
+    "",
+    pc.dim("The funnel plugin will auto-start with the daemon."),
+  ].join("\n"), "External Access Ready");
+
+  return {
+    external: {
+      enabled: true,
+      hostname: ts.hostname,
+      webhookUrl,
+    },
+  } as any;
+};

--- a/src/commands/onboard/steps/07d-github.ts
+++ b/src/commands/onboard/steps/07d-github.ts
@@ -1,0 +1,207 @@
+/**
+ * Step 7d: GitHub Integration
+ *
+ * Sets up GitHub webhook routing for PR automation.
+ */
+import { confirm, note, spinner, text, select, pc } from "../prompts.js";
+import { execSync } from "node:child_process";
+import type { OnboardContext, OnboardStep } from "../types.js";
+
+function exec(cmd: string): { stdout: string; success: boolean } {
+  try {
+    const stdout = execSync(cmd, { encoding: "utf-8", timeout: 30000 }).trim();
+    return { stdout, success: true };
+  } catch (err: any) {
+    return { stdout: err.stderr || err.message || "", success: false };
+  }
+}
+
+function checkGhAuth(): boolean {
+  const result = exec("gh auth status");
+  return result.success;
+}
+
+function getGhOrgs(): string[] {
+  const result = exec("gh api user/orgs --jq '.[].login'");
+  if (!result.success) return [];
+  return result.stdout.split("\n").filter(Boolean);
+}
+
+export const githubStep: OnboardStep = async (ctx: OnboardContext) => {
+  // Check if external access is configured
+  const external = (ctx.nextConfig as any).external;
+  if (!external?.webhookUrl) {
+    await note([
+      "Skipping GitHub integration.",
+      "",
+      "GitHub webhooks require external access (Tailscale Funnel).",
+      "Set up external access first, then re-run this wizard.",
+    ].join("\n"), "GitHub");
+    return {};
+  }
+
+  // Ask if user wants GitHub integration
+  const wantGithub = await confirm({
+    message: "Set up GitHub webhook integration?",
+    initialValue: true,
+  });
+
+  if (!wantGithub) {
+    await note([
+      "Skipping GitHub integration.",
+      "",
+      "You can set this up later:",
+      pc.cyan("  wopr github setup <org>"),
+    ].join("\n"), "GitHub");
+    return {};
+  }
+
+  // Check gh CLI
+  const s = await spinner();
+  s.start("Checking GitHub CLI...");
+
+  const ghInstalled = exec("which gh").success;
+  if (!ghInstalled) {
+    s.stop("GitHub CLI not installed");
+    await note([
+      "GitHub CLI (gh) is required for webhook setup.",
+      "",
+      "Install it:",
+      pc.cyan("  brew install gh       # macOS"),
+      pc.cyan("  apt install gh        # Debian/Ubuntu"),
+      pc.cyan("  winget install gh     # Windows"),
+      "",
+      "Then authenticate:",
+      pc.cyan("  gh auth login"),
+      "",
+      "And re-run this wizard.",
+    ].join("\n"), "GitHub CLI Required");
+    return {};
+  }
+
+  const ghAuthed = checkGhAuth();
+  if (!ghAuthed) {
+    s.stop("GitHub CLI not authenticated");
+    await note([
+      "GitHub CLI needs to be authenticated.",
+      "",
+      "Run:",
+      pc.cyan("  gh auth login"),
+      "",
+      "Then re-run this wizard.",
+    ].join("\n"), "GitHub Auth Required");
+    return {};
+  }
+
+  s.stop("GitHub CLI authenticated");
+
+  // Get orgs
+  s.start("Fetching your GitHub organizations...");
+  const orgs = getGhOrgs();
+  s.stop(`Found ${orgs.length} organization(s)`);
+
+  if (orgs.length === 0) {
+    const manualOrg = await text({
+      message: "Enter organization name to configure:",
+      placeholder: "wopr-network",
+    });
+
+    if (!manualOrg) {
+      await note("No organization configured.", "GitHub");
+      return {};
+    }
+
+    orgs.push(manualOrg);
+  }
+
+  // Select org to configure
+  let selectedOrg: string;
+  if (orgs.length === 1) {
+    const useOrg = await confirm({
+      message: `Configure webhooks for ${orgs[0]}?`,
+      initialValue: true,
+    });
+    if (!useOrg) return {};
+    selectedOrg = orgs[0];
+  } else {
+    selectedOrg = await select({
+      message: "Select organization to configure:",
+      options: orgs.map(o => ({ value: o, label: o })),
+    });
+  }
+
+  // Configure PR review session
+  const prSession = await text({
+    message: "Session to route PR events to:",
+    initialValue: "discord:misfits:#pay-no-attention-to-the-man-behind-the-curtain",
+    placeholder: "discord:server:#channel",
+  });
+
+  // Create webhook
+  s.start(`Setting up webhook for ${selectedOrg}...`);
+
+  const webhookUrl = `${external.webhookUrl}/github`;
+  const webhookSecret = `wopr-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+  const createCmd = `gh api orgs/${selectedOrg}/hooks -X POST \
+    -f name=web \
+    -f active=true \
+    -f 'config[url]=${webhookUrl}' \
+    -f 'config[content_type]=json' \
+    -f 'config[secret]=${webhookSecret}' \
+    -f 'events[]=pull_request' \
+    -f 'events[]=pull_request_review' \
+    --jq '.id'`;
+
+  const createResult = exec(createCmd);
+
+  if (!createResult.success) {
+    s.stop("Webhook creation failed");
+
+    // Check if it already exists
+    const listResult = exec(`gh api orgs/${selectedOrg}/hooks --jq '.[].config.url'`);
+    if (listResult.success && listResult.stdout.includes(webhookUrl)) {
+      await note([
+        `Webhook already exists for ${selectedOrg}!`,
+        "",
+        `URL: ${webhookUrl}`,
+        "",
+        "PRs will be routed to the configured session.",
+      ].join("\n"), "GitHub Webhook");
+    } else {
+      await note([
+        "Failed to create webhook.",
+        "",
+        `Error: ${createResult.stdout}`,
+        "",
+        "You may need admin access to the organization.",
+        "Try manually:",
+        pc.cyan(`  wopr github setup ${selectedOrg}`),
+      ].join("\n"), "Webhook Error");
+    }
+    return {};
+  }
+
+  const webhookId = createResult.stdout;
+  s.stop(`Webhook created! ID: ${webhookId}`);
+
+  await note([
+    `GitHub webhook configured for ${selectedOrg}!`,
+    "",
+    `Webhook URL: ${pc.green(webhookUrl)}`,
+    `PR Session: ${pc.cyan(prSession)}`,
+    "",
+    "When PRs are opened or reviewed, events will be",
+    `routed to ${prSession} for automated handling.`,
+    "",
+    pc.dim("Update webhook config: wopr configure --plugin github"),
+  ].join("\n"), "GitHub Integration Ready");
+
+  return {
+    github: {
+      orgs: [selectedOrg],
+      webhookSecret,
+      prReviewSession: prSession,
+    },
+  } as any;
+};

--- a/src/commands/onboard/types.ts
+++ b/src/commands/onboard/types.ts
@@ -26,6 +26,17 @@ export interface OnboardConfig {
   skills?: string[];
   plugins?: string[];
   voicePlugins?: string[];
+  external?: {
+    enabled?: boolean;
+    hostname?: string;
+    webhookUrl?: string;
+  };
+  github?: {
+    orgs?: string[];
+    webhookSecret?: string;
+    prReviewSession?: string;
+    releaseSession?: string;
+  };
   wizard?: {
     lastRunAt?: string;
     lastRunVersion?: string;
@@ -39,6 +50,8 @@ export interface OnboardOptions {
   workspace?: string;
   reset?: boolean;
   skipChannels?: boolean;
+  skipExternal?: boolean;
+  skipGithub?: boolean;
   skipSkills?: boolean;
   skipPlugins?: boolean;
   skipDaemon?: boolean;


### PR DESCRIPTION
## Summary
- New onboard step: **07c-external** - Tailscale Funnel setup for external webhook access
- New onboard step: **07d-github** - GitHub webhook configuration for PR automation

## Flow
```
wopr onboard
  ...
  Step 7c: External Access
  → Checking Tailscale... [installed/connected]
  → Enabling Funnel... [done]
  → Webhook URL: https://wopr.tailnet.ts.net/hooks

  Step 7d: GitHub Integration
  → Checking gh CLI... [authenticated]
  → Select organization: [wopr-network]
  → PR review session: [discord:misfits:#pay-no-attention...]
  → Creating webhook... [done]
  ...
```

## Companion Plugins (separate PRs)
- `wopr-plugin-tailscale-funnel` - Exposes ports via Tailscale Funnel
- `wopr-plugin-github` - GitHub webhook setup and PR routing  
- `wopr-plugin-webhooks` - Updated to auto-expose via funnel

## Test plan
- [ ] Run `wopr onboard` with Tailscale installed
- [ ] Verify external access step detects Tailscale status
- [ ] Verify GitHub step creates org webhook
- [ ] Verify PRs route to configured session

🤖 Generated with [Claude Code](https://claude.com/claude-code)