### PR TITLE
chore: tighten TypeScript and biome strictness (WOP-14)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,11 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["src/**/*.ts", "!!**/dist", "!!**/node_modules"]
+    "includes": [
+      "src/**/*.ts",
+      "!!**/dist",
+      "!!**/node_modules"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -19,15 +23,15 @@
     "rules": {
       "recommended": true,
       "correctness": {
-        "noUnusedVariables": "warn",
-        "noUnusedImports": "warn"
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
       },
       "suspicious": {
-        "noExplicitAny": "off"
+        "noExplicitAny": "warn"
       },
       "style": {
-        "noNonNullAssertion": "off",
-        "useConst": "warn"
+        "noNonNullAssertion": "warn",
+        "useConst": "error"
       }
     }
   },

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -35,7 +35,7 @@ export {
 } from "./a2a-mcp.js";
 
 // Initialize context system with defaults (async)
-const _contextInitPromise = initContextSystem();
+initContextSystem();
 // Don't block - let it initialize in background
 
 // Export functions for A2A MCP server (deferred to avoid circular imports)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,13 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "declaration": true
+    "declaration": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
## Summary

- Enable strict TypeScript compiler options: `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`, `useUnknownInCatchVariables`
- Promote biome lint rules from warn to error: `noUnusedVariables`, `noUnusedImports`, `useConst`
- Enable `noExplicitAny` and `noNonNullAssertion` as warnings (272 warnings to address in Phase 3)
- Remove unused `_contextInitPromise` variable in sessions.ts

## Test plan

- [x] `tsc --noEmit` compiles clean (0 errors)
- [x] `biome lint` passes (272 warnings, 0 errors)
- [ ] CI pipeline passes

Resolves WOP-14 (core portion)