### PR TITLE
feat: add rate limiting to daemon API (WOP-59)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hono/node-ws": "^1.3.0",
         "@openai/codex-sdk": "^0.91.0",
         "hono": "^4.11.9",
+        "hono-rate-limiter": "^0.5.3",
         "hyperswarm": "^4.16.0",
         "picocolors": "^1.1.1",
         "sqlite-vec": "0.1.7-alpha.2",
@@ -3242,6 +3243,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hono-rate-limiter": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/hono-rate-limiter/-/hono-rate-limiter-0.5.3.tgz",
+      "integrity": "sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": "^4.10.8",
+        "unstorage": "^1.17.3"
+      },
+      "peerDependenciesMeta": {
+        "unstorage": {
+          "optional": true
+        }
       }
     },
     "node_modules/hypercore-crypto": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@hono/node-ws": "^1.3.0",
     "@openai/codex-sdk": "^0.91.0",
     "hono": "^4.11.9",
+    "hono-rate-limiter": "^0.5.3",
     "hyperswarm": "^4.16.0",
     "picocolors": "^1.1.1",
     "sqlite-vec": "0.1.7-alpha.2",

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -22,6 +22,7 @@ import { LOG_FILE, PID_FILE } from "../paths.js";
 import { loadAllPlugins, registerPluginExtension, shutdownAllPlugins } from "../plugins.js";
 import { ensureToken } from "./auth-token.js";
 import { bearerAuth } from "./middleware/auth.js";
+import { rateLimit } from "./middleware/rate-limit.js";
 import { checkReadiness, markCronRunning, markStartupComplete } from "./readiness.js";
 import { authRouter } from "./routes/auth.js";
 import { configRouter } from "./routes/config.js";
