### PR TITLE
test: add unit tests for core skills module (WOP-82)

### DIFF
--- a/tests/unit/skills.test.ts
+++ b/tests/unit/skills.test.ts
@@ -12,7 +12,7 @@
  * - CRUD operations (create, remove, clearCache)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -26,7 +26,7 @@ vi.mock("../../src/logger.js", () => ({
   },
 }));
 
-// Mock paths — we override them per-test via vi.doMock where needed
+// Mock paths
 vi.mock("../../src/paths.js", () => ({
   WOPR_HOME: "/tmp/wopr-test-skills-home",
   SKILLS_DIR: "/tmp/wopr-test-skills-home/skills",
@@ -53,7 +53,6 @@ import {
 } from "../../src/core/skills.js";
 import type {
   Skill,
-  SkillMetadata,
   ParsedFrontmatter,
 } from "../../src/core/skills.js";
 


### PR DESCRIPTION
## Summary
Closes WOP-82

- Add 81 comprehensive unit tests for `src/core/skills.ts` (774 lines, 0% -> covered)
- Cover skill name validation (length, pattern, hyphens, directory matching)
- Cover skill description validation (required, length limits)
- Cover frontmatter field validation (allowed/unknown fields)
- Cover frontmatter parsing (YAML-like, JSON metadata, arrays, edge cases)
- Cover metadata resolution (wopr/clawdbot keys, string/object, precedence)
- Cover command dispatch resolution (tool type, arg modes, case-insensitive)
- Cover skill discovery (managed/bundled/extra/workspace dirs, dedup by realpath, name collisions, include/ignore filters, glob patterns, hidden/node_modules skip)
- Cover XML formatting and prompt building
- Cover command spec generation (sanitization, deduplication, reserved names, description truncation)
- Cover dependency checking (missing bins, satisfied)
- Cover CRUD operations (createSkill, removeSkill, clearSkillCache)

## Test plan
- [x] `npx tsc --noEmit` passes (type-check)
- [x] `npx vitest run` passes (261 tests across 7 files, all green)
- [x] New tests all pass (81/81)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for the Skills module to improve code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->