### PR TITLE
feat: add manifest support to core plugin loader

### DIFF
--- a/src/plugins/config-schemas.ts
+++ b/src/plugins/config-schemas.ts
@@ -1,5 +1,11 @@
 /**
  * Config schema accessors.
+ *
+ * Schemas are populated from two sources:
+ * 1. Manifest configSchema (populated during loadPlugin, before init)
+ * 2. Runtime registration via context.registerConfigSchema() (during init)
+ *
+ * Runtime registrations overwrite manifest-provided schemas for backward compat.
  */
 
 import type { ConfigSchema } from "../types.js";
@@ -14,4 +20,11 @@ export function listConfigSchemas(): { pluginId: string; schema: ConfigSchema }[
     pluginId,
     schema,
   }));
+}
+
+/**
+ * Check if a config schema exists for a plugin (from manifest or runtime registration).
+ */
+export function hasConfigSchema(pluginId: string): boolean {
+  return configSchemas.has(pluginId);
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -6,8 +6,18 @@
  * same public API as the original monolithic plugins.ts.
  */
 
-// --- State (public accessors only) ---
-export { channelAdapters, channelKey, configSchemas, contextProviders, uiComponents, webUiExtensions } from "./state.js";
+// --- Public accessors for runtime maps ---
+export {
+  getChannel,
+  getChannels,
+  getChannelsForSession,
+  getContextProvider,
+  getUiComponents,
+  getWebUiExtensions,
+} from "./accessors.js";
+
+// --- Config Schemas ---
+export { getConfigSchemas, hasConfigSchema, listConfigSchemas } from "./config-schemas.js";
 
 // --- Extensions ---
 export {
@@ -17,6 +27,7 @@ export {
   unregisterPluginExtension,
 } from "./extensions.js";
 
+export type { InstallResult } from "./installation.js";
 // --- Installation ---
 export {
   disablePlugin,
@@ -27,12 +38,21 @@ export {
   removePlugin,
   uninstallPlugin,
 } from "./installation.js";
-export type { InstallResult } from "./installation.js";
 
-// --- Loading ---
-export { getLoadedPlugin, loadAllPlugins, loadPlugin, shutdownAllPlugins, unloadPlugin } from "./loading.js";
 export type { LoadPluginOptions } from "./loading.js";
+// --- Loading ---
+export {
+  getAllPluginManifests,
+  getLoadedPlugin,
+  getPluginManifest,
+  loadAllPlugins,
+  loadPlugin,
+  readPluginManifest,
+  shutdownAllPlugins,
+  unloadPlugin,
+} from "./loading.js";
 
+export type { DiscoveredPlugin } from "./registry.js";
 // --- Registry & Discovery ---
 export {
   addRegistry,
@@ -42,11 +62,14 @@ export {
   removeRegistry,
   searchPlugins,
 } from "./registry.js";
-export type { DiscoveredPlugin } from "./registry.js";
 
-// --- Config Schemas ---
-export { getConfigSchemas, listConfigSchemas } from "./config-schemas.js";
-
-// --- Public accessors for runtime maps ---
-export { getChannel, getChannels, getChannelsForSession, getContextProvider } from "./accessors.js";
-export { getUiComponents, getWebUiExtensions } from "./accessors.js";
+// --- State (public accessors only) ---
+export {
+  channelAdapters,
+  channelKey,
+  configSchemas,
+  contextProviders,
+  pluginManifests,
+  uiComponents,
+  webUiExtensions,
+} from "./state.js";

--- a/src/plugins/state.ts
+++ b/src/plugins/state.ts
@@ -7,6 +7,7 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { PluginManifest } from "../plugin-types/manifest.js";
 import type { ModelProvider } from "../types/provider.js";
 import type {
   ChannelAdapter,
@@ -37,6 +38,9 @@ export const providerPlugins: Map<string, ModelProvider> = new Map();
 
 /** Config schemas registry (pluginId -> schema) */
 export const configSchemas: Map<string, ConfigSchema> = new Map();
+
+/** Plugin manifests registry (pluginName -> manifest) */
+export const pluginManifests: Map<string, PluginManifest> = new Map();
 
 /**
  * Plugin extensions registry - plugins can expose APIs to other plugins.


### PR DESCRIPTION
## Summary

Closes WOP-64.

- Reads static plugin manifests (from `package.json` `wopr` field or `wopr-plugin.json`) **before** calling `plugin.init()`, solving the chicken-and-egg problem where config schemas and requirements were only available after initialization
- Populates `configSchemas` map from manifest data pre-init, so the platform/webui can render settings UIs without loading the plugin
- Validates OS and Node.js version constraints from manifest before attempting load
- Adds `pluginManifests` registry map in state for platform-level manifest queries
- Extends `checkRequirements`/`ensureRequirements` to accept the manifest `PluginRequirements` type alongside legacy `VoicePluginRequirements`
- Fully backward compatible: plugins without manifests fall back to the legacy `pkg.wopr.plugin.requires` path

## Files Changed

- `src/plugins/loading.ts` — manifest reading before init, OS/Node validation, manifest accessor functions
- `src/plugins/state.ts` — new `pluginManifests` registry map
- `src/plugins/requirements.ts` — `checkOsRequirement`, `checkNodeRequirement`, widened type signatures
- `src/plugins/config-schemas.ts` — `hasConfigSchema` accessor, dual-source documentation
- `src/plugins/index.ts` — re-exports for new manifest APIs

## Test plan

- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Load a plugin WITH a manifest in `package.json` `wopr` field — manifest should be read, config schema populated before init
- [ ] Load a plugin WITH a `wopr-plugin.json` file — should be picked up as fallback
- [ ] Load a plugin WITHOUT any manifest — should fall back to legacy `pkg.wopr.plugin.requires` path
- [ ] Plugin with `os` constraint not matching current platform — should throw descriptive error
- [ ] Plugin with `node` constraint not satisfied — should throw descriptive error
- [ ] `getPluginManifest(name)` and `getAllPluginManifests()` return correct data after load
- [ ] `unloadPlugin` cleans up manifest and config schema entries