@@ -62,6 +63,7 @@ export function createApp() {
   // Middleware
   app.use("*", cors());
   app.use("*", logger());
+  app.use("*", rateLimit());
   app.use("*", bearerAuth());
 
   // Health check (unauthenticated: /health)

--- a/src/daemon/middleware/rate-limit.ts
+++ b/src/daemon/middleware/rate-limit.ts
@@ -1,0 +1,50 @@
+/**
+ * Rate Limiting Middleware (WOP-59)
+ *
+ * Prevents API abuse by limiting requests per client.
+ * Uses hono-rate-limiter with sensible defaults (60 req/min).
+ * Returns 429 with Retry-After header when limit is exceeded.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { rateLimiter } from "hono-rate-limiter";
+
+/** Paths exempt from rate limiting (health/readiness probes). */
+const SKIP_PATHS = new Set(["/health", "/ready"]);
+
+export interface RateLimitConfig {
+  /** Time window in milliseconds. Default: 60_000 (1 minute). */
+  windowMs?: number;
+  /** Max requests per window per client. Default: 60. */
+  limit?: number;
+}
+
+/**
+ * Creates a rate limiting middleware for the Hono API.
+ *
+ * Identifies clients by Authorization header (since all non-health
+ * routes require bearer auth) with IP fallback.
+ */
+export function rateLimit(config: RateLimitConfig = {}): MiddlewareHandler {
+  const windowMs = config.windowMs ?? 60_000;
+  const limit = config.limit ?? 60;
+
+  return rateLimiter({
+    windowMs,
+    limit,
+    standardHeaders: "draft-6",
+    keyGenerator: (c) => c.req.header("authorization") ?? c.req.header("x-forwarded-for") ?? "anonymous",
+    skip: (c) => SKIP_PATHS.has(c.req.path),
+    handler: (c) => {
+      const retryAfterSeconds = Math.ceil(windowMs / 1000);
+      c.header("Retry-After", String(retryAfterSeconds));
+      return c.json(
+        {
+          error: "Too many requests",
+          retryAfter: retryAfterSeconds,
+        },
+        429,
+      );
+    },
+  });
+}

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Rate Limiting Middleware Tests (WOP-59)
+ *
+ * Verifies that the rate limiter:
+ * - Allows requests within the limit
+ * - Returns 429 with Retry-After when limit is exceeded
+ * - Skips health/readiness probes
+ * - Keys by Authorization header
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { rateLimit } from "../../src/daemon/middleware/rate-limit.js";
+
+function createTestApp(config?: { windowMs?: number; limit?: number }) {
+  const app = new Hono();
+  app.use("*", rateLimit(config));
+  app.get("/health", (c) => c.json({ status: "ok" }));
+  app.get("/ready", (c) => c.json({ ready: true }));
+  app.get("/api/test", (c) => c.json({ data: "hello" }));
+  app.post("/api/action", (c) => c.json({ done: true }));
+  return app;
+}
+
+describe("Rate Limiting Middleware", () => {
+  it("should allow requests within the limit", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 5 });
+
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/api/test", {
+        headers: { Authorization: "Bearer test-token" },
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("should return 429 when limit is exceeded", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 3 });
+
+    // Exhaust the limit
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request("/api/test", {
+        headers: { Authorization: "Bearer token-exceed" },
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // This request should be rate-limited
+    const res = await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-exceed" },
+    });
+    expect(res.status).toBe(429);
+  });
+
+  it("should include Retry-After header in 429 response", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 1 });
+
+    // Use up the limit
+    await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-retry" },
+    });
+
+    const res = await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-retry" },
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+  });
+
+  it("should return error body with retryAfter field on 429", async () => {
+    const app = createTestApp({ windowMs: 30_000, limit: 1 });
+
+    await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-body" },
+    });
+
+    const res = await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-body" },
+    });
+    expect(res.status).toBe(429);
+
+    const body = await res.json();
+    expect(body.error).toBe("Too many requests");
+    expect(body.retryAfter).toBe(30);
+  });
+
+  it("should skip rate limiting for /health", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 1 });
+
+    // First request uses the limit for this key
+    await app.request("/api/test");
+
+    // /health should still work even if limit is reached
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/health");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("should skip rate limiting for /ready", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 1 });
+
+    await app.request("/api/test");
+
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/ready");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("should track limits independently per client", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 2 });
+
+    // Client A uses 2 requests
+    for (let i = 0; i < 2; i++) {
+      const res = await app.request("/api/test", {
+        headers: { Authorization: "Bearer client-a" },
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // Client A is now rate-limited
+    const resA = await app.request("/api/test", {
+      headers: { Authorization: "Bearer client-a" },
+    });
+    expect(resA.status).toBe(429);
+
+    // Client B should still have their own limit
+    const resB = await app.request("/api/test", {
+      headers: { Authorization: "Bearer client-b" },
+    });
+    expect(resB.status).toBe(200);
+  });
+
+  it("should include rate limit headers in responses", async () => {
+    const app = createTestApp({ windowMs: 60_000, limit: 10 });
+
+    const res = await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-headers" },
+    });
+    expect(res.status).toBe(200);
+
+    // draft-6 headers
+    expect(res.headers.get("RateLimit-Limit")).toBe("10");
+    expect(res.headers.get("RateLimit-Remaining")).toBe("9");
+    expect(res.headers.get("RateLimit-Reset")).toBeTruthy();
+  });
+
+  it("should use default config (60 req/min) when no config provided", async () => {
+    const app = createTestApp();
+
+    // Should handle 60 requests without issue
+    const res = await app.request("/api/test", {
+      headers: { Authorization: "Bearer token-default" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("RateLimit-Limit")).toBe("60");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `hono-rate-limiter` middleware to the WOPR daemon Hono API with 60 req/min per-client default
- Returns HTTP 429 with `Retry-After` header and JSON error body when rate limit is exceeded
- Health (`/health`) and readiness (`/ready`) probes are exempt from rate limiting
- Clients are identified by `Authorization` header (with IP fallback)

## Test plan

- [x] 9 new tests in `tests/unit/rate-limit.test.ts` covering:
  - Requests within limit succeed (200)
  - Requests exceeding limit get 429
  - `Retry-After` header present in 429 responses
  - JSON error body contains `error` and `retryAfter` fields
  - `/health` and `/ready` are exempt
  - Per-client independent tracking
  - Standard rate limit headers (`RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`)
  - Default config (60 req/min)
- [x] Full test suite passes (566 tests, 14 files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

Resolves WOP-59