### PR TITLE
devops: add Docker build and push workflow (WOP-187)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,64 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }}
+    runs-on: [self-hosted, Linux, X64]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: wopr
+            dockerfile: Dockerfile
+          - image: wopr-slim
+            dockerfile: Dockerfile.service
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/wopr-network/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
Closes WOP-187

- Add `.github/workflows/docker.yml` that builds both `wopr` (fat) and `wopr-slim` (service) Docker images
- Push to `ghcr.io/wopr-network/wopr` and `ghcr.io/wopr-network/wopr-slim`
- Tags: `latest` on main, `vX.Y.Z` + `vX.Y` on version tags, `sha-<short>` on every push
- PR builds are build-only (no push) to validate Dockerfiles
- Uses `docker/build-push-action@v6` with buildx and GHA cache
- Login via `docker/login-action@v3` with `GITHUB_TOKEN`
- Matrix strategy builds both variants in parallel with `fail-fast: false`

## Test plan
- [ ] PR triggers build-only (no push) for both images
- [ ] Push to main triggers build + push with `:latest` and `:sha-<short>` tags
- [ ] Version tag push triggers build + push with semver tags

Generated with Claude Code