### PR TITLE
docs: evaluate MCP Apps pattern for WebUI extensibility (WOP-58)

### DIFF
--- a/docs/design/mcp-apps-evaluation.md
+++ b/docs/design/mcp-apps-evaluation.md
@@ -101,7 +101,7 @@ interface UiComponentExtension {
 }
 ```
 
-These are served via the daemon's HTTP API at `GET /api/plugins/ui` and `GET /api/plugins/components`.
+These are served via the daemon's HTTP API at `GET /plugins/ui` and `GET /plugins/components`.
 
 ### 2.3 MCP Feasibility Study (WOP-95)
 
@@ -349,6 +349,6 @@ Total incremental effort beyond WOP-95: **4-5 weeks, low risk.**
 - [MCP Apps Documentation](https://modelcontextprotocol.io/docs/extensions/apps)
 - [MCP Apps GitHub (ext-apps)](https://github.com/modelcontextprotocol/ext-apps)
 - [MCP Apps Specification (2026-01-26)](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx)
-- [MCP Apps Launch Blog Post](http://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/)
+- [MCP Apps Launch Blog Post](https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/)
 - [MCP Apps SDK API Docs](https://modelcontextprotocol.github.io/ext-apps/api/)
 - [WOPR MCP Feasibility Study (WOP-95)](../MCP_FEASIBILITY.md)


### PR DESCRIPTION
## Summary
Closes WOP-58

- Evaluates MCP Apps (the first official MCP extension, launched Jan 26, 2026) for WOPR WebUI extensibility
- Analyzes how WOPR's existing MCP surface (A2A server, plugin context UI types) maps to MCP Apps primitives
- Recommends integrating MCP Apps as Phase 2 of the WOP-95 MCP Bridge implementation
- Identifies 5 candidate App surfaces: Dashboard, Memory Explorer, Config Editor, Plugin Browser, Chat Interface
- Estimates 4-5 weeks incremental effort on top of WOP-95, low risk

## Design Doc Contents
1. MCP Apps overview (ui:// scheme, bidirectional comms, SDK, security model, client support)
2. WOPR's existing MCP surface and capability mapping
3. Integration points with the WebUI plugin (5 candidate apps, architecture diagram, reuse strategy)
4. Recommended approach: Integrate into the planned MCP bridge, not build from scratch or defer
5. Phased implementation plan with effort estimates and risk assessment

## Test plan
- [ ] Design doc renders correctly in GitHub markdown
- [ ] Cross-references to WOP-95, WOP-63, WOP-230 are accurate
- [ ] Technical details match current WOPR architecture (verified against source)

Generated with Claude Code