### PR TITLE
chore: update core dependencies (WOP-16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,14 @@
       "name": "@tsavo/wopr",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.12",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.39",
         "@clack/prompts": "^0.7.0",
-        "@hono/node-server": "^1.13.0",
-        "@hono/node-ws": "^1.0.0",
+        "@hono/node-server": "^1.19.9",
+        "@hono/node-ws": "^1.3.0",
         "@openai/codex-sdk": "^0.91.0",
-        "hono": "^4.6.0",
+        "hono": "^4.11.9",
         "hyperswarm": "^4.16.0",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.1.1",
         "sqlite-vec": "0.1.7-alpha.2",
         "winston": "^3.19.0",
         "ws": "^8.19.0",
@@ -28,8 +28,8 @@
         "@biomejs/biome": "^2.3.14",
         "@types/node": "^22.19.7",
         "@types/ws": "^8.18.1",
-        "tsx": "^4.0.0",
-        "typescript": "^5.0.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.19.tgz",
-      "integrity": "sha512-DjaX4t3Swjt5PcsZt6krcp5TfBTRxVuUZhkY6L8WWF8kZBJFuuEd5akNg486XRskTXGuwLmitxp0wHB1hJ9muw==",
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.39.tgz",
+      "integrity": "sha512-wR1TBH62X6E1YwRnWa+A2Eau7AfpTWtfpnwQXO3yRY31FtmzOjPkQb93hbF3AkT0WL7YF9mxBBwJKUa3ZEc5+A==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
@@ -251,7 +251,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3237,9 +3236,9 @@
       "optional": true
     },
     "node_modules/hono": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
-      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "tar": "^7.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.12",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.39",
     "@clack/prompts": "^0.7.0",
-    "@hono/node-server": "^1.13.0",
-    "@hono/node-ws": "^1.0.0",
+    "@hono/node-server": "^1.19.9",
+    "@hono/node-ws": "^1.3.0",
     "@openai/codex-sdk": "^0.91.0",
-    "hono": "^4.6.0",
+    "hono": "^4.11.9",
     "hyperswarm": "^4.16.0",
-    "picocolors": "^1.0.0",
+    "picocolors": "^1.1.1",
     "sqlite-vec": "0.1.7-alpha.2",
     "winston": "^3.19.0",
     "ws": "^8.19.0",
@@ -47,8 +47,8 @@
     "@biomejs/biome": "^2.3.14",
     "@types/node": "^22.19.7",
     "@types/ws": "^8.18.1",
-    "tsx": "^4.0.0",
-    "typescript": "^5.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Update 7 low-risk dependencies to their latest minor/patch versions:

| Package | Old | New | Risk |
|---------|-----|-----|------|
| @anthropic-ai/claude-agent-sdk | ^0.2.12 | ^0.2.39 | Low (same minor) |
| @hono/node-server | ^1.13.0 | ^1.19.9 | Low (minor) |
| @hono/node-ws | ^1.0.0 | ^1.3.0 | Low (minor) |
| hono | ^4.6.0 | ^4.11.9 | Low (minor) |
| picocolors | ^1.0.0 | ^1.1.1 | Low (patch) |
| tsx | ^4.0.0 | ^4.21.0 | Low (minor) |
| typescript | ^5.0.0 | ^5.9.3 | Low (minor) |

**Not updated (needs separate investigation):**
- @clack/prompts ^0.7 -> ^1.0 (major version, API audit needed)
- @openai/codex-sdk ^0.91 -> ^0.98 (large jump)
- sqlite-vec 0.1.7-alpha.2 (pinned, waiting for stable)
- node-llama-cpp ^3.0 (optional, avoid native rebuild)

## Test plan
- [x] All 113 tests pass
- [x] Type check clean (0 errors)
- [x] 0 npm audit vulnerabilities
- [ ] CI pipeline passes

Relates to WOP-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)