### PR TITLE
fix: bind daemon to 0.0.0.0 in Docker images (WOP-289, WOP-288)

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -55,10 +55,12 @@ jobs:
 
           # Wait up to 60s for the health endpoint to respond
           HEALTHY=false
+          echo "Polling http://localhost:${HOST_PORT}/health ..."
           for i in $(seq 1 30); do
             # Check container is still running
             if ! docker ps --filter "name=$CONTAINER_NAME" --format '{{.Status}}' | grep -q "Up"; then
-              echo "Container crashed"
+              echo "Container exited unexpectedly"
+              docker logs "$CONTAINER_NAME" 2>&1 | tail -40
               break
             fi
             if curl -sf --max-time 5 --connect-timeout 3 "http://localhost:${HOST_PORT}/health" > /dev/null 2>&1; then
@@ -67,6 +69,13 @@ jobs:
             fi
             sleep 2
           done
+
+          # Dump container logs on failure before cleanup
+          if [ "$HEALTHY" != "true" ]; then
+            echo "--- container logs (last 60 lines) ---"
+            docker logs "$CONTAINER_NAME" 2>&1 | tail -60
+            echo "--- end container logs ---"
+          fi
 
           # Cleanup
           docker rm -f "$CONTAINER_NAME" > /dev/null 2>&1 || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN mkdir -p /data && chown -R node:node /data
 RUN mkdir -p /home/node/.claude && chown -R node:node /home/node/.claude
 
 ENV WOPR_HOME=/data
+ENV WOPR_DAEMON_HOST=0.0.0.0
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -42,6 +42,7 @@ COPY --from=build /app/dist ./dist
 RUN mkdir -p /data && chown -R node:node /data
 
 ENV WOPR_HOME=/data
+ENV WOPR_DAEMON_HOST=0.0.0.0
 ENV NODE_ENV=production
 
 # Drop to non-root user


### PR DESCRIPTION
## Summary
Closes WOP-289
Closes WOP-288

The nightly stable promotion smoke test failed for both `wopr:latest` and `wopr-slim:latest` because the daemon was binding to `127.0.0.1` inside the container.

**Root cause:** The promotion workflow uses `docker run` directly, not docker-compose. Both compose files set `WOPR_DAEMON_HOST=0.0.0.0`, but the Dockerfiles did not — so when run without compose, the daemon defaulted to `127.0.0.1` (the container's loopback), making it unreachable from the host's health check curl.

- Add `ENV WOPR_DAEMON_HOST=0.0.0.0` to `Dockerfile` and `Dockerfile.service`
- Improve smoke test to dump container logs on failure for easier future diagnosis

## Test plan
- [ ] `docker build -t wopr-test .` succeeds
- [ ] `docker run -d -p 127.0.0.1:0:7437 wopr-test` + health check curl passes
- [ ] `docker build -t wopr-slim-test -f Dockerfile.service .` succeeds
- [ ] `docker run -d -p 127.0.0.1:0:7437 wopr-slim-test` + health check curl passes
- [ ] Re-run Promote Stable workflow via workflow_dispatch

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced container health-check monitoring with clearer error messages and contextual logging for improved debugging visibility
  - Added comprehensive log output when health checks fail to facilitate faster issue resolution

* **Configuration**
  - WOPR daemon now accessible on all available network interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->