### PR TITLE
docs: add brand voice + pre-launch Twitter plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,3 +590,9 @@ Contributions welcome! See [docs/PLUGINS.md](docs/PLUGINS.md) for plugin develop
 ## License
 
 MIT
+
+## Official Channels
+
+- Twitter/X: (TBD)
+- Discord: (TBD)
+

--- a/docs/BRAND_VOICE.md
+++ b/docs/BRAND_VOICE.md
@@ -1,0 +1,54 @@
+# Brand Voice (WOPR)
+
+Goal: sound like a *person with taste*, not a corporate product page.
+
+## Core rules
+- Write like a human. Short sentences.
+- No "We're excited to announce...".
+- No hashtags. No emojis.
+- Avoid "comprehensive", "platform", "solution".
+- Prefer punchy one-liners over paragraphs.
+- If a line works as a screenshot, it's good.
+
+## Vocabulary
+Use:
+- "WOPR Bot" (a thing you own)
+- "ship", "build", "deploy", "run"
+- "$5" as the punchline (not in every sentence)
+
+Avoid:
+- "AI-powered", "leveraging", "synergy", "enterprise-grade"
+- "end-to-end", "best-in-class"
+
+## Tone
+- Confident, a little ruthless.
+- More "this changes your life" than "this has features".
+- Mystery beats explanation early on.
+
+## Twitter/X style
+- One idea per tweet.
+- 5–12 words is often enough.
+- No threads that start with "1/".
+- Don’t over-explain in replies.
+
+### Examples (good)
+- "3 weeks."
+- "2 weeks. wopr.bot"
+- "1 week. $5. No joke."
+- "Your WOPR Bot doesn’t sleep. Invoice: $5."
+- "OpenClaw helps you build a chatbot. Your WOPR Bot builds you a company."
+
+### Examples (bad)
+- "We're excited to announce the launch of our AI-powered automation platform..."
+- "#AI #automation #startup"
+
+## GitHub voice
+- README: practical, minimal, no marketing fluff.
+- Issues: direct, actionable, clear "done" criteria.
+- PRs: explain *why* in 1–3 bullets.
+
+## Discord voice
+- Light moderation.
+- Encourage showcasing builds.
+- Let users flex.
+

--- a/docs/LAUNCH_TWITTER_PLAN.md
+++ b/docs/LAUNCH_TWITTER_PLAN.md
@@ -1,0 +1,37 @@
+# Pre-launch Twitter/X plan (3-week teaser)
+
+**Rule:** The mystery is the marketing. Don’t explain early.
+
+## Week 3 (~3 weeks out)
+Post 1 tweet:
+- "3 weeks."
+
+Notes:
+- Black image, green monospace text.
+- Don’t reply to "what is this?".
+
+## Week 2 (~2 weeks out)
+Post 1 tweet:
+- "2 weeks. wopr.bot"
+
+Notes:
+- Link goes to a black page with a blinking cursor.
+
+## Week 1 (~1 week out)
+Post 1 tweet:
+- "1 week. $5. No joke."
+
+Notes:
+- Still no explanation.
+- Let replies/quote tweets do the work.
+
+## Launch day
+Post 1 tweet (pin it):
+- "What would you do with your own WOPR Bot? $5/month. wopr.bot"
+
+## Checklist
+- [ ] Secure handle (@wopr_bot or @woprbot)
+- [ ] Create simple landing page
+- [ ] Prep 4 images (3/2/1/launch)
+- [ ] Pin launch tweet
+


### PR DESCRIPTION
Implements #549 by adding:
- docs/BRAND_VOICE.md (voice rules + examples)
- docs/LAUNCH_TWITTER_PLAN.md (3-week teaser plan + checklist)
- README: Official Channels placeholders

No external posting performed; this only provides templates/guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Official Channels subsection to README with Twitter/X and Discord platforms
  * New brand voice guidelines documentation defining communication tone, vocabulary, and style standards across all channels
  * New pre-launch Twitter strategy detailing three-week messaging calendar, visual guidelines, and launch day operations checklist

<!-- end of auto-generated comment: release notes by coderabbit.ai -->