### PR TITLE
test: Add unit tests for workspace module (WOP-83)

### DIFF
--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -12,6 +12,7 @@
  * - Edge cases: missing files, empty content, concurrent sessions
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import os from "node:os";
 import path from "node:path";
 
 // ---------------------------------------------------------------------------
@@ -101,7 +102,6 @@ describe("resolveDefaultWorkspaceDir", () => {
 
   it("falls back to ~/.wopr/workspace when WOPR_HOME is not set", () => {
     vi.stubEnv("WOPR_HOME", "");
-    const os = require("node:os");
     const dir = workspace.resolveDefaultWorkspaceDir();
     expect(dir).toBe(path.join(os.homedir(), ".wopr", "workspace"));
   });


### PR DESCRIPTION
## Summary
- Adds 74 unit tests for `src/core/workspace.ts` which previously had zero test coverage
- Covers all 15+ exported functions: directory resolution, workspace initialization, bootstrap file loading, identity/profile parsing, ack reaction, message prefix, bootstrap context formatting, and the complete SOUL_EVIL system
- Tests use in-memory filesystem mocks following the project's existing test patterns (see `sessions.test.ts`)

## Test Coverage

| Area | Tests |
|------|-------|
| Directory resolution (`resolveDefaultWorkspaceDir`, `resolveWorkspaceDir`) | 6 |
| Workspace init (`ensureWorkspace`) | 5 |
| Bootstrap files (`loadBootstrapFiles`) | 5 |
| Identity parsing (`parseIdentity`) | 6 |
| User profile parsing (`parseUserProfile`) | 4 |
| Identity resolution (`resolveIdentity`) | 3 |
| User profile resolution (`resolveUserProfile`) | 3 |
| Ack reaction & message prefix | 7 |
| Bootstrap context formatting | 6 |
| SOUL_EVIL decision logic | 13 |
| SOUL_EVIL file override | 8 |
| Constants & isolation | 3 |
| **Total** | **74** |

## Test plan
- [x] All 74 tests pass locally (`npx vitest run tests/unit/workspace.test.ts`)
- [x] Tests follow project conventions (vi.mock for fs/logger/paths, in-memory filesystem)
- [x] Edge cases covered: missing files, empty content, whitespace-only, invalid formats, midnight wrapping

Closes WOP-83