### PR TITLE
fix: address PR #30 review findings (WOP-18)

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -388,8 +388,11 @@ class WOPREventBusImpl implements WOPREventBus {
         if (result && typeof result.then === "function") {
           wcPromises.push(
             (result as Promise<void>).catch((err: unknown) => {
-              const errMsg = err instanceof Error ? (err as Error).message : String(err);
+              const errMsg = err instanceof Error ? err.message : String(err);
               logger.error(`[events] Wildcard handler error for '${eventName}': ${errMsg}`);
+              if (err instanceof Error && err.stack) {
+                logger.error(`[events] Stack: ${err.stack}`);
+              }
             }),
           );
         }

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -79,9 +79,7 @@ function initQueue(): void {
   // Subscribe to queue events for logging
   queueManager.on((event) => {
     if (event.type === "error") {
-      const errorDetail = event.data?.error
-        ? `: ${event.data.error instanceof Error ? event.data.error.message : String(event.data.error)}`
-        : "";
+      const errorDetail = event.data?.error ? `: ${String(event.data.error)}` : "";
       logger.error({
         msg: `[queue] error${errorDetail}`,
         sessionKey: event.sessionKey,


### PR DESCRIPTION
## Summary

Addresses 4 actionable review findings from PR #30 (WOP-15 error handling) flagged by Greptile and Copilot:

- **events.ts**: Add stack trace logging for wildcard handler async errors
- **daemon/index.ts**: Fix cron timeout timer leak — `clearTimeout` in `finally` block prevents lingering 5-minute timers when `inject()` completes before timeout
- **daemon/index.ts**: Properly decode WebSocket `RawData` — handles `Buffer`, `ArrayBuffer`, and `Buffer[]` instead of naive `String()` which would produce `[object ArrayBuffer]`
- **sessions.ts**: Simplify dead `instanceof Error` branch — the queue emits string errors, not Error objects

## Test plan

- [x] `npx tsc --noEmit` — passes clean
- [x] `npx vitest run` — all 113 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)