### PR TITLE
feat: wire SoulEvil config to app config in core context (WOP-106)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -6,6 +6,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { logger } from "../logger.js";
 import { CONFIG_FILE, WOPR_HOME } from "../paths.js";
+import type { SoulEvilConfig } from "./workspace.js";
 /**
  * Per-provider default settings
  */
@@ -60,6 +61,8 @@ export interface WoprConfig {
   providers?: Record<string, ProviderDefaults>;
   /** Memory system configuration (chunking, sync, etc.) */
   memory?: Partial<import("../memory/types.js").MemoryConfig>;
+  /** SOUL_EVIL personality override configuration */
+  soulEvil?: SoulEvilConfig;
   /**
    * Sandbox configuration for Docker-based isolation
    */

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -22,8 +22,9 @@ import { join } from "node:path";
 import { SESSIONS_DIR } from "../paths.js";
 import { getChannel } from "../plugins.js";
 import type { ChannelRef } from "../types.js";
+import { config } from "./config.js";
 import { discoverSkills, formatSkillsXml } from "./skills.js";
-import { applySoulEvilOverride, formatBootstrapContext, loadBootstrapFiles, type SoulEvilConfig } from "./workspace.js";
+import { applySoulEvilOverride, formatBootstrapContext, loadBootstrapFiles } from "./workspace.js";
 
 // ============================================================================
 // Types
@@ -169,8 +170,7 @@ const bootstrapFilesProvider: ContextProvider = {
       let files = await loadBootstrapFiles();
 
       // Apply SOUL_EVIL override if configured
-      // TODO: Get SoulEvilConfig from app config when available
-      const soulEvilConfig: SoulEvilConfig | undefined = undefined;
+      const soulEvilConfig = config.get().soulEvil;
       files = await applySoulEvilOverride(files, undefined, soulEvilConfig);
 
       // Filter out missing and empty files


### PR DESCRIPTION
## Summary
Closes WOP-106

- Added optional `soulEvil` field (type `SoulEvilConfig`) to `WoprConfig` interface in `src/core/config.ts`
- Wired the `bootstrapFilesProvider` in `src/core/context.ts` to read `soulEvil` from the config singleton instead of hardcoding `undefined`
- Removed the TODO comment at the call site

## Test plan
- [x] `npx tsc --noEmit` passes (no type errors)
- [x] `npm test` passes (718/718 tests, 20 test files)
- [x] Existing workspace/SoulEvil tests still pass (74 tests in workspace.test.ts)

Generated with Claude Code