### PR TITLE
feat: create canonical plugin-types module (WOP-62)

### DIFF
--- a/src/plugin-types/a2a.ts
+++ b/src/plugin-types/a2a.ts
@@ -1,0 +1,38 @@
+/**
+ * Agent-to-Agent (A2A) tool types for WOPR plugins.
+ *
+ * Plugins register A2A tools to expose functionality to other agents.
+ * These tools follow the MCP (Model Context Protocol) pattern.
+ */
+
+/**
+ * Result from an A2A tool handler.
+ */
+export interface A2AToolResult {
+  content: Array<{
+    type: "text" | "image" | "resource";
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
+  isError?: boolean;
+}
+
+/**
+ * Definition of an A2A tool that plugins can register.
+ */
+export interface A2AToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>; // JSON Schema format
+  handler: (args: Record<string, unknown>) => Promise<A2AToolResult>;
+}
+
+/**
+ * Configuration for registering an A2A server (collection of tools).
+ */
+export interface A2AServerConfig {
+  name: string;
+  version?: string;
+  tools: A2AToolDefinition[];
+}

--- a/src/plugin-types/channel.ts
+++ b/src/plugin-types/channel.ts
@@ -1,0 +1,95 @@
+/**
+ * Channel types for WOPR plugins.
+ *
+ * Channels are the communication pathways (Discord, Slack, P2P, etc.)
+ * that plugins can register to send and receive messages.
+ */
+
+/**
+ * Reference to a communication channel.
+ */
+export interface ChannelRef {
+  id: string;
+  type: string;
+  name?: string;
+}
+
+/**
+ * Adapter for a specific channel instance.
+ * Plugins register these to bridge between WOPR sessions and external channels.
+ */
+export interface ChannelAdapter {
+  channel: ChannelRef;
+  session: string;
+  getContext(): Promise<string>;
+  send(message: string): Promise<void>;
+}
+
+/**
+ * Context passed to channel command handlers.
+ */
+export interface ChannelCommandContext {
+  channel: string;
+  channelType: string;
+  sender: string;
+  args: string[];
+  reply: (msg: string) => Promise<void>;
+  getBotUsername: () => string;
+}
+
+/**
+ * Context passed to channel message parsers.
+ */
+export interface ChannelMessageContext {
+  channel: string;
+  channelType: string;
+  sender: string;
+  content: string;
+  reply: (msg: string) => Promise<void>;
+  getBotUsername: () => string;
+}
+
+/**
+ * A command that can be registered on channel providers.
+ */
+export interface ChannelCommand {
+  name: string;
+  description: string;
+  handler: (ctx: ChannelCommandContext) => Promise<void>;
+}
+
+/**
+ * A message parser that watches channel messages.
+ */
+export interface ChannelMessageParser {
+  id: string;
+  pattern: RegExp | ((msg: string) => boolean);
+  handler: (ctx: ChannelMessageContext) => Promise<void>;
+}
+
+/**
+ * Channel provider interface.
+ *
+ * Channel plugins (Discord, Slack, Telegram, etc.) implement this to
+ * expose their channels to other plugins for registering protocol-level
+ * commands and message parsers.
+ */
+export interface ChannelProvider {
+  id: string;
+
+  // Command registration
+  registerCommand(cmd: ChannelCommand): void;
+  unregisterCommand(name: string): void;
+  getCommands(): ChannelCommand[];
+
+  // Message watching
+  addMessageParser(parser: ChannelMessageParser): void;
+  removeMessageParser(id: string): void;
+  getMessageParsers(): ChannelMessageParser[];
+
+  // Send to channel
+  send(channel: string, content: string): Promise<void>;
+
+  // Bot username for this provider
+  getBotUsername(): string;
+}

