### PR TITLE
chore: add Claude Code quality hooks + biome

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "pluginMarketplaces": [
+    {
+      "name": "wopr-marketplace",
+      "source": "https://github.com/wopr-network/wopr-claude-hooks"
+    }
+  ],
+  "enabledPlugins": ["wopr-hooks@wopr-marketplace"]
+}


### PR DESCRIPTION
## Summary

- Adds shared Claude Code quality hooks via [wopr-claude-hooks](https://github.com/wopr-network/wopr-claude-hooks) plugin
- Adds `@biomejs/biome` for linting + formatting (if missing)
- Adds `biome.json` config (if missing)
- Adds `lint`, `lint:fix`, `format`, `check` scripts (if missing)

## What the hooks do

| Hook | Trigger | Action |
|------|---------|--------|
| PostToolUse | Every `Edit`/`Write` on `.ts` files | Auto-format with biome, type-check with tsc |
| PreToolUse | Any `git commit` command | Block commit if biome or tsc fail |

## How to use

The plugin activates automatically when Claude Code detects `.claude/settings.json`. No manual setup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration infrastructure to support plugin marketplaces and plugin management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->