### PR TITLE
chore: track creation time and lastChecked in core registries (WOP-89)

### DIFF
--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -132,11 +132,12 @@ export class ProviderRegistry {
   /**
    * List all registered providers
    */
-  listProviders(): Array<{ id: string; name: string; available: boolean }> {
+  listProviders(): Array<{ id: string; name: string; available: boolean; lastChecked: number }> {
     return Array.from(this.providers.values()).map((reg) => ({
       id: reg.provider.id,
       name: reg.provider.name,
       available: reg.available,
+      lastChecked: reg.lastChecked,
     }));
   }
 

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -155,6 +155,6 @@ export function getProviderStatus(): Array<{
     id: p.id,
     name: p.name,
     available: p.available,
-    lastChecked: Date.now(),
+    lastChecked: p.lastChecked,
   }));
 }

--- a/tests/unit/query.test.ts
+++ b/tests/unit/query.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Query Module Tests (WOP-89)
+ *
+ * Tests for src/core/query.ts covering:
+ * - getProviderStatus: returns lastChecked from registry (not Date.now())
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock logger
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock config
+vi.mock("../../src/core/config.js", () => ({
+  config: {
+    getProviderDefaults: vi.fn(() => undefined),
+  },
+}));
+
+// Mock providers module
+const mockListProviders = vi.fn();
+vi.mock("../../src/core/providers.js", () => ({
+  providerRegistry: {
+    listProviders: mockListProviders,
+    resolveProvider: vi.fn(),
+  },
+}));
+
+let query: typeof import("../../src/core/query.js");
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockListProviders.mockReset();
+  query = await import("../../src/core/query.js");
+});
+
+describe("getProviderStatus", () => {
+  it("should return lastChecked from the provider registry", () => {
+    const checkedAt = 1700000000000;
+    mockListProviders.mockReturnValue([
+      { id: "anthropic", name: "Anthropic", available: true, lastChecked: checkedAt },
+    ]);
+
+    const result = query.getProviderStatus();
+    expect(result).toHaveLength(1);
+    expect(result[0].lastChecked).toBe(checkedAt);
+    expect(result[0].id).toBe("anthropic");
+    expect(result[0].available).toBe(true);
+  });
+
+  it("should return 0 for providers that have never been checked", () => {
+    mockListProviders.mockReturnValue([
+      { id: "openai", name: "OpenAI", available: false, lastChecked: 0 },
+    ]);
+
+    const result = query.getProviderStatus();
+    expect(result[0].lastChecked).toBe(0);
+  });
+
+  it("should return multiple providers with their individual lastChecked", () => {
+    mockListProviders.mockReturnValue([
+      { id: "anthropic", name: "Anthropic", available: true, lastChecked: 1700000000000 },
+      { id: "openai", name: "OpenAI", available: false, lastChecked: 1700000001000 },
+    ]);
+
+    const result = query.getProviderStatus();
+    expect(result).toHaveLength(2);
+    expect(result[0].lastChecked).toBe(1700000000000);
+    expect(result[1].lastChecked).toBe(1700000001000);
+  });
+
+  it("should return empty array when no providers are registered", () => {
+    mockListProviders.mockReturnValue([]);
+
+    const result = query.getProviderStatus();
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves WOP-89: Three TODO items in core had hardcoded placeholder values instead of actual timestamps.

**Changes:**

- **Session creation time** (`src/core/sessions.ts`): `listSessions()` was returning `Date.now()` (listing time) instead of the actual session creation time. Now persists a `.created` file per session when first created via `saveSessionId()`, and reads it back in `listSessions()` and new `getSessionCreated()` helper. Session deletion cleans up the `.created` file.

- **Provider lastChecked** (`src/core/query.ts` + `src/core/providers.ts`): `getProviderStatus()` was returning `Date.now()` instead of the actual last health-check timestamp. Now `listProviders()` exposes the `lastChecked` field from `ProviderRegistration`, and `getProviderStatus()` uses it.

- **lastRunVersion** (`src/commands/onboard/helpers.ts`): Already reads from `package.json` via `pkgVersion` — no changes needed.

## Test plan

- [x] Added `getSessionCreated` tests (return 0 for missing file, return persisted timestamp, return 0 for invalid content)
- [x] Added `saveSessionId` tests for creation timestamp persistence (new sessions get timestamp, existing sessions don't overwrite)
- [x] Updated `listSessions` tests to verify persisted timestamps
- [x] Updated `deleteSession` test to verify `.created` file cleanup
- [x] Added `tests/unit/query.test.ts` with `getProviderStatus` tests (uses registry lastChecked, handles 0 for unchecked, multiple providers)
- [x] Full test suite passes: 567 tests across 14 files
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider information now includes last checked timestamp
  * Session creation time is persisted and accurately recalled across sessions

* **Bug Fixes**
  * Provider and session timestamps now reflect actual check/creation times rather than current time

* **Tests**
  * Added unit test coverage for provider status tracking and session timestamp persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->