--- a/src/plugin-types/config.ts
+++ b/src/plugin-types/config.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical configuration types for WOPR plugins.
+ *
+ * ConfigField.type is extended to include "array", "boolean", and "object"
+ * which plugins are already using in the wild. This is the canonical source
+ * of truth — plugins should import from here, not define their own.
+ */
+
+/**
+ * A single configuration field definition for plugin config UIs.
+ *
+ * The `type` union covers all field types that plugins actually use,
+ * including "array", "boolean", and "object" which were previously
+ * missing from the core definition.
+ */
+export interface ConfigField {
+  name: string;
+  type: "text" | "password" | "select" | "checkbox" | "number" | "array" | "boolean" | "object" | "textarea";
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+  default?: unknown;
+  options?: { value: string; label: string }[]; // For select type
+  description?: string;
+  /** For array type: schema of each item */
+  items?: ConfigField;
+  /** For object type: nested fields */
+  fields?: ConfigField[];
+}
+
+/**
+ * A configuration schema describing a plugin's configurable settings.
+ * Used to render configuration UIs dynamically.
+ */
+export interface ConfigSchema {
+  title: string;
+  description?: string;
+  fields: ConfigField[];
+}

--- a/src/plugin-types/context-provider.ts
+++ b/src/plugin-types/context-provider.ts
@@ -1,0 +1,44 @@
+/**
+ * Context provider types for WOPR plugins.
+ *
+ * Context providers contribute information to conversations.
+ * Plugins register these to inject relevant context before
+ * the AI processes a message.
+ */
+
+import type { ChannelRef } from "./channel.js";
+
+/**
+ * Information about an incoming message.
+ */
+export interface MessageInfo {
+  content: string;
+  from: string;
+  channel?: ChannelRef;
+  timestamp: number;
+}
+
+/**
+ * A piece of context contributed by a provider.
+ */
+export interface ContextPart {
+  content: string;
+  role?: "system" | "context" | "warning" | "user";
+  metadata?: {
+    source: string;
+    priority: number;
+    trustLevel?: "trusted" | "untrusted" | "verified";
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Composable context provider — plugins register these to contribute
+ * context to conversations.
+ */
+export interface ContextProvider {
+  name: string;
+  priority: number;
+  enabled?: boolean | ((session: string, message: MessageInfo) => boolean);
+  getContext(session: string, message: MessageInfo): Promise<ContextPart | null>;
+}

--- a/src/plugin-types/context.ts
+++ b/src/plugin-types/context.ts
@@ -1,0 +1,244 @@
+/**
+ * Plugin context — the full API surface available to plugins at runtime.
+ *
+ * This is the canonical definition of WOPRPluginContext. Plugins receive
+ * this object during init() and use it to interact with the WOPR daemon.
+ */
+
+import type { ConfigSchema } from "./config.js";
+import type { ChannelAdapter, ChannelProvider, ChannelRef } from "./channel.js";
+import type { ContextProvider } from "./context-provider.js";
+import type {
+  WOPREventBus,
+  WOPRHookManager,
+} from "./events.js";
+import type { A2AServerConfig } from "./a2a.js";
+
+/**
+ * Multimodal message with optional images.
+ */
+export interface MultimodalMessage {
+  text: string;
+  images?: string[]; // URLs of images
+}
+
+/**
+ * Streaming message from the AI provider.
+ */
+export interface StreamMessage {
+  type: "text" | "tool_use" | "complete" | "error" | "system";
+  content: string;
+  toolName?: string;
+  subtype?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type StreamCallback = (msg: StreamMessage) => void;
+
+/**
+ * Options for plugin inject calls.
+ */
+export interface PluginInjectOptions {
+  silent?: boolean;
+  onStream?: StreamCallback;
+  from?: string;
+  channel?: ChannelRef;
+  images?: string[];
+  /**
+   * Security source for this injection.
+   * Uses InjectionSource from security types when provided.
+   */
+  source?: unknown;
+  /** Control which context providers to use. */
+  contextProviders?: string[];
+  /** Priority level (higher = processed first within queue) */
+  priority?: number;
+}
+
+/**
+ * Agent persona identity (from IDENTITY.md workspace file).
+ */
+export interface AgentIdentity {
+  name?: string;
+  creature?: string;
+  vibe?: string;
+  emoji?: string;
+}
+
+/**
+ * User profile (from USER.md workspace file).
+ */
+export interface UserProfile {
+  name?: string;
+  preferredAddress?: string;
+  pronouns?: string;
+  timezone?: string;
+  notes?: string;
+}
+
+/**
+ * Web UI navigation extension — plugins register links in the dashboard.
+ */
+export interface WebUiExtension {
+  id: string;
+  title: string;
+  url: string;
+  description?: string;
+  category?: string;
+}
+
+/**
+ * UI component extension — plugins export SolidJS components that render inline.
+ */
+export interface UiComponentExtension {
+  id: string;
+  title: string;
+  moduleUrl: string;
+  slot: "sidebar" | "settings" | "statusbar" | "chat-header" | "chat-footer";
+  description?: string;
+}
+
+/**
+ * Props passed to plugin UI components.
+ */
+export interface PluginUiComponentProps {
+  api: {
+    getSessions: () => Promise<{ sessions: unknown[] }>;
+    inject: (session: string, message: string) => Promise<unknown>;
+    getConfig: () => Promise<unknown>;
+    setConfigValue: (key: string, value: unknown) => Promise<void>;
+  };
+  currentSession?: string;
+  pluginConfig: unknown;
+  saveConfig: (config: unknown) => Promise<void>;
+}
+
+/**
+ * Plugin logger interface.
+ */
+export interface PluginLogger {
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+  debug(message: string, ...args: unknown[]): void;
+}
+
+/**
+ * STT provider interface (minimal, for context typing).
+ * Full definition lives in voice/types.ts.
+ */
+export interface STTProviderRef {
+  readonly metadata: { name: string; type: "stt" };
+}
+
+/**
+ * TTS provider interface (minimal, for context typing).
+ * Full definition lives in voice/types.ts.
+ */
+export interface TTSProviderRef {
+  readonly metadata: { name: string; type: "tts" };
+}
+
+/**
+ * The full plugin context API.
+ *
+ * This is the canonical interface that all plugins receive during init().
+ * It provides access to sessions, events, hooks, channels, config, UI
+ * extensions, voice, A2A tools, and more.
+ */
+export interface WOPRPluginContext {
+  // Inject into local session, get response (with optional streaming)
+  inject(session: string, message: string | MultimodalMessage, options?: PluginInjectOptions): Promise<string>;
+
+  // Log a message without triggering a response
+  logMessage(
+    session: string,
+    message: string,
+    options?: { from?: string; senderId?: string; channel?: ChannelRef },
+  ): void;
+
+  // Agent persona identity
+  getAgentIdentity(): AgentIdentity | Promise<AgentIdentity>;
+
+  // User profile
+  getUserProfile(): UserProfile | Promise<UserProfile>;
+
+  // Sessions
+  getSessions(): string[];
+
+  // Cancel in-progress injection
+  cancelInject(session: string): boolean;
+
+  // Event bus
+  events: WOPREventBus;
+
+  // Hook manager
+  hooks: WOPRHookManager;
+
+  // Context providers
+  registerContextProvider(provider: ContextProvider): void;
+  unregisterContextProvider(name: string): void;
+  getContextProvider(name: string): ContextProvider | undefined;
+
+  // Channels
+  registerChannel(adapter: ChannelAdapter): void;
+  unregisterChannel(channel: ChannelRef): void;
+  getChannel(channel: ChannelRef): ChannelAdapter | undefined;
+  getChannels(): ChannelAdapter[];
+  getChannelsForSession(session: string): ChannelAdapter[];
+
+  // Web UI extensions
+  registerWebUiExtension(extension: WebUiExtension): void;
+  unregisterWebUiExtension(id: string): void;
+  getWebUiExtensions(): WebUiExtension[];
+
+  // UI Component extensions
+  registerUiComponent(extension: UiComponentExtension): void;
+  unregisterUiComponent(id: string): void;
+  getUiComponents(): UiComponentExtension[];
+
+  // Plugin config
+  getConfig<T = unknown>(): T;
+  saveConfig<T = unknown>(config: T): Promise<void>;
+
+  // Main WOPR config (read-only)
+  getMainConfig(key?: string): unknown;
+
+  // Model providers
+  registerProvider(provider: unknown): void;
+  unregisterProvider(id: string): void;
+  getProvider(id: string): unknown;
+
+  // Config schemas
+  registerConfigSchema(pluginId: string, schema: ConfigSchema): void;
+  unregisterConfigSchema(pluginId: string): void;
+  getConfigSchema(pluginId: string): ConfigSchema | undefined;
+
+  // Plugin extensions (inter-plugin APIs)
+  registerExtension(name: string, extension: unknown): void;
+  unregisterExtension(name: string): void;
+  getExtension<T = unknown>(name: string): T | undefined;
+  listExtensions(): string[];
+
+  // Voice providers
+  registerSTTProvider(provider: unknown): void;
+  registerTTSProvider(provider: unknown): void;
+  getSTT(): unknown;
+  getTTS(): unknown;
+  hasVoice(): { stt: boolean; tts: boolean };
+
+  // Channel providers
+  registerChannelProvider(provider: ChannelProvider): void;
+  unregisterChannelProvider(id: string): void;
+  getChannelProvider(id: string): ChannelProvider | undefined;
+  getChannelProviders(): ChannelProvider[];
+
+  // A2A tools
+  registerA2AServer?(config: A2AServerConfig): void;
+
+  // Logging
+  log: PluginLogger;
+
+  // Plugin directory
+  getPluginDir(): string;
+}

--- a/src/plugin-types/events.ts
+++ b/src/plugin-types/events.ts
@@ -1,0 +1,232 @@
+/**
+ * Event and hook types for the WOPR plugin system.
+ *
+ * The event bus provides reactive composition between plugins.
+ * Hooks provide typed lifecycle interception points.
+ */
+
+import type { ChannelRef } from "./channel.js";
+
+// ============================================================================
+// Event Types
+// ============================================================================
+
+/**
+ * Base event interface — all events extend this.
+ */
+export interface WOPREvent {
+  type: string;
+  payload: unknown;
+  timestamp: number;
+  source?: string;
+}
+
+// Session lifecycle events
+export interface SessionCreateEvent {
+  session: string;
+  config?: unknown;
+}
+
+export interface SessionInjectEvent {
+  session: string;
+  message: string;
+  from: string;
+  channel?: { type: string; id: string; name?: string };
+}
+
+export interface SessionResponseEvent {
+  session: string;
+  message: string;
+  response: string;
+  from: string;
+}
+
+export interface SessionResponseChunkEvent extends SessionResponseEvent {
+  chunk: string;
+}
+
+export interface SessionDestroyEvent {
+  session: string;
+  history: unknown[];
+  reason?: string;
+}
+
+// Channel events
+export interface ChannelMessageEvent {
+  channel: { type: string; id: string; name?: string };
+  message: string;
+  from: string;
+  metadata?: unknown;
+}
+
+export interface ChannelSendEvent {
+  channel: { type: string; id: string };
+  content: string;
+}
+
+// Plugin events
+export interface PluginInitEvent {
+  plugin: string;
+  version: string;
+}
+
+export interface PluginErrorEvent {
+  plugin: string;
+  error: Error;
+  context?: string;
+}
+
+// Config events
+export interface ConfigChangeEvent {
+  key: string;
+  oldValue: unknown;
+  newValue: unknown;
+  plugin?: string;
+}
+
+// System events
+export interface SystemShutdownEvent {
+  reason: string;
+  code?: number;
+}
+
+// Memory events
+export interface MemoryFileChange {
+  action: "upsert" | "delete";
+  path: string;
+  absPath?: string;
+  source: "global" | "session" | "sessions";
+  chunks?: Array<{
+    id: string;
+    text: string;
+    hash: string;
+    startLine: number;
+    endLine: number;
+  }>;
+}
+
+export interface MemoryFilesChangedEvent {
+  changes: MemoryFileChange[];
+}
+
+export interface MemorySearchEvent {
+  query: string;
+  maxResults: number;
+  minScore: number;
+  sessionName: string;
+  results: unknown[] | null;
+}
+
+/**
+ * Event map — all core events and their payloads.
+ */
+export interface WOPREventMap {
+  "session:create": SessionCreateEvent;
+  "session:beforeInject": SessionInjectEvent;
+  "session:afterInject": SessionResponseEvent;
+  "session:responseChunk": SessionResponseChunkEvent;
+  "session:destroy": SessionDestroyEvent;
+  "channel:message": ChannelMessageEvent;
+  "channel:send": ChannelSendEvent;
+  "plugin:beforeInit": PluginInitEvent;
+  "plugin:afterInit": PluginInitEvent;
+  "plugin:error": PluginErrorEvent;
+  "config:change": ConfigChangeEvent;
+  "system:shutdown": SystemShutdownEvent;
+  "memory:search": MemorySearchEvent;
+  "memory:filesChanged": MemoryFilesChangedEvent;
+  "*": WOPREvent;
+}
+
+/**
+ * Event handler type.
+ */
+export type EventHandler<T = unknown> = (payload: T, event: WOPREvent) => void | Promise<void>;
+
+/**
+ * Event bus interface — reactive primitive for plugins.
+ */
+export interface WOPREventBus {
+  on<T extends keyof WOPREventMap>(event: T, handler: EventHandler<WOPREventMap[T]>): () => void;
+  once<T extends keyof WOPREventMap>(event: T, handler: EventHandler<WOPREventMap[T]>): void;
+  off<T extends keyof WOPREventMap>(event: T, handler: EventHandler<WOPREventMap[T]>): void;
+  emit<T extends keyof WOPREventMap>(event: T, payload: WOPREventMap[T]): Promise<void>;
+  emitCustom(event: string, payload: unknown): Promise<void>;
+  listenerCount(event: string): number;
+}
+
+// ============================================================================
+// Hook Types
+// ============================================================================
+
+/**
+ * Hook event with mutable state (for before hooks).
+ */
+export interface MutableHookEvent<T> {
+  data: T;
+  session: string;
+  preventDefault(): void;
+  isPrevented(): boolean;
+}
+
+/**
+ * Hook options — priority ordering and identification.
+ */
+export interface HookOptions {
+  /** Lower = runs first (default: 100) */
+  priority?: number;
+  /** Name for debugging and removal */
+  name?: string;
+  /** Run once then auto-remove */
+  once?: boolean;
+}
+
+/**
+ * Hook handler types.
+ */
+export type MessageIncomingHandler = (
+  event: MutableHookEvent<{ message: string; from: string; channel?: ChannelRef }>,
+) => void | Promise<void>;
+
+export type MessageOutgoingHandler = (
+  event: MutableHookEvent<{ response: string; from: string; channel?: ChannelRef }>,
+) => void | Promise<void>;
+
+export type SessionCreateHandler = (event: { session: string; config?: unknown }) => void | Promise<void>;
+
+export type SessionDestroyHandler = (event: {
+  session: string;
+  history: unknown[];
+  reason?: string;
+}) => void | Promise<void>;
+
+export type ChannelMessageHandler = (
+  event: MutableHookEvent<{ channel: ChannelRef; message: string; from: string; metadata?: unknown }>,
+) => void | Promise<void>;
+
+/**
+ * Hook manager — typed hooks for core lifecycle events.
+ */
+export interface WOPRHookManager {
+  // Mutable hooks — can transform data or block
+  on(event: "message:incoming", handler: MessageIncomingHandler, options?: HookOptions): () => void;
+  on(event: "message:outgoing", handler: MessageOutgoingHandler, options?: HookOptions): () => void;
+  on(event: "channel:message", handler: ChannelMessageHandler, options?: HookOptions): () => void;
+
+  // Read-only hooks — observe lifecycle
+  on(event: "session:create", handler: SessionCreateHandler, options?: HookOptions): () => void;
+  on(event: "session:destroy", handler: SessionDestroyHandler, options?: HookOptions): () => void;
+
+  // Remove by handler reference
+  off(event: "message:incoming", handler: MessageIncomingHandler): void;
+  off(event: "message:outgoing", handler: MessageOutgoingHandler): void;
+  off(event: "channel:message", handler: ChannelMessageHandler): void;
+  off(event: "session:create", handler: SessionCreateHandler): void;
+  off(event: "session:destroy", handler: SessionDestroyHandler): void;
+
+  // Remove by name
+  offByName(name: string): void;
+
+  // List registered hooks
+  list(): Array<{ event: string; name?: string; priority: number }>;
+}

--- a/src/plugin-types/index.ts
+++ b/src/plugin-types/index.ts
@@ -1,0 +1,90 @@
+/**
+ * @wopr-network/plugin-types — canonical type definitions for WOPR plugins.
+ *
+ * This is the single source of truth for all plugin-facing types.
+ * Plugins should import from here instead of defining their own copies.
+ *
+ * Usage (once published as @wopr-network/plugin-types):
+ *   import type { WOPRPlugin, WOPRPluginContext, ConfigSchema } from "@wopr-network/plugin-types";
+ *
+ * Usage (from within the wopr monorepo):
+ *   import type { WOPRPlugin, WOPRPluginContext, ConfigSchema } from "../plugin-types/index.js";
+ */
+
+// Config types
+export type { ConfigField, ConfigSchema } from "./config.js";
+
+// Manifest types
+export type {
+  InstallMethod,
+  PluginCapability,
+  PluginCategory,
+  PluginManifest,
+  PluginRequirements,
+  SetupStep,
+} from "./manifest.js";
+
+// Core plugin types
+export type { InstalledPlugin, PluginCommand, PluginRegistryEntry, WOPRPlugin } from "./plugin.js";
+
+// Context (the runtime API plugins receive)
+export type {
+  AgentIdentity,
+  MultimodalMessage,
+  PluginInjectOptions,
+  PluginLogger,
+  PluginUiComponentProps,
+  StreamCallback,
+  StreamMessage,
+  UiComponentExtension,
+  UserProfile,
+  WebUiExtension,
+  WOPRPluginContext,
+} from "./context.js";
+
+// Channel types
+export type {
+  ChannelAdapter,
+  ChannelCommand,
+  ChannelCommandContext,
+  ChannelMessageContext,
+  ChannelMessageParser,
+  ChannelProvider,
+  ChannelRef,
+} from "./channel.js";
+
+// Event and hook types
+export type {
+  ChannelMessageEvent,
+  ChannelMessageHandler,
+  ChannelSendEvent,
+  ConfigChangeEvent,
+  EventHandler,
+  HookOptions,
+  MemoryFileChange,
+  MemoryFilesChangedEvent,
+  MemorySearchEvent,
+  MessageIncomingHandler,
+  MessageOutgoingHandler,
+  MutableHookEvent,
+  PluginErrorEvent,
+  PluginInitEvent,
+  SessionCreateEvent,
+  SessionCreateHandler,
+  SessionDestroyEvent,
+  SessionDestroyHandler,
+  SessionInjectEvent,
+  SessionResponseChunkEvent,
+  SessionResponseEvent,
+  SystemShutdownEvent,
+  WOPREvent,
+  WOPREventBus,
+  WOPREventMap,
+  WOPRHookManager,
+} from "./events.js";
+
+// Context provider types
+export type { ContextPart, ContextProvider, MessageInfo } from "./context-provider.js";
+
+// A2A types
+export type { A2AServerConfig, A2AToolDefinition, A2AToolResult } from "./a2a.js";

--- a/src/plugin-types/manifest.ts
+++ b/src/plugin-types/manifest.ts
@@ -1,0 +1,143 @@
+/**
+ * Plugin manifest types for WOPR as a Service (WaaS).
+ *
+ * The manifest describes a plugin's capabilities, requirements,
+ * and setup flows. This is the metadata that WaaS uses to present
+ * plugins in a marketplace and auto-configure them.
+ */
+
+import type { ConfigSchema } from "./config.js";
+
+/**
+ * Installation method for plugin dependencies.
+ * Describes how to install a missing dependency automatically.
+ */
+export type InstallMethod =
+  | { kind: "brew"; formula: string; bins?: string[]; label?: string }
+  | { kind: "apt"; package: string; bins?: string[]; label?: string }
+  | { kind: "pip"; package: string; bins?: string[]; label?: string }
+  | { kind: "npm"; package: string; bins?: string[]; label?: string }
+  | { kind: "docker"; image: string; tag?: string; label?: string }
+  | { kind: "script"; url: string; label?: string }
+  | { kind: "manual"; instructions: string; label?: string };
+
+/**
+ * Runtime requirements for a plugin.
+ * Specifies what binaries, env vars, docker images, or config keys
+ * must be present for the plugin to function.
+ */
+export interface PluginRequirements {
+  /** Required binary executables (checked via `which`) */
+  bins?: string[];
+  /** Required environment variables */
+  env?: string[];
+  /** Required docker images */
+  docker?: string[];
+  /** Required config keys (dot-notation paths) */
+  config?: string[];
+}
+
+/**
+ * A setup step that guides users through plugin configuration.
+ * WaaS renders these as a wizard flow.
+ */
+export interface SetupStep {
+  /** Step identifier */
+  id: string;
+  /** Human-readable title */
+  title: string;
+  /** Description or instructions (markdown) */
+  description: string;
+  /** Config fields to collect in this step */
+  fields?: ConfigSchema;
+  /** Whether this step can be skipped */
+  optional?: boolean;
+}
+
+/**
+ * Plugin manifest — the complete metadata for a WOPR plugin.
+ *
+ * This is the canonical type for describing a plugin's identity,
+ * capabilities, requirements, and setup flows. It extends beyond
+ * the basic WOPRPlugin interface to support WaaS marketplace and
+ * auto-configuration features.
+ */
+export interface PluginManifest {
+  /** Plugin package name (e.g., "@wopr-network/plugin-discord") */
+  name: string;
+  /** Semantic version */
+  version: string;
+  /** Human-readable description */
+  description: string;
+  /** Author or organization */
+  author?: string;
+  /** License identifier (e.g., "MIT") */
+  license?: string;
+  /** Homepage or documentation URL */
+  homepage?: string;
+  /** Repository URL */
+  repository?: string;
+
+  /** Plugin capabilities — what this plugin provides */
+  capabilities: PluginCapability[];
+
+  /** Runtime requirements for this plugin */
+  requires?: PluginRequirements;
+
+  /** How to install missing dependencies (ordered by preference) */
+  install?: InstallMethod[];
+
+  /** Setup wizard steps for first-time configuration */
+  setup?: SetupStep[];
+
+  /** Configuration schema for the plugin's settings */
+  configSchema?: ConfigSchema;
+
+  /** Plugin category for marketplace organization */
+  category?: PluginCategory;
+
+  /** Tags for search and discovery */
+  tags?: string[];
+
+  /** Icon emoji for UI display */
+  icon?: string;
+
+  /** Minimum WOPR core version required */
+  minCoreVersion?: string;
+
+  /** Other plugins this plugin depends on */
+  dependencies?: string[];
+
+  /** Other plugins this plugin conflicts with */
+  conflicts?: string[];
+}
+
+/**
+ * Plugin capabilities — what a plugin provides to the system.
+ */
+export type PluginCapability =
+  | "channel" // Provides a message channel (Discord, Slack, etc.)
+  | "provider" // Provides an AI model provider
+  | "stt" // Provides speech-to-text
+  | "tts" // Provides text-to-speech
+  | "context" // Provides context to conversations
+  | "storage" // Provides persistent storage
+  | "auth" // Provides authentication
+  | "webhook" // Provides webhook endpoints
+  | "commands" // Provides CLI commands
+  | "ui" // Provides UI components
+  | "a2a" // Provides agent-to-agent tools
+  | "middleware"; // Provides message middleware/hooks
+
+/**
+ * Plugin categories for marketplace organization.
+ */
+export type PluginCategory =
+  | "channel" // Communication channels
+  | "ai-provider" // AI model providers
+  | "voice" // Voice/audio plugins
+  | "integration" // Third-party integrations
+  | "utility" // Utility/helper plugins
+  | "security" // Security plugins
+  | "analytics" // Analytics/monitoring
+  | "developer"; // Developer tools

--- a/src/plugin-types/plugin.ts
+++ b/src/plugin-types/plugin.ts
@@ -1,0 +1,64 @@
+/**
+ * Core plugin interface and command types.
+ *
+ * WOPRPlugin is the interface every WOPR plugin must implement.
+ * PluginCommand defines CLI commands that plugins can register.
+ */
+
+import type { PluginManifest } from "./manifest.js";
+import type { WOPRPluginContext } from "./context.js";
+
+/**
+ * A CLI command registered by a plugin.
+ */
+export interface PluginCommand {
+  name: string;
+  description: string;
+  usage?: string;
+  handler: (ctx: WOPRPluginContext, args: string[]) => Promise<void>;
+}
+
+/**
+ * The core plugin interface.
+ *
+ * Every WOPR plugin must satisfy this interface. The `manifest` field
+ * is optional for backward compatibility but recommended for WaaS.
+ */
+export interface WOPRPlugin {
+  name: string;
+  version: string;
+  description?: string;
+
+  /** Plugin manifest with full metadata (optional, for WaaS support) */
+  manifest?: PluginManifest;
+
+  /** Runtime hooks (daemon) */
+  init?(ctx: WOPRPluginContext): Promise<void>;
+  shutdown?(): Promise<void>;
+
+  /** CLI extensions */
+  commands?: PluginCommand[];
+}
+
+/**
+ * Record of an installed plugin (on disk).
+ */
+export interface InstalledPlugin {
+  name: string;
+  version: string;
+  description?: string;
+  source: "npm" | "github" | "local";
+  path: string;
+  enabled: boolean;
+  installedAt: number;
+}
+
+/**
+ * A plugin registry entry for remote discovery.
+ */
+export interface PluginRegistryEntry {
+  name: string;
+  url: string;
+  enabled: boolean;
+  lastSync: number;
+}


### PR DESCRIPTION
## Summary
Closes WOP-62

- Create `src/plugin-types/` as the canonical source of truth for all WOPR plugin type definitions
- Export `WOPRPlugin`, `WOPRPluginContext`, `ConfigSchema`, `ConfigField`, `PluginCommand`, and all event/hook/channel types
- Add `PluginManifest` type (new) with capabilities, requirements, setup flows for WaaS support
- Extend `ConfigField.type` union to include `array`, `boolean`, `object`, `textarea` — types plugins already use in the wild
- Organized into focused files: `config.ts`, `manifest.ts`, `plugin.ts`, `context.ts`, `channel.ts`, `events.ts`, `context-provider.ts`, `a2a.ts`
- Barrel export from `index.ts` for clean imports

## Test plan
- [x] `npm run build` (tsc) passes with zero errors
- [x] `npm test` passes — all 180 tests pass
- [x] Existing imports in `src/types.ts` still resolve (no changes to existing files)
- [x] Declaration files generated in `dist/plugin-types/`

Generated with Claude Code