### PR TITLE
Slim Docker image for multi-tenant (WOP-67)

### DIFF
--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,0 +1,46 @@
+# Slim multi-tenant service image for WOPR
+# - No Tailscale, no Docker-in-Docker, no privileged mode
+# - Only /data mounted for persistence
+# - Credentials via env vars, not file mounts
+#
+# For self-hosted power-user image, see Dockerfile
+
+# --- Build stage ---
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+RUN npm run build
+
+# --- Production stage ---
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install only git (needed at runtime for plugin operations)
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+# Create data directory owned by node
+RUN mkdir -p /data && chown -R node:node /data
+
+ENV WOPR_HOME=/data
+ENV NODE_ENV=production
+
+# Drop to non-root user
+USER node
+
+EXPOSE 7437
+
+CMD ["node", "dist/cli.js", "daemon", "run"]

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -1,0 +1,56 @@
+# Slim multi-tenant compose — no privileged mode, minimal mounts.
+# For self-hosted power-user setup, see docker-compose.yml
+networks:
+  wopr-net:
+    driver: bridge
+
+services:
+  wopr:
+    build:
+      context: .
+      dockerfile: Dockerfile.service
+    container_name: wopr
+    restart: unless-stopped
+    read_only: true
+    networks:
+      - wopr-net
+    tmpfs:
+      - /tmp
+    volumes:
+      - wopr-data:/data
+    environment:
+      - WOPR_HOME=/data
+      - WOPR_DAEMON_HOST=0.0.0.0
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OLLAMA_HOST=http://ollama:11434
+    ports:
+      - "7437:7437"
+    security_opt:
+      - no-new-privileges:true
+
+  ollama:
+    image: ollama/ollama
+    container_name: ollama
+    restart: unless-stopped
+    networks:
+      - wopr-net
+    volumes:
+      - ollama-data:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    ports:
+      - "11434:11434"
+    environment:
+      - OLLAMA_MODEL=qwen3-embedding:0.6b
+    entrypoint: /bin/sh -c "ollama serve & sleep 5 && ollama pull $$OLLAMA_MODEL && wait"
+
+volumes:
+  wopr-data:
+  ollama-data:


### PR DESCRIPTION
## Summary

Adds a minimal `Dockerfile.service` and `docker-compose.service.yml` for multi-tenant deployments, stripping out everything not needed for hosted service operation.

**Removed from service image (vs existing `Dockerfile`):**
- Tailscale daemon and entrypoint logic
- Docker-in-Docker (docker CLI, socket mount)
- `privileged: true`, `NET_ADMIN`, `SYS_ADMIN` capabilities
- Broad host mounts (`/usr`, `/etc`, `/var/lib`, `/var/cache`, `/opt`)
- sudo / passwordless sudoer config
- Claude credential file mounts (use env vars instead)

**Added security hardening:**
- Multi-stage build (build deps not in final image)
- `USER node` — runs as non-root
- `read_only: true` rootfs in compose
- `no-new-privileges` seccomp option
- Named volumes instead of host bind mounts
- Only `/data` mounted for persistence (skills, registries, sessions all resolve to `WOPR_HOME=/data`)
- `--omit=dev` for production dependencies only

**Existing `Dockerfile` + `docker-compose.yml` preserved** for self-hosted power users who need Tailscale, Docker socket, and privileged access.

Resolves WOP-67