### PR TITLE
refactor: Remove dead vector search code from core memory (WOP-249)

### DIFF
--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -236,27 +236,6 @@ export function chunkMarkdown(content: string, chunking: { tokens: number; overl
   return chunks;
 }
 
-export function cosineSimilarity(a: number[], b: number[]): number {
-  if (a.length === 0 || b.length === 0) {
-    return 0;
-  }
-  const len = Math.min(a.length, b.length);
-  let dot = 0;
-  let normA = 0;
-  let normB = 0;
-  for (let i = 0; i < len; i += 1) {
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
-    dot += av * bv;
-    normA += av * av;
-    normB += bv * bv;
-  }
-  if (normA === 0 || normB === 0) {
-    return 0;
-  }
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}
-
 // UTF-16 safe string utilities (inlined from utils.ts)
 function isHighSurrogate(codeUnit: number): boolean {
   return codeUnit >= 0xd800 && codeUnit <= 0xdbff;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -337,7 +337,6 @@ export class MemoryIndexManager {
     await syncSessionFiles({
       db: this.db,
       needsFullReindex,
-      vectorTable: "",
       ftsTable: FTS_TABLE,
       ftsEnabled: this.fts.enabled,
       ftsAvailable: this.fts.available,

--- a/src/memory/sync-sessions.ts
+++ b/src/memory/sync-sessions.ts
@@ -7,7 +7,6 @@ import { buildSessionEntry, listSessionFiles, type SessionFileEntry, sessionPath
 export async function syncSessionFiles(params: {
   db: DatabaseSync;
   needsFullReindex: boolean;
-  vectorTable: string;
   ftsTable: string;
   ftsEnabled: boolean;
   ftsAvailable: boolean;
@@ -49,17 +48,6 @@ export async function syncSessionFiles(params: {
       continue;
     }
     params.db.prepare(`DELETE FROM files WHERE path = ? AND source = ?`).run(stale.path, "sessions");
-    if (params.vectorTable) {
-      try {
-        params.db
-          .prepare(
-            `DELETE FROM ${params.vectorTable} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
-          )
-          .run(stale.path, "sessions");
-      } catch (err) {
-        logger.warn(`[sync-sessions] Vector table delete failed for ${stale.path}: ${err}`);
-      }
-    }
     params.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stale.path, "sessions");
     if (params.ftsEnabled && params.ftsAvailable) {
       try {

--- a/tests/unit/memory.test.ts
+++ b/tests/unit/memory.test.ts
@@ -2,7 +2,7 @@
  * Memory Module Tests (WOP-12)
  *
  * Tests FTS query building, BM25 score normalization, temporal filtering,
- * markdown chunking, hashing, and cosine similarity.
+ * markdown chunking, and hashing.
  *
  * The MemoryIndexManager requires node:sqlite which is Node 22+ only,
  * so we test the pure utility functions and the exported helpers from
@@ -21,7 +21,7 @@ vi.mock("../../src/logger.js", () => ({
 }));
 
 // Import the pure utility functions from the internal module
-const { hashText, chunkMarkdown, cosineSimilarity, normalizeRelPath, isMemoryPath, normalizeExtraMemoryPaths } =
+const { hashText, chunkMarkdown, normalizeRelPath, isMemoryPath, normalizeExtraMemoryPaths } =
   await import("../../src/memory/internal.js");
 
 // Import buildFtsQuery and bm25RankToScore from the manager module
@@ -231,37 +231,6 @@ describe("Memory Module - Pure Utility Functions", () => {
     it("should produce chunks with text property", () => {
       const chunks = chunkMarkdown("Hello\nWorld", { tokens: 100, overlap: 0 });
       expect(chunks[0].text).toContain("Hello");
-    });
-  });
-
-  // ========================================================================
-  // Cosine Similarity
-  // ========================================================================
-  describe("cosineSimilarity", () => {
-    it("should return 1 for identical vectors", () => {
-      expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 5);
-    });
-
-    it("should return 0 for orthogonal vectors", () => {
-      expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0, 5);
-    });
-
-    it("should return -1 for opposite vectors", () => {
-      expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1, 5);
-    });
-
-    it("should return 0 for empty vectors", () => {
-      expect(cosineSimilarity([], [])).toBe(0);
-    });
-
-    it("should handle zero vectors", () => {
-      expect(cosineSimilarity([0, 0], [1, 1])).toBe(0);
-    });
-
-    it("should handle vectors of different lengths (uses min length)", () => {
-      const result = cosineSimilarity([1, 2, 3], [1, 2]);
-      expect(result).toBeDefined();
-      expect(typeof result).toBe("number");
     });
   });
 


### PR DESCRIPTION
## Summary
Closes WOP-249

- Deleted `cosineSimilarity()` from `src/memory/internal.ts` -- exported but never imported or called anywhere in the codebase; pure dead code from when vector search was planned in core
- Removed `vectorTable` parameter from `src/memory/sync-sessions.ts` params and the conditional delete block that used it -- `manager.ts` always passed `""` so this code never executed
- Removed `vectorTable: ""` from the call site in `src/memory/manager.ts`
- Removed corresponding `cosineSimilarity` tests from `tests/unit/memory.test.ts`

Plugin/core boundary: vector/semantic search belongs exclusively in `wopr-plugin-memory-semantic`. Core does FTS5 keyword search only.

## Test plan
- [x] `npm run build` passes (tsc clean)
- [x] `npm test` passes (777 tests, 23 files, 0 failures)
- [x] `grep -r cosineSimilarity src/` returns zero results
- [x] `grep -r vectorTable src/` returns zero results

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up deprecated internal utility functions from the memory module to improve overall code maintainability and reduce unnecessary system dependencies across the entire codebase.
  * Simplified memory indexing and session synchronization operations by removing unused vector table parameters and associated cleanup routines from the backend, streamlining the session file synchronization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->