### PR TITLE
feat: add hosted provider types and meter events (WOP-298)

### DIFF
--- a/src/plugin-types/events.ts
+++ b/src/plugin-types/events.ts
@@ -117,6 +117,20 @@ export interface MemorySearchEvent {
   results: unknown[] | null;
 }
 
+// Meter events (for hosted provider usage tracking)
+export interface MeterEvent {
+  /** User or organization ID */
+  tenant: string;
+  /** What capability was used (e.g., "voice-transcription", "embeddings") */
+  capability: string;
+  /** Which adapter handled the call (e.g., "replicate", "modal") */
+  provider: string;
+  /** Upstream cost in USD cents */
+  cost: number;
+  /** When the usage occurred (epoch ms) */
+  timestamp: number;
+}
+
 /**
  * Event map — all core events and their payloads.
  */
@@ -135,6 +149,7 @@ export interface WOPREventMap {
   "system:shutdown": SystemShutdownEvent;
   "memory:search": MemorySearchEvent;
   "memory:filesChanged": MemoryFilesChangedEvent;
+  "meter:usage": MeterEvent;
   "*": WOPREvent;
 }
 

--- a/src/plugin-types/index.ts
+++ b/src/plugin-types/index.ts
@@ -54,6 +54,7 @@ export type {
   MemoryFileChange,
   MemoryFilesChangedEvent,
   MemorySearchEvent,
+  MeterEvent,
   MessageIncomingHandler,
   MessageOutgoingHandler,
   MutableHookEvent,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type {
   TrustLevel,
 } from "./security/types.js";
 // Re-export provider types for plugins
-export type { ModelProvider } from "./types/provider.js";
+export type { ModelProvider, ProviderResponse, ProviderSource } from "./types/provider.js";
 
 // Import InjectionSource for use within this file
 import type { InjectionSource as _InjectionSource } from "./security/types.js";
@@ -579,6 +579,20 @@ export interface MemorySearchEvent {
   results: unknown[] | null;
 }
 
+// Meter events (for hosted provider usage tracking)
+export interface MeterEvent {
+  /** User or organization ID */
+  tenant: string;
+  /** What capability was used (e.g., "voice-transcription", "embeddings") */
+  capability: string;
+  /** Which adapter handled the call (e.g., "replicate", "modal") */
+  provider: string;
+  /** Upstream cost in USD cents */
+  cost: number;
+  /** When the usage occurred (epoch ms) */
+  timestamp: number;
+}
+
 /**
  * Event map - all core events and their payloads
  */
@@ -597,6 +611,7 @@ export interface WOPREventMap {
   "system:shutdown": SystemShutdownEvent;
   "memory:search": MemorySearchEvent;
   "memory:filesChanged": MemoryFilesChangedEvent;
+  "meter:usage": MeterEvent;
   "*": WOPREvent;
 }
 

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -7,6 +7,13 @@
  */
 
 /**
+ * Provider source type.
+ * - "byok": User brings their own API key (cost is 0, user pays provider directly)
+ * - "hosted": WOPR-hosted provider that returns cost information for metering
+ */
+export type ProviderSource = "byok" | "hosted";
+
+/**
  * Provider configuration for a session
  * Specifies which provider to use and fallback chain
  */
@@ -22,6 +29,22 @@ export interface ProviderConfig {
 
   /** Provider-specific options (e.g., temperature, top_p) */
   options?: Record<string, unknown>;
+
+  /** Provider source: "byok" (default) or "hosted" */
+  source?: ProviderSource;
+}
+
+/**
+ * Response from a hosted provider call.
+ * Hosted providers return cost alongside the result so the platform
+ * can apply a margin and meter usage. BYOK providers just return
+ * the result directly (cost is 0 — user pays their provider).
+ */
+export interface ProviderResponse<T = unknown> {
+  /** The actual response from the provider */
+  result: T;
+  /** Upstream cost in USD cents — only set by hosted providers */
+  cost?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
Closes WOP-298

- Adds `ProviderSource` type (`"byok" | "hosted"`) and `source` field to `ProviderConfig` so provider routing can distinguish between user-supplied keys and WOPR-hosted services
- Adds `ProviderResponse<T>` interface with optional `cost` field for hosted providers to report upstream costs
- Adds `MeterEvent` interface and `"meter:usage"` event to all three event map definitions (core, plugin-types, types) so the platform can subscribe and apply margins
- Adds `emitMeterUsage()` convenience helper alongside the other emit helpers in `src/core/events.ts`
- Exports new types from barrel files (`src/types.ts`, `src/plugin-types/index.ts`)

Core only -- no adapters, no billing logic, no Stripe. Platform will consume `meter:usage` events downstream.

## Test plan
- [x] `npm run build` passes (pre-existing dockerode errors only)
- [x] `npx vitest run` passes (46 test files, 1308 tests)
- [ ] Manual: verify new types are importable from `@wopr-network/wopr`

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage metrics tracking for hosted providers, capturing provider usage, cost, and timestamp data
  * Introduced provider source categorization to distinguish between bring-your-own-key and hosted providers
  * Enabled cost tracking capabilities for hosted provider responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->