### PR TITLE
test: add unit tests for core security/policy module (WOP-84)

### DIFF
--- a/tests/security/context.test.ts
+++ b/tests/security/context.test.ts
@@ -1,0 +1,801 @@
+/**
+ * Security Context Module Tests (WOP-84)
+ *
+ * Tests SecurityContext class, factory functions, context isolation,
+ * event recording, and context storage.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockFs } from "../mocks/index.js";
+
+// Mock the logger to suppress output during tests
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Set up filesystem mock before importing modules
+const mockFs = createMockFs();
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    existsSync: (p: string) => mockFs.existsSync(p),
+    readFileSync: (p: string, enc?: string) => mockFs.readFileSync(p, enc),
+    writeFileSync: (p: string, content: string) => mockFs.writeFileSync(p, content),
+  };
+});
+
+// Import after mocks are set up
+const { initSecurity } = await import("../../src/security/policy.js");
+const {
+  SecurityContext,
+  createSecurityContext,
+  createCliContext,
+  createDaemonContext,
+  createPluginContext,
+  createCronContext,
+  createP2PContext,
+  createP2PDiscoveryContext,
+  createApiContext,
+  storeContext,
+  getContext,
+  clearContext,
+  withSecurityContext,
+} = await import("../../src/security/context.js");
+
+const {
+  createInjectionSource,
+  DEFAULT_SECURITY_CONFIG,
+} = await import("../../src/security/types.js");
+
+import type { SecurityConfig } from "../../src/security/types.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function setSecurityConfig(config: Partial<SecurityConfig>): void {
+  const full = {
+    ...DEFAULT_SECURITY_CONFIG,
+    ...config,
+  };
+  mockFs.set("/mock/wopr/security.json", JSON.stringify(full));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Security Context Module", () => {
+  beforeEach(() => {
+    mockFs.clear();
+    initSecurity("/mock/wopr");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // SecurityContext Class
+  // ==========================================================================
+  describe("SecurityContext", () => {
+    it("should initialize with source, session, and request ID", () => {
+      const source = createInjectionSource("cli");
+      const ctx = new SecurityContext(source, "main");
+
+      expect(ctx.source).toBe(source);
+      expect(ctx.session).toBe("main");
+      expect(ctx.requestId).toMatch(/^sec-/);
+      expect(ctx.createdAt).toBeLessThanOrEqual(Date.now());
+    });
+
+    it("should generate unique request IDs", () => {
+      const source = createInjectionSource("cli");
+      const ctx1 = new SecurityContext(source, "main");
+      const ctx2 = new SecurityContext(source, "main");
+
+      expect(ctx1.requestId).not.toBe(ctx2.requestId);
+    });
+
+    it("should lazily resolve policy", () => {
+      const source = createInjectionSource("cli");
+      const ctx = new SecurityContext(source, "main");
+
+      // Access policy triggers resolution
+      const policy = ctx.policy;
+      expect(policy.trustLevel).toBe("owner");
+      expect(policy.capabilities).toContain("*");
+
+      // Subsequent access returns same object (cached)
+      expect(ctx.policy).toBe(policy);
+    });
+
+    it("should expose trust level from source", () => {
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.trustLevel).toBe("untrusted");
+    });
+
+    it("should expose capabilities from resolved policy", () => {
+      const source = createInjectionSource("plugin");
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.capabilities).toContain("inject");
+      expect(ctx.capabilities).toContain("inject.tools");
+    });
+
+    it("should return resolved policy via getResolvedPolicy()", () => {
+      const source = createInjectionSource("cli");
+      const ctx = new SecurityContext(source, "main");
+
+      const policy = ctx.getResolvedPolicy();
+      expect(policy).toBe(ctx.policy);
+    });
+  });
+
+  // ==========================================================================
+  // Capability Checking
+  // ==========================================================================
+  describe("hasCapability", () => {
+    it("should return true for owner with any capability", () => {
+      const ctx = createCliContext("main");
+
+      expect(ctx.hasCapability("config.write")).toBe(true);
+      expect(ctx.hasCapability("inject.exec")).toBe(true);
+      expect(ctx.hasCapability("*")).toBe(true);
+    });
+
+    it("should return false for untrusted requesting privileged capabilities", () => {
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.hasCapability("config.write")).toBe(false);
+      expect(ctx.hasCapability("session.spawn")).toBe(false);
+      expect(ctx.hasCapability("memory.write")).toBe(false);
+    });
+
+    it("should record capability check events", () => {
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+
+      ctx.hasCapability("config.write");
+
+      const events = ctx.getEvents();
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe("capability_check");
+      expect(events[0].capability).toBe("config.write");
+      expect(events[0].allowed).toBe(false);
+    });
+
+    it("should return true for granted capabilities", () => {
+      const source = createInjectionSource("p2p", {
+        grantedCapabilities: ["memory.read"],
+      });
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.hasCapability("memory.read")).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Session Access
+  // ==========================================================================
+  describe("canAccessSession", () => {
+    it("should allow owner to access sessions", () => {
+      const ctx = createCliContext("main");
+      const result = ctx.canAccessSession();
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny untrusted below minimum trust level", () => {
+      setSecurityConfig({
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "trusted",
+        },
+      });
+
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+      const result = ctx.canAccessSession();
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("should record access events", () => {
+      const ctx = createCliContext("main");
+      ctx.canAccessSession();
+
+      const events = ctx.getEvents();
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe("access_granted");
+    });
+
+    it("should record denied access events", () => {
+      setSecurityConfig({
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "trusted",
+        },
+      });
+
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+      ctx.canAccessSession();
+
+      const events = ctx.getEvents();
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe("access_denied");
+      expect(events[0].allowed).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Tool Access
+  // ==========================================================================
+  describe("canUseTool", () => {
+    it("should allow owner to use any tool", () => {
+      const ctx = createCliContext("main");
+      const result = ctx.canUseTool("exec_command");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should record tool check events", () => {
+      const ctx = createCliContext("main");
+      ctx.canUseTool("config_set");
+
+      const events = ctx.getEvents();
+      expect(events.length).toBe(1);
+      expect(events[0].type).toBe("capability_check");
+      expect(events[0].tool).toBe("config_set");
+    });
+
+    it("should handle warn mode tool checks", () => {
+      // Default is warn mode
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+
+      const result = ctx.canUseTool("http_fetch");
+      // In warn mode, allowed but with warning
+      expect(result.allowed).toBe(true);
+      expect(result.warning).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Tool Filtering
+  // ==========================================================================
+  describe("filterTools", () => {
+    it("should return all tools for owner context", () => {
+      const ctx = createCliContext("main");
+      const tools = ["config_set", "http_fetch", "exec_command"];
+      const filtered = ctx.filterTools(tools);
+
+      expect(filtered).toEqual(tools);
+    });
+
+    it("should filter based on policy in enforce mode", () => {
+      setSecurityConfig({
+        enforcement: "enforce",
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            tools: { deny: ["*"], allow: ["security_whoami"] },
+          },
+        },
+      });
+
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+      const tools = ["security_whoami", "http_fetch", "exec_command"];
+      const filtered = ctx.filterTools(tools);
+
+      expect(filtered).toContain("security_whoami");
+      expect(filtered).not.toContain("http_fetch");
+      expect(filtered).not.toContain("exec_command");
+    });
+  });
+
+  // ==========================================================================
+  // Sandbox
+  // ==========================================================================
+  describe("requiresSandbox / getSandboxConfig", () => {
+    it("should not require sandbox for owner", () => {
+      const ctx = createCliContext("main");
+      expect(ctx.requiresSandbox()).toBe(false);
+      expect(ctx.getSandboxConfig()).toBeNull();
+    });
+
+    it("should require sandbox for untrusted", () => {
+      const source = createInjectionSource("p2p");
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.requiresSandbox()).toBe(true);
+
+      const sandbox = ctx.getSandboxConfig();
+      expect(sandbox).not.toBeNull();
+      expect(sandbox!.network).toBe("none");
+    });
+
+    it("should require sandbox for semi-trusted", () => {
+      const source = createInjectionSource("api");
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.requiresSandbox()).toBe(true);
+
+      const sandbox = ctx.getSandboxConfig();
+      expect(sandbox).not.toBeNull();
+      expect(sandbox!.network).toBe("bridge");
+    });
+  });
+
+  // ==========================================================================
+  // Gateway / Forward
+  // ==========================================================================
+  describe("isGateway / canForward / getForwardRules", () => {
+    it("should detect gateway context", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["gw-session"],
+          forwardRules: {
+            "gw-session": {
+              allowForwardTo: ["main"],
+            },
+          },
+        },
+      });
+
+      const source = createInjectionSource("api");
+      const ctx = new SecurityContext(source, "gw-session");
+
+      expect(ctx.isGateway()).toBe(true);
+      expect(ctx.getForwardRules()).toBeDefined();
+      expect(ctx.getForwardRules()!.allowForwardTo).toContain("main");
+    });
+
+    it("should report canForward when gateway with cross.inject", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["gw-session"],
+        },
+        trustLevels: {
+          trusted: {
+            capabilities: ["inject", "cross.inject"],
+          },
+        },
+      });
+
+      const source = createInjectionSource("plugin"); // trusted
+      const ctx = new SecurityContext(source, "gw-session");
+
+      expect(ctx.canForward()).toBe(true);
+    });
+
+    it("should not canForward without cross.inject", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["gw-session"],
+        },
+      });
+
+      const source = createInjectionSource("p2p"); // untrusted
+      const ctx = new SecurityContext(source, "gw-session");
+
+      expect(ctx.canForward()).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Derived Context (Forwarding)
+  // ==========================================================================
+  describe("deriveForForward", () => {
+    it("should create a derived context for forwarding", () => {
+      const source = createInjectionSource("plugin");
+      const ctx = new SecurityContext(source, "gateway");
+
+      const derived = ctx.deriveForForward("target-session");
+
+      expect(derived.session).toBe("target-session");
+      expect(derived.source.type).toBe("gateway");
+      expect(derived.source.trustLevel).toBe("semi-trusted");
+      expect(derived.source.identity?.gatewaySession).toBe("gateway");
+    });
+
+    it("should carry forward public key from original source", () => {
+      const source = createInjectionSource("p2p", {
+        identity: { publicKey: "abc123" },
+      });
+      const ctx = new SecurityContext(source, "gateway");
+
+      const derived = ctx.deriveForForward("target");
+
+      expect(derived.source.identity?.publicKey).toBe("abc123");
+    });
+
+    it("should not share events between original and derived", () => {
+      const source = createInjectionSource("cli");
+      const ctx = new SecurityContext(source, "gateway");
+      ctx.hasCapability("inject"); // Record event on original
+
+      const derived = ctx.deriveForForward("target");
+
+      expect(ctx.getEvents().length).toBe(1);
+      expect(derived.getEvents().length).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // Event Recording
+  // ==========================================================================
+  describe("recordEvent / getEvents", () => {
+    it("should record and return security events", () => {
+      const source = createInjectionSource("api");
+      const ctx = new SecurityContext(source, "test");
+
+      ctx.recordEvent("access_granted", { allowed: true });
+      ctx.recordEvent("capability_check", {
+        capability: "inject",
+        allowed: true,
+      });
+
+      const events = ctx.getEvents();
+      expect(events.length).toBe(2);
+      expect(events[0].type).toBe("access_granted");
+      expect(events[1].type).toBe("capability_check");
+    });
+
+    it("should return a copy of events (not mutable reference)", () => {
+      const source = createInjectionSource("cli");
+      const ctx = new SecurityContext(source, "test");
+
+      ctx.recordEvent("access_granted", { allowed: true });
+
+      const events1 = ctx.getEvents();
+      const events2 = ctx.getEvents();
+
+      expect(events1).not.toBe(events2); // Different references
+      expect(events1).toEqual(events2); // Same content
+    });
+
+    it("should include source and session in recorded events", () => {
+      const source = createInjectionSource("p2p", {
+        identity: { publicKey: "peer123" },
+      });
+      const ctx = new SecurityContext(source, "target-session");
+
+      ctx.recordEvent("access_denied", {
+        allowed: false,
+        reason: "trust too low",
+      });
+
+      const events = ctx.getEvents();
+      expect(events[0].source.type).toBe("p2p");
+      expect(events[0].session).toBe("target-session");
+      expect(events[0].reason).toBe("trust too low");
+    });
+  });
+
+  // ==========================================================================
+  // Serialization
+  // ==========================================================================
+  describe("toJSON", () => {
+    it("should serialize context for logging", () => {
+      const source = createInjectionSource("api", {
+        identity: { apiKeyId: "key-123" },
+      });
+      const ctx = new SecurityContext(source, "api-session");
+
+      const json = ctx.toJSON();
+
+      expect(json.requestId).toBe(ctx.requestId);
+      expect(json.session).toBe("api-session");
+      expect((json.source as any).type).toBe("api");
+      expect((json.source as any).trustLevel).toBe("semi-trusted");
+      expect((json.source as any).identity.apiKeyId).toBe("key-123");
+      expect(json.createdAt).toBe(ctx.createdAt);
+      expect(json.eventCount).toBe(0);
+    });
+
+    it("should include event count", () => {
+      const ctx = createCliContext("main");
+      ctx.hasCapability("inject");
+      ctx.hasCapability("config.write");
+
+      const json = ctx.toJSON();
+      expect(json.eventCount).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // Factory Functions
+  // ==========================================================================
+  describe("Factory Functions", () => {
+    it("createSecurityContext should create context with given source and session", () => {
+      const source = createInjectionSource("api");
+      const ctx = createSecurityContext(source, "my-session");
+
+      expect(ctx.source).toBe(source);
+      expect(ctx.session).toBe("my-session");
+    });
+
+    it("createCliContext should create owner-trust context", () => {
+      const ctx = createCliContext("main");
+
+      expect(ctx.source.type).toBe("cli");
+      expect(ctx.trustLevel).toBe("owner");
+    });
+
+    it("createDaemonContext should create owner-trust context", () => {
+      const ctx = createDaemonContext("main");
+
+      expect(ctx.source.type).toBe("daemon");
+      expect(ctx.trustLevel).toBe("owner");
+    });
+
+    it("createPluginContext should create trusted context with plugin name", () => {
+      const ctx = createPluginContext("main", "my-plugin");
+
+      expect(ctx.source.type).toBe("plugin");
+      expect(ctx.trustLevel).toBe("trusted");
+      expect(ctx.source.identity?.pluginName).toBe("my-plugin");
+    });
+
+    it("createCronContext should create owner-trust context", () => {
+      const ctx = createCronContext("cron-session");
+
+      expect(ctx.source.type).toBe("cron");
+      expect(ctx.trustLevel).toBe("owner");
+    });
+
+    it("createP2PContext should create context with configurable trust", () => {
+      const ctx = createP2PContext("p2p-session", "peer-key-abc", "trusted", ["memory.read"], "grant-1");
+
+      expect(ctx.source.type).toBe("p2p");
+      expect(ctx.trustLevel).toBe("trusted");
+      expect(ctx.source.identity?.publicKey).toBe("peer-key-abc");
+      expect(ctx.source.grantedCapabilities).toContain("memory.read");
+      expect(ctx.source.grantId).toBe("grant-1");
+    });
+
+    it("createP2PContext should default to untrusted", () => {
+      const ctx = createP2PContext("p2p-session", "peer-key");
+
+      expect(ctx.trustLevel).toBe("untrusted");
+    });
+
+    it("createP2PDiscoveryContext should always be untrusted", () => {
+      const ctx = createP2PDiscoveryContext("disc-session", "disc-peer-key");
+
+      expect(ctx.source.type).toBe("p2p.discovery");
+      expect(ctx.trustLevel).toBe("untrusted");
+      expect(ctx.source.identity?.publicKey).toBe("disc-peer-key");
+    });
+
+    it("createApiContext should default to semi-trusted", () => {
+      const ctx = createApiContext("api-session");
+
+      expect(ctx.source.type).toBe("api");
+      expect(ctx.trustLevel).toBe("semi-trusted");
+    });
+
+    it("createApiContext should allow configurable trust and API key", () => {
+      const ctx = createApiContext("api-session", "api-key-456", "trusted");
+
+      expect(ctx.trustLevel).toBe("trusted");
+      expect(ctx.source.identity?.apiKeyId).toBe("api-key-456");
+    });
+  });
+
+  // ==========================================================================
+  // Context Storage
+  // ==========================================================================
+  describe("Context Storage", () => {
+    it("should store and retrieve context by session", () => {
+      const ctx = createCliContext("stored-session");
+      storeContext(ctx);
+
+      const retrieved = getContext("stored-session");
+      expect(retrieved).toBe(ctx);
+    });
+
+    it("should return undefined for unknown sessions", () => {
+      const result = getContext("nonexistent-session");
+      expect(result).toBeUndefined();
+    });
+
+    it("should clear context by session", () => {
+      const ctx = createCliContext("temp-session");
+      storeContext(ctx);
+
+      clearContext("temp-session");
+
+      expect(getContext("temp-session")).toBeUndefined();
+    });
+
+    it("should overwrite existing context for same session", () => {
+      const ctx1 = createCliContext("shared-session");
+      const ctx2 = createApiContext("shared-session");
+
+      storeContext(ctx1);
+      storeContext(ctx2);
+
+      const retrieved = getContext("shared-session");
+      expect(retrieved).toBe(ctx2);
+      expect(retrieved!.source.type).toBe("api");
+    });
+  });
+
+  // ==========================================================================
+  // withSecurityContext
+  // ==========================================================================
+  describe("withSecurityContext", () => {
+    it("should store context during function execution", async () => {
+      const ctx = createCliContext("with-ctx-session");
+
+      await withSecurityContext(ctx, async () => {
+        const current = getContext("with-ctx-session");
+        expect(current).toBe(ctx);
+      });
+    });
+
+    it("should clear context after function completes", async () => {
+      const ctx = createCliContext("cleanup-session");
+
+      await withSecurityContext(ctx, async () => {
+        // Context exists during execution
+        expect(getContext("cleanup-session")).toBe(ctx);
+      });
+
+      // Context cleared after
+      expect(getContext("cleanup-session")).toBeUndefined();
+    });
+
+    it("should clear context even if function throws", async () => {
+      const ctx = createCliContext("error-session");
+
+      await expect(
+        withSecurityContext(ctx, async () => {
+          throw new Error("intentional error");
+        }),
+      ).rejects.toThrow("intentional error");
+
+      // Context should still be cleared
+      expect(getContext("error-session")).toBeUndefined();
+    });
+
+    it("should return the function result", async () => {
+      const ctx = createCliContext("result-session");
+
+      const result = await withSecurityContext(ctx, async () => {
+        return 42;
+      });
+
+      expect(result).toBe(42);
+    });
+  });
+
+  // ==========================================================================
+  // Context Isolation
+  // ==========================================================================
+  describe("Context Isolation", () => {
+    it("should isolate contexts for different sessions", () => {
+      const ctx1 = createCliContext("session-a");
+      const ctx2 = createApiContext("session-b");
+
+      storeContext(ctx1);
+      storeContext(ctx2);
+
+      expect(getContext("session-a")!.trustLevel).toBe("owner");
+      expect(getContext("session-b")!.trustLevel).toBe("semi-trusted");
+    });
+
+    it("should not share events between contexts", () => {
+      const ctx1 = createCliContext("session-1");
+      const ctx2 = createApiContext("session-2");
+
+      ctx1.hasCapability("inject");
+      ctx2.hasCapability("config.write");
+
+      expect(ctx1.getEvents().length).toBe(1);
+      expect(ctx2.getEvents().length).toBe(1);
+
+      // Events are independent
+      expect(ctx1.getEvents()[0].type).toBe("capability_check");
+      expect(ctx2.getEvents()[0].type).toBe("capability_check");
+    });
+
+    it("should not share policy between contexts of different trust levels", () => {
+      const ownerCtx = createCliContext("main");
+      const untrustedCtx = new SecurityContext(createInjectionSource("p2p"), "public");
+
+      expect(ownerCtx.policy.capabilities).toContain("*");
+      expect(untrustedCtx.policy.capabilities).not.toContain("*");
+      expect(untrustedCtx.policy.capabilities).toEqual(["inject"]);
+    });
+
+    it("should maintain separate sandbox configs per context", () => {
+      const ownerCtx = createCliContext("admin");
+      const p2pCtx = new SecurityContext(createInjectionSource("p2p"), "external");
+
+      expect(ownerCtx.requiresSandbox()).toBe(false);
+      expect(p2pCtx.requiresSandbox()).toBe(true);
+    });
+
+    it("should allow concurrent contexts for same session name without interference", async () => {
+      const ctx1 = createCliContext("shared");
+      const ctx2 = createApiContext("shared");
+
+      // Both can exist independently
+      expect(ctx1.trustLevel).toBe("owner");
+      expect(ctx2.trustLevel).toBe("semi-trusted");
+
+      // Storage overwrites, but the objects themselves are independent
+      storeContext(ctx1);
+      expect(getContext("shared")!.trustLevel).toBe("owner");
+
+      storeContext(ctx2);
+      expect(getContext("shared")!.trustLevel).toBe("semi-trusted");
+
+      // ctx1 is still independently usable even though it's not stored
+      expect(ctx1.trustLevel).toBe("owner");
+      expect(ctx1.hasCapability("*")).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+  describe("Edge Cases", () => {
+    it("should handle context with no identity", () => {
+      const source = createInjectionSource("internal");
+      const ctx = new SecurityContext(source, "test");
+
+      expect(ctx.source.identity).toBeUndefined();
+      expect(ctx.trustLevel).toBe("owner");
+    });
+
+    it("should handle empty session name", () => {
+      const ctx = createCliContext("");
+
+      expect(ctx.session).toBe("");
+      expect(ctx.policy).toBeDefined();
+    });
+
+    it("should handle P2P context with elevated trust correctly", () => {
+      const ctx = createP2PContext("p2p-elevated", "key", "trusted", [
+        "memory.read",
+        "memory.write",
+        "session.history",
+      ]);
+
+      expect(ctx.trustLevel).toBe("trusted");
+      expect(ctx.hasCapability("memory.read")).toBe(true);
+      expect(ctx.hasCapability("memory.write")).toBe(true);
+      // Should not have owner-level capabilities
+      expect(ctx.hasCapability("config.write")).toBe(false);
+    });
+
+    it("should handle multiple tool checks recording separate events", () => {
+      const ctx = createApiContext("api-test");
+
+      ctx.canUseTool("config_get");
+      ctx.canUseTool("http_fetch");
+      ctx.canUseTool("exec_command");
+
+      const events = ctx.getEvents();
+      expect(events.length).toBe(3);
+      expect(events[0].tool).toBe("config_get");
+      expect(events[1].tool).toBe("http_fetch");
+      expect(events[2].tool).toBe("exec_command");
+    });
+  });
+});

--- a/tests/security/policy.test.ts
+++ b/tests/security/policy.test.ts
@@ -1,0 +1,1053 @@
+/**
+ * Security Policy Module Tests (WOP-84)
+ *
+ * Tests policy resolution, enforcement checks, session access,
+ * capability checking, tool access, and edge cases.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockFs } from "../mocks/index.js";
+
+// Mock the logger to suppress output during tests
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Set up filesystem mock before importing policy module
+const mockFs = createMockFs();
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    existsSync: (p: string) => mockFs.existsSync(p),
+    readFileSync: (p: string, enc?: string) => mockFs.readFileSync(p, enc),
+    writeFileSync: (p: string, content: string) => mockFs.writeFileSync(p, content),
+  };
+});
+
+// Import after mocks are set up
+const {
+  initSecurity,
+  getSecurityConfig,
+  saveSecurityConfig,
+  resolvePolicy,
+  checkSessionAccess,
+  checkCapability,
+  checkToolAccess,
+  checkSandboxRequired,
+  filterToolsByPolicy,
+  isEnforcementEnabled,
+  shouldLogSecurityEvent,
+  sessionAllowsUntrusted,
+  isGatewaySession,
+  getGatewayRules,
+  canSessionForward,
+  canGatewayForward,
+} = await import("../../src/security/policy.js");
+
+const {
+  createInjectionSource,
+  DEFAULT_SECURITY_CONFIG,
+} = await import("../../src/security/types.js");
+
+import type { InjectionSource, SecurityConfig } from "../../src/security/types.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeSource(type: InjectionSource["type"], overrides?: Partial<InjectionSource>): InjectionSource {
+  return createInjectionSource(type, overrides);
+}
+
+function setSecurityConfig(config: Partial<SecurityConfig>): void {
+  const full = {
+    ...DEFAULT_SECURITY_CONFIG,
+    ...config,
+  };
+  mockFs.set("/mock/wopr/security.json", JSON.stringify(full));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Security Policy Module", () => {
+  beforeEach(() => {
+    mockFs.clear();
+    // Reset cached config by re-initializing
+    initSecurity("/mock/wopr");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // Config Loading
+  // ==========================================================================
+  describe("getSecurityConfig", () => {
+    it("should return default config when no security.json exists", () => {
+      const config = getSecurityConfig();
+      expect(config.enforcement).toBe("warn");
+      expect(config.defaults.minTrustLevel).toBe("semi-trusted");
+    });
+
+    it("should load and merge config from security.json", () => {
+      setSecurityConfig({ enforcement: "enforce" });
+
+      const config = getSecurityConfig();
+      expect(config.enforcement).toBe("enforce");
+      // Defaults should still be merged
+      expect(config.defaults).toBeDefined();
+    });
+
+    it("should cache loaded config on subsequent calls", () => {
+      setSecurityConfig({ enforcement: "enforce" });
+
+      const config1 = getSecurityConfig();
+      const config2 = getSecurityConfig();
+      expect(config1).toBe(config2); // Same reference (cached)
+    });
+
+    it("should return default config when security.json is invalid JSON", () => {
+      mockFs.set("/mock/wopr/security.json", "not valid json{{{");
+
+      const config = getSecurityConfig();
+      expect(config.enforcement).toBe("warn"); // Falls back to default
+    });
+  });
+
+  describe("saveSecurityConfig", () => {
+    it("should save config to security.json", () => {
+      const config = { ...DEFAULT_SECURITY_CONFIG, enforcement: "enforce" as const };
+      saveSecurityConfig(config);
+
+      const saved = JSON.parse(mockFs.get("/mock/wopr/security.json")!);
+      expect(saved.enforcement).toBe("enforce");
+    });
+
+    it("should write to the configured security.json path", () => {
+      const config = { ...DEFAULT_SECURITY_CONFIG, enforcement: "off" as const };
+      saveSecurityConfig(config);
+      const saved = JSON.parse(mockFs.get("/mock/wopr/security.json")!);
+      expect(saved.enforcement).toBe("off");
+    });
+  });
+
+  // ==========================================================================
+  // Policy Resolution
+  // ==========================================================================
+  describe("resolvePolicy", () => {
+    it("should resolve owner trust level with wildcard capabilities", () => {
+      const source = makeSource("cli"); // owner trust
+      const policy = resolvePolicy(source);
+
+      expect(policy.trustLevel).toBe("owner");
+      expect(policy.capabilities).toContain("*");
+    });
+
+    it("should resolve trusted with appropriate capability set", () => {
+      const source = makeSource("plugin"); // trusted
+      const policy = resolvePolicy(source);
+
+      expect(policy.trustLevel).toBe("trusted");
+      expect(policy.capabilities).toContain("inject");
+      expect(policy.capabilities).toContain("inject.tools");
+      expect(policy.capabilities).toContain("session.spawn");
+    });
+
+    it("should resolve semi-trusted with limited capabilities", () => {
+      const source = makeSource("api"); // semi-trusted
+      const policy = resolvePolicy(source);
+
+      expect(policy.trustLevel).toBe("semi-trusted");
+      expect(policy.capabilities).toContain("inject");
+      expect(policy.capabilities).not.toContain("config.write");
+      expect(policy.capabilities).not.toContain("memory.write");
+    });
+
+    it("should resolve untrusted with minimal capabilities", () => {
+      const source = makeSource("p2p"); // untrusted
+      const policy = resolvePolicy(source);
+
+      expect(policy.trustLevel).toBe("untrusted");
+      expect(policy.capabilities).toEqual(["inject"]);
+    });
+
+    it("should merge granted capabilities with base capabilities", () => {
+      const source = makeSource("p2p", {
+        grantedCapabilities: ["memory.read", "session.history"],
+      });
+      const policy = resolvePolicy(source);
+
+      expect(policy.capabilities).toContain("inject");
+      expect(policy.capabilities).toContain("memory.read");
+      expect(policy.capabilities).toContain("session.history");
+    });
+
+    it("should not duplicate granted capabilities already in base set", () => {
+      const source = makeSource("p2p", {
+        grantedCapabilities: ["inject"], // already in untrusted base
+      });
+      const policy = resolvePolicy(source);
+
+      const injectCount = policy.capabilities.filter((c) => c === "inject").length;
+      expect(injectCount).toBe(1);
+    });
+
+    it("should apply sandbox defaults by trust level", () => {
+      const untrustedSource = makeSource("p2p");
+      const untrustedPolicy = resolvePolicy(untrustedSource);
+      expect(untrustedPolicy.sandbox.enabled).toBe(true);
+      expect(untrustedPolicy.sandbox.network).toBe("none");
+
+      const ownerSource = makeSource("cli");
+      const ownerPolicy = resolvePolicy(ownerSource);
+      expect(ownerPolicy.sandbox.enabled).toBe(false);
+    });
+
+    it("should apply rate limits from defaults", () => {
+      const source = makeSource("api");
+      const policy = resolvePolicy(source);
+
+      expect(policy.rateLimit.perMinute).toBeGreaterThan(0);
+      expect(policy.rateLimit.perHour).toBeGreaterThan(0);
+    });
+
+    it("should apply trust level rate limit overrides", () => {
+      setSecurityConfig({
+        trustLevels: {
+          "semi-trusted": {
+            capabilities: ["inject"],
+            rateLimit: { perMinute: 10, perHour: 100 },
+          },
+        },
+      });
+
+      const source = makeSource("api");
+      const policy = resolvePolicy(source);
+
+      expect(policy.rateLimit.perMinute).toBe(10);
+      expect(policy.rateLimit.perHour).toBe(100);
+    });
+
+    it("should resolve session access from trust level policy", () => {
+      setSecurityConfig({
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            sessions: {
+              allowed: ["public-session"],
+              blocked: ["admin-session"],
+            },
+          },
+        },
+      });
+
+      const source = makeSource("p2p");
+      const policy = resolvePolicy(source);
+
+      expect(policy.allowedSessions).toEqual(["public-session"]);
+      expect(policy.blockedSessions).toEqual(["admin-session"]);
+    });
+
+    it("should default to wildcard session access when no restrictions", () => {
+      const source = makeSource("cli");
+      const policy = resolvePolicy(source);
+
+      expect(policy.allowedSessions).toBe("*");
+      expect(policy.blockedSessions).toEqual([]);
+    });
+
+    it("should detect gateway sessions", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["discord-gateway"],
+          forwardRules: {
+            "discord-gateway": {
+              allowForwardTo: ["main"],
+              allowActions: ["inject"],
+            },
+          },
+        },
+      });
+
+      const source = makeSource("api");
+      const policy = resolvePolicy(source, "discord-gateway");
+
+      expect(policy.isGateway).toBe(true);
+      expect(policy.forwardRules).toBeDefined();
+      expect(policy.forwardRules!.allowForwardTo).toContain("main");
+    });
+
+    it("should set canForward when gateway and has cross.inject", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["gateway-session"],
+        },
+        trustLevels: {
+          trusted: {
+            capabilities: ["inject", "cross.inject"],
+          },
+        },
+      });
+
+      const source = makeSource("plugin"); // trusted
+      const policy = resolvePolicy(source, "gateway-session");
+
+      expect(policy.isGateway).toBe(true);
+      expect(policy.canForward).toBe(true);
+    });
+
+    it("should not canForward when gateway but no cross.inject", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["gateway-session"],
+        },
+      });
+
+      const source = makeSource("p2p"); // untrusted - no cross.inject
+      const policy = resolvePolicy(source, "gateway-session");
+
+      expect(policy.isGateway).toBe(true);
+      expect(policy.canForward).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Session Access Checks
+  // ==========================================================================
+  describe("checkSessionAccess", () => {
+    it("should allow owner to access any session", () => {
+      const source = makeSource("cli");
+      const result = checkSessionAccess(source, "any-session");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny untrusted below minimum trust level", () => {
+      setSecurityConfig({
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "trusted",
+        },
+      });
+
+      const source = makeSource("p2p"); // untrusted
+      const result = checkSessionAccess(source, "any-session");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("Trust level");
+      expect(result.reason).toContain("below minimum");
+    });
+
+    it("should deny access to blocked sessions", () => {
+      setSecurityConfig({
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            sessions: {
+              blocked: ["private-session"],
+            },
+          },
+        },
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "untrusted",
+        },
+        defaultAccess: ["trust:untrusted"],
+      });
+
+      const source = makeSource("p2p");
+      const result = checkSessionAccess(source, "private-session");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("blocked");
+    });
+
+    it("should deny access when session not in allowed list", () => {
+      setSecurityConfig({
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            sessions: {
+              allowed: ["public-only"],
+            },
+          },
+        },
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "untrusted",
+        },
+        defaultAccess: ["trust:untrusted"],
+      });
+
+      const source = makeSource("p2p");
+      const result = checkSessionAccess(source, "not-in-list");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("not in allowed list");
+    });
+
+    it("should allow access when session is in allowed list and matches access patterns", () => {
+      setSecurityConfig({
+        trustLevels: {
+          "semi-trusted": {
+            capabilities: ["inject"],
+            sessions: {
+              allowed: ["api-session"],
+            },
+          },
+        },
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "semi-trusted",
+        },
+        sessions: {
+          "api-session": {
+            access: ["trust:semi-trusted"],
+          },
+        },
+      });
+
+      const source = makeSource("api");
+      const result = checkSessionAccess(source, "api-session");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny when source does not match session access patterns", () => {
+      setSecurityConfig({
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "untrusted",
+        },
+        sessions: {
+          "owner-only": {
+            access: ["trust:owner"],
+          },
+        },
+      });
+
+      const source = makeSource("api"); // semi-trusted, not owner
+      const result = checkSessionAccess(source, "owner-only");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("does not match access rules");
+    });
+  });
+
+  // ==========================================================================
+  // Capability Checks
+  // ==========================================================================
+  describe("checkCapability", () => {
+    it("should allow owner all capabilities via wildcard", () => {
+      const source = makeSource("cli");
+      const result = checkCapability(source, "config.write");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should allow trusted sources their granted capabilities", () => {
+      const source = makeSource("plugin");
+      const result = checkCapability(source, "inject.tools");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny untrusted sources capabilities they don't have", () => {
+      const source = makeSource("p2p");
+      const result = checkCapability(source, "config.write");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("not granted");
+    });
+
+    it("should allow explicitly granted capabilities to override base", () => {
+      const source = makeSource("p2p", {
+        grantedCapabilities: ["memory.read"],
+      });
+      const result = checkCapability(source, "memory.read");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should check parent capability (inject grants inject.tools)", () => {
+      // Semi-trusted has "inject" which should grant "inject.tools" via parent check
+      const source = makeSource("api");
+      const result = checkCapability(source, "inject.tools");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny capabilities with no parent match", () => {
+      const source = makeSource("p2p"); // only has "inject"
+      const result = checkCapability(source, "config.read");
+
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Tool Access Checks
+  // ==========================================================================
+  describe("checkToolAccess", () => {
+    it("should allow owner access to all tools", () => {
+      const source = makeSource("cli");
+      const result = checkToolAccess(source, "config_set");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny explicitly denied tools", () => {
+      setSecurityConfig({
+        enforcement: "enforce",
+        trustLevels: {
+          "semi-trusted": {
+            capabilities: ["inject"],
+            tools: { deny: ["dangerous_tool"] },
+          },
+        },
+      });
+
+      const source = makeSource("api");
+      const result = checkToolAccess(source, "dangerous_tool");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("denied");
+    });
+
+    it("should allow explicitly allowed tools even when wildcard deny", () => {
+      setSecurityConfig({
+        enforcement: "enforce",
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            tools: { deny: ["*"], allow: ["security_whoami"] },
+          },
+        },
+      });
+
+      const source = makeSource("p2p");
+      const result = checkToolAccess(source, "security_whoami");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should return warning instead of deny in warn mode", () => {
+      setSecurityConfig({
+        enforcement: "warn",
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            tools: { deny: ["dangerous_tool"] },
+          },
+        },
+      });
+
+      const source = makeSource("p2p");
+      const result = checkToolAccess(source, "dangerous_tool");
+
+      expect(result.allowed).toBe(true);
+      expect(result.warning).toContain("warn mode");
+    });
+
+    it("should deny tools requiring capabilities the source lacks", () => {
+      setSecurityConfig({ enforcement: "enforce" });
+
+      const source = makeSource("p2p"); // untrusted, only has "inject"
+      // http_fetch requires inject.network, but untrusted has deny: ["*"]
+      // so it gets denied by tool policy first
+      const result = checkToolAccess(source, "http_fetch");
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("denied");
+    });
+
+    it("should warn about missing capability in warn mode", () => {
+      // Default config is "warn" mode
+      const source = makeSource("p2p");
+      const result = checkToolAccess(source, "http_fetch");
+
+      expect(result.allowed).toBe(true);
+      expect(result.warning).toContain("warn mode");
+    });
+
+    it("should allow tools with no capability requirement", () => {
+      const source = makeSource("p2p");
+      // A tool not in the TOOL_CAPABILITY_MAP has no requirement
+      const result = checkToolAccess(source, "unknown_tool");
+
+      // Not in deny list for untrusted? Check default config
+      // Default untrusted has tools: { deny: ["*"] }
+      // With warn mode, this should warn
+      expect(result.allowed).toBe(true); // warn mode
+      expect(result.warning).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Sandbox Checks
+  // ==========================================================================
+  describe("checkSandboxRequired", () => {
+    it("should not require sandbox for owner", () => {
+      const source = makeSource("cli");
+      const result = checkSandboxRequired(source);
+
+      expect(result).toBeNull();
+    });
+
+    it("should not require sandbox for trusted", () => {
+      const source = makeSource("plugin");
+      const result = checkSandboxRequired(source);
+
+      expect(result).toBeNull();
+    });
+
+    it("should require sandbox for semi-trusted", () => {
+      const source = makeSource("api");
+      const result = checkSandboxRequired(source);
+
+      expect(result).not.toBeNull();
+      expect(result!.enabled).toBe(true);
+      expect(result!.network).toBe("bridge");
+    });
+
+    it("should require sandbox for untrusted with stricter config", () => {
+      const source = makeSource("p2p");
+      const result = checkSandboxRequired(source);
+
+      expect(result).not.toBeNull();
+      expect(result!.enabled).toBe(true);
+      expect(result!.network).toBe("none");
+    });
+  });
+
+  // ==========================================================================
+  // Tool Filtering
+  // ==========================================================================
+  describe("filterToolsByPolicy", () => {
+    it("should return all tools for owner", () => {
+      const source = makeSource("cli");
+      const tools = ["config_set", "http_fetch", "exec_command", "memory_write"];
+      const filtered = filterToolsByPolicy(source, tools);
+
+      expect(filtered).toEqual(tools);
+    });
+
+    it("should filter denied tools in enforce mode", () => {
+      setSecurityConfig({
+        enforcement: "enforce",
+        trustLevels: {
+          untrusted: {
+            capabilities: ["inject"],
+            tools: { deny: ["*"], allow: ["security_whoami"] },
+          },
+        },
+      });
+
+      const source = makeSource("p2p");
+      const tools = ["security_whoami", "config_set", "http_fetch"];
+      const filtered = filterToolsByPolicy(source, tools);
+
+      expect(filtered).toContain("security_whoami");
+      expect(filtered).not.toContain("config_set");
+      expect(filtered).not.toContain("http_fetch");
+    });
+
+    it("should filter tools denied by wildcard even in warn mode", () => {
+      // Default untrusted has tools: { deny: ["*"] }
+      // filterToolsByPolicy checks deny list first - deny list is enforced
+      // even in warn mode (warn mode only applies to capability checks)
+      const source = makeSource("p2p");
+      const tools = ["http_fetch", "security_whoami"];
+      const filtered = filterToolsByPolicy(source, tools);
+
+      // Untrusted has deny: ["*"] with no allow list, so all filtered out
+      expect(filtered).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // Enforcement Mode
+  // ==========================================================================
+  describe("isEnforcementEnabled", () => {
+    it("should return false for default config (warn mode)", () => {
+      expect(isEnforcementEnabled()).toBe(false);
+    });
+
+    it("should return true when enforcement is 'enforce'", () => {
+      setSecurityConfig({ enforcement: "enforce" });
+      const result = isEnforcementEnabled();
+      expect(result).toBe(true);
+    });
+
+    it("should return false when enforcement is 'off'", () => {
+      setSecurityConfig({ enforcement: "off" });
+      expect(isEnforcementEnabled()).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Audit Logging
+  // ==========================================================================
+  describe("shouldLogSecurityEvent", () => {
+    it("should log denied events when audit.logDenied is true", () => {
+      setSecurityConfig({
+        audit: { enabled: true, logDenied: true, logSuccess: false },
+      });
+      expect(shouldLogSecurityEvent(false)).toBe(true);
+    });
+
+    it("should not log success events when audit.logSuccess is false", () => {
+      setSecurityConfig({
+        audit: { enabled: true, logDenied: true, logSuccess: false },
+      });
+      expect(shouldLogSecurityEvent(true)).toBe(false);
+    });
+
+    it("should log success events when audit.logSuccess is true", () => {
+      setSecurityConfig({
+        audit: { enabled: true, logDenied: true, logSuccess: true },
+      });
+      expect(shouldLogSecurityEvent(true)).toBe(true);
+    });
+
+    it("should not log anything when audit is disabled", () => {
+      setSecurityConfig({
+        audit: { enabled: false, logDenied: true, logSuccess: true },
+      });
+      expect(shouldLogSecurityEvent(true)).toBe(false);
+      expect(shouldLogSecurityEvent(false)).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Session Access Helpers
+  // ==========================================================================
+  describe("sessionAllowsUntrusted", () => {
+    it("should return true for sessions with wildcard access", () => {
+      setSecurityConfig({
+        sessions: {
+          "open-session": { access: ["*"] },
+        },
+      });
+
+      expect(sessionAllowsUntrusted("open-session")).toBe(true);
+    });
+
+    it("should return true for sessions with trust:untrusted access", () => {
+      setSecurityConfig({
+        sessions: {
+          "public-session": { access: ["trust:untrusted"] },
+        },
+      });
+
+      expect(sessionAllowsUntrusted("public-session")).toBe(true);
+    });
+
+    it("should return false for sessions with only trusted access", () => {
+      setSecurityConfig({
+        sessions: {
+          "private-session": { access: ["trust:trusted"] },
+        },
+      });
+
+      expect(sessionAllowsUntrusted("private-session")).toBe(false);
+    });
+
+    it("should return false for sessions with default access", () => {
+      // Default access is trust:trusted
+      expect(sessionAllowsUntrusted("default-session")).toBe(false);
+    });
+  });
+
+  describe("isGatewaySession (deprecated)", () => {
+    it("should return true for sessions in legacy gateways config", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["discord-gw"],
+        },
+      });
+
+      expect(isGatewaySession("discord-gw")).toBe(true);
+    });
+
+    it("should return true for sessions allowing untrusted access (new pattern)", () => {
+      setSecurityConfig({
+        sessions: {
+          "public-gw": { access: ["trust:untrusted"] },
+        },
+      });
+
+      expect(isGatewaySession("public-gw")).toBe(true);
+    });
+
+    it("should return false for non-gateway sessions", () => {
+      expect(isGatewaySession("normal-session")).toBe(false);
+    });
+  });
+
+  describe("getGatewayRules (deprecated)", () => {
+    it("should return forward rules for configured gateways", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["my-gw"],
+          forwardRules: {
+            "my-gw": {
+              allowForwardTo: ["main", "backup"],
+              allowActions: ["inject"],
+              requireApproval: true,
+            },
+          },
+        },
+      });
+
+      const rules = getGatewayRules("my-gw");
+      expect(rules).toBeDefined();
+      expect(rules!.allowForwardTo).toEqual(["main", "backup"]);
+      expect(rules!.requireApproval).toBe(true);
+    });
+
+    it("should return undefined for sessions without forward rules", () => {
+      expect(getGatewayRules("no-rules")).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // Session Forwarding
+  // ==========================================================================
+  describe("canSessionForward", () => {
+    it("should deny when source session lacks cross.inject capability", () => {
+      setSecurityConfig({
+        sessions: {
+          "no-forward": { capabilities: ["inject"] },
+        },
+      });
+
+      const source = makeSource("api");
+      const result = canSessionForward("no-forward", "target", source);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("cross.inject");
+    });
+
+    it("should allow when source session has cross.inject and target is accessible", () => {
+      setSecurityConfig({
+        defaults: {
+          ...DEFAULT_SECURITY_CONFIG.defaults,
+          minTrustLevel: "untrusted",
+        },
+        sessions: {
+          "gateway-session": { capabilities: ["inject", "cross.inject"] },
+          "target-session": { access: ["trust:semi-trusted"] },
+        },
+      });
+
+      const source = makeSource("api"); // semi-trusted
+      const result = canSessionForward("gateway-session", "target-session", source);
+
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("canGatewayForward (deprecated)", () => {
+    it("should allow forwarding based on legacy gateway rules", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["legacy-gw"],
+          forwardRules: {
+            "legacy-gw": {
+              allowForwardTo: ["main-session"],
+              allowActions: ["inject"],
+            },
+          },
+        },
+      });
+
+      const result = canGatewayForward("legacy-gw", "main-session");
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should deny forwarding to non-allowed targets", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["legacy-gw"],
+          forwardRules: {
+            "legacy-gw": {
+              allowForwardTo: ["main-session"],
+            },
+          },
+        },
+      });
+
+      const result = canGatewayForward("legacy-gw", "secret-session");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("cannot forward");
+    });
+
+    it("should deny non-allowed actions", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["legacy-gw"],
+          forwardRules: {
+            "legacy-gw": {
+              allowForwardTo: ["main-session"],
+              allowActions: ["inject"],
+            },
+          },
+        },
+      });
+
+      const result = canGatewayForward("legacy-gw", "main-session", "exec_command");
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("not allowed");
+    });
+
+    it("should allow wildcard forward targets", () => {
+      setSecurityConfig({
+        gateways: {
+          sessions: ["wildcard-gw"],
+          forwardRules: {
+            "wildcard-gw": {
+              allowForwardTo: ["*"],
+            },
+          },
+        },
+      });
+
+      const result = canGatewayForward("wildcard-gw", "any-session");
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+  describe("Edge Cases", () => {
+    it("should handle missing trust level policy gracefully", () => {
+      setSecurityConfig({
+        trustLevels: {}, // No trust level policies defined
+      });
+
+      const source = makeSource("p2p");
+      const policy = resolvePolicy(source);
+
+      // Should fall back to defaults
+      expect(policy.trustLevel).toBe("untrusted");
+      expect(policy.capabilities).toBeDefined();
+    });
+
+    it("should handle conflicting allow and deny tool lists", () => {
+      setSecurityConfig({
+        enforcement: "enforce",
+        trustLevels: {
+          "semi-trusted": {
+            capabilities: ["inject", "inject.network"],
+            tools: {
+              deny: ["http_fetch"],
+              allow: ["http_fetch"], // Explicitly allowed overrides deny
+            },
+          },
+        },
+      });
+
+      const source = makeSource("api");
+      const result = checkToolAccess(source, "http_fetch");
+
+      expect(result.allowed).toBe(true);
+    });
+
+    it("should handle privilege escalation attempt (untrusted trying owner caps)", () => {
+      setSecurityConfig({ enforcement: "enforce" });
+
+      const source = makeSource("p2p"); // untrusted, only has "inject"
+      const configWrite = checkCapability(source, "config.write");
+      const crossInject = checkCapability(source, "cross.inject");
+      const sessionSpawn = checkCapability(source, "session.spawn");
+      const memoryWrite = checkCapability(source, "memory.write");
+
+      expect(configWrite.allowed).toBe(false);
+      expect(crossInject.allowed).toBe(false);
+      expect(sessionSpawn.allowed).toBe(false);
+      expect(memoryWrite.allowed).toBe(false);
+
+      // Note: inject.exec IS allowed because "inject" parent grants inject.*
+      // This is by design - the parent capability model means "inject" grants all inject sub-caps
+      const execCmd = checkCapability(source, "inject.exec");
+      expect(execCmd.allowed).toBe(true);
+    });
+
+    it("should prevent untrusted from spawning sessions", () => {
+      const source = makeSource("p2p");
+      const result = checkCapability(source, "session.spawn");
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("should handle multiple granted capabilities correctly", () => {
+      const source = makeSource("p2p", {
+        grantedCapabilities: ["memory.read", "session.history", "config.read"],
+      });
+
+      const policy = resolvePolicy(source);
+      expect(policy.capabilities).toContain("memory.read");
+      expect(policy.capabilities).toContain("session.history");
+      expect(policy.capabilities).toContain("config.read");
+      expect(policy.capabilities).toContain("inject"); // base
+      // Should NOT have escalated capabilities
+      expect(policy.capabilities).not.toContain("config.write");
+      expect(policy.capabilities).not.toContain("*");
+    });
+
+    it("should apply sandbox overrides from trust level policy", () => {
+      setSecurityConfig({
+        trustLevels: {
+          "semi-trusted": {
+            capabilities: ["inject"],
+            sandbox: {
+              enabled: true,
+              network: "none", // Override default "bridge"
+              memoryLimit: "128m",
+            },
+          },
+        },
+      });
+
+      const source = makeSource("api");
+      const policy = resolvePolicy(source);
+
+      expect(policy.sandbox.network).toBe("none");
+      expect(policy.sandbox.memoryLimit).toBe("128m");
+    });
+
+    it("should apply tool policy overrides from trust level", () => {
+      setSecurityConfig({
+        enforcement: "enforce",
+        trustLevels: {
+          trusted: {
+            capabilities: ["inject", "inject.tools", "config.read"],
+            tools: {
+              deny: ["exec_command"],
+              allow: ["config_get"],
+            },
+          },
+        },
+      });
+
+      const source = makeSource("plugin"); // trusted
+      const denied = checkToolAccess(source, "exec_command");
+      expect(denied.allowed).toBe(false);
+
+      // config_get requires config.read capability (included above) and is in allow list
+      const allowed = checkToolAccess(source, "config_get");
+      expect(allowed.allowed).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-84

- Add 75 unit tests for `src/security/policy.ts` covering policy resolution, session access checks, capability checking, tool access with allow/deny lists, sandbox requirements, gateway/forwarding logic, and edge cases
- Add 60 unit tests for `src/security/context.ts` covering SecurityContext class, factory functions, context isolation, event recording, context storage, and withSecurityContext cleanup
- 135 new tests total, all passing alongside existing 180 tests (315 total)

### Test Coverage Details

**policy.test.ts (75 tests):**
- Config loading (default, file-based, caching, invalid JSON)
- Policy resolution for all 4 trust levels
- Granted capability merging
- Session access with trust level enforcement, blocked/allowed lists, and access patterns
- Capability checks with parent capability inheritance
- Tool access with deny/allow lists, warn/enforce modes
- Sandbox requirement detection
- Tool filtering by policy
- Gateway detection and session forwarding (legacy + new APIs)
- Edge cases: missing policies, conflicting rules, privilege escalation attempts

**context.test.ts (60 tests):**
- SecurityContext initialization, unique request IDs, lazy policy resolution
- hasCapability with event recording
- canAccessSession with access/denied events
- canUseTool with warn mode handling
- filterTools in enforce mode
- Sandbox requirement checks
- Gateway/forward detection
- Derived context for forwarding
- Event recording and immutability
- toJSON serialization
- All factory functions (CLI, daemon, plugin, cron, P2P, P2P discovery, API)
- Context storage (store/get/clear/overwrite)
- withSecurityContext lifecycle and error cleanup
- Context isolation between sessions

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (315/315)
- [x] New tests all pass (135/135)

Generated with Claude Code