### PR TITLE
devops: multi-arch Docker builds (amd64 + arm64) (WOP-189)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,10 +31,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
@@ -55,14 +56,18 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-,format=short
 
-      - name: Build image
+      # Pass 1: single-platform build for Trivy scanning
+      - name: Build image for scanning
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Get short SHA
         id: short-sha
         run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
@@ -85,10 +90,15 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
 
-      - name: Push image
+      # Pass 2: multi-arch build + push (only on main/tags, reuses GHA cache)
+      - name: Build and push multi-arch
         if: github.event_name != 'pull_request'
-        run: |
-          set -euo pipefail
-          echo '${{ steps.meta.outputs.tags }}' | while IFS= read -r tag; do
-            [ -n "$tag" ] && docker push "$tag"
-          done
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha


### PR DESCRIPTION
## Summary
Closes WOP-189

- Added `docker/setup-qemu-action@v3` for cross-platform emulation (arm64 on amd64 runners)
- Added `platforms: linux/amd64,linux/arm64` to `docker/build-push-action@v6`
- Both `Dockerfile` and `Dockerfile.service` are already architecture-compatible:
  - `Dockerfile` uses `dpkg --print-architecture` for Docker repo setup (resolves dynamically per platform)
  - `Dockerfile.service` uses `node:22-slim` which has native multi-arch manifests
  - All bundled plugins are pure JS/TS with no native binary dependencies

## Test plan
- [ ] CI builds both matrix images (`wopr` and `wopr-slim`) successfully
- [ ] After merge, `docker manifest inspect ghcr.io/wopr-network/wopr:latest` shows both `amd64` and `arm64` entries
- [ ] `docker pull ghcr.io/wopr-network/wopr:latest` works on arm64 (M-series Mac / Raspberry Pi)
- [ ] `docker pull ghcr.io/wopr-network/wopr-slim:latest` works on arm64

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI adds QEMU setup to enable cross-platform builds.
  * Pipeline extended to produce and publish multi-architecture container images (linux/amd64, linux/arm64) and removes the prior manual push loop.
  * Build step now includes caching and image scanning integration for faster, more secure builds.
  * No changes to application functionality or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->