### PR TITLE
feat(auth): credential injection via env vars and encryption at rest (WOP-68)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,19 @@ set -e
 chown -R node:node /data
 chown -R node:node /home/node
 
-# Copy Claude credentials if mounted (as root, then chown to node)
+# Credential injection — env vars are the preferred method for platform
+# deployments and remove the need for file mounts entirely:
+#
+#   WOPR_CLAUDE_OAUTH_TOKEN   — Claude Max OAuth access token
+#   WOPR_CLAUDE_REFRESH_TOKEN — OAuth refresh token (optional)
+#   WOPR_API_KEY              — Anthropic API key
+#   WOPR_PLUGIN_CONFIG        — JSON blob of provider credentials
+#                                e.g. {"anthropic":"sk-...","openai":"sk-..."}
+#   WOPR_CREDENTIAL_KEY       — Passphrase to encrypt auth.json at rest
+#
+# When env vars are set, the file-mount path below is unnecessary.
+
+# Legacy file-mount path: copy Claude credentials if mounted
 if [ -f /claude-creds/.credentials.json ]; then
   mkdir -p /home/node/.claude
   install -D -o node -g node -m 600 /claude-creds/.credentials.json /home/node/.claude/.credentials.json

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -8,6 +8,7 @@ import {
   exchangeCode,
   generatePKCE,
   loadAuth,
+  loadAuthFromEnv,
   loadClaudeCodeCredentials,
   saveApiKey,
   saveOAuthTokens,
@@ -17,10 +18,22 @@ import { help } from "./help.js";
 
 export async function authCommand(subcommand: string | undefined, args: string[]): Promise<void> {
   if (!subcommand || subcommand === "status") {
+    const envAuth = loadAuthFromEnv();
     const claudeCodeAuth = loadClaudeCodeCredentials();
     const auth = loadAuth();
 
-    if (claudeCodeAuth) {
+    if (envAuth) {
+      if (envAuth.type === "oauth") {
+        logger.info("Auth: OAuth (environment variable)");
+        logger.info("Source: WOPR_CLAUDE_OAUTH_TOKEN");
+      } else {
+        logger.info("Auth: API Key (environment variable)");
+        logger.info("Source: WOPR_API_KEY");
+      }
+      if (process.env.WOPR_CREDENTIAL_KEY) {
+        logger.info("Encryption: auth.json encrypted at rest");
+      }
+    } else if (claudeCodeAuth) {
       logger.info("Auth: Claude Code OAuth (shared credentials)");
       logger.info("Source: ~/.claude/.credentials.json");
       if (claudeCodeAuth.expiresAt) {


### PR DESCRIPTION
## Summary

Resolves WOP-68 — Credential injection via environment.

Enables platform/container credential injection without file mounts by adding environment variable support to the auth module:

- **`WOPR_CLAUDE_OAUTH_TOKEN`** — inject Claude Max OAuth access token directly
- **`WOPR_CLAUDE_REFRESH_TOKEN`** — optional OAuth refresh token companion
- **`WOPR_CLAUDE_OAUTH_EXPIRES_AT`** — optional expiry timestamp
- **`WOPR_API_KEY`** — inject Anthropic API key directly
- **`WOPR_PLUGIN_CONFIG`** — JSON blob for all provider credentials (e.g. `{"anthropic":"sk-...","openai":"sk-..."}`)
- **`WOPR_CREDENTIAL_KEY`** — encrypt `auth.json` at rest using AES-256-GCM with scrypt key derivation

### Priority chain in `loadAuth()`

1. Environment variables (highest — platform deployments)
2. WOPR `auth.json` API key (supports encrypted files)
3. Claude Code OAuth (`~/.claude/.credentials.json`)
4. WOPR `auth.json` OAuth (lowest)

### Encryption at rest

When `WOPR_CREDENTIAL_KEY` is set, `saveAuth()` encrypts the JSON payload using AES-256-GCM before writing to disk. `loadAuth()` transparently decrypts when reading. The encrypted format uses a `wopr:enc:` prefix with random salt and IV, so credentials are never stored in plaintext inside the container.

### Backward compatibility

Existing file-based credential loading for self-hosted users is fully preserved. The env var path is additive — when no env vars are set, behavior is identical to before.

## Files changed

- `src/auth.ts` — env var loading, encryption/decryption helpers, updated `loadAuth()`/`saveAuth()`
- `src/commands/auth.ts` — `auth status` shows env var source and encryption state
- `docker-entrypoint.sh` — documents new env vars for container deployments
- `tests/unit/auth.test.ts` — 25 new tests covering env vars, encryption round-trip, and priority chain

## Test plan

- [x] All 56 auth tests pass (25 new + 31 existing)
- [x] Full test suite passes (582 tests across 13 files)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No new lint warnings introduced
- [ ] Manual verification: set `WOPR_CLAUDE_OAUTH_TOKEN` and confirm `wopr auth status` shows env source
- [ ] Manual verification: set `WOPR_CREDENTIAL_KEY`, save auth, confirm `auth.json` is encrypted