### PR TITLE
security: remove env from exec_command allowlist (WOP-235)

### DIFF
--- a/src/core/a2a-tools/http-exec.ts
+++ b/src/core/a2a-tools/http-exec.ts
@@ -125,7 +125,6 @@ export function createHttpExecTools(sessionName: string): any[] {
             "sort",
             "uniq",
             "diff",
-            "env",
             "which",
             "file",
             "stat",


### PR DESCRIPTION
## Summary
Closes WOP-235

- Remove `env` from the `exec_command` allowed commands list for non-sandboxed sessions
- `env` dumps the full process environment including `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `SLACK_BOT_TOKEN`, and any other secrets
- Attack chain: AI session calls `exec_command("env")`, captures secrets, exfiltrates via `http_fetch`
- One-line fix that eliminates the information disclosure vector

## Test plan
- [x] `npx tsc --noEmit` passes (no type errors)
- [x] `npm test` passes (783 tests, 0 failures)
- [x] Verified `env` is no longer in the allowed commands array
- [x] All other allowed commands remain unchanged

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the "env" command from the allowed operations in HTTP execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->