### PR TITLE
feat: add baseUrl override to ProviderConfig for hosted-mode gateway routing (WOP-465)

### DIFF
--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -211,7 +211,12 @@ export class ProviderRegistry {
       }
 
       try {
-        const client = await reg.provider.createClient(cred?.credential || "", config.options);
+        // Merge baseUrl into options so provider implementations can use it
+        // to override the SDK's default API endpoint (hosted mode).
+        const options = config.baseUrl
+          ? { ...config.options, baseUrl: config.baseUrl }
+          : config.options;
+        const client = await reg.provider.createClient(cred?.credential || "", options);
         return {
           name: providerName,
           provider: reg.provider,

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -32,6 +32,22 @@ export interface ProviderConfig {
 
   /** Provider source: "byok" (default) or "hosted" */
   source?: ProviderSource;
+
+  /**
+   * Override the SDK's default API endpoint.
+   *
+   * When set, the provider plugin MUST pass this URL to the SDK constructor
+   * so all API calls go through this endpoint instead of the provider's
+   * default (e.g., api.anthropic.com, api.openai.com).
+   *
+   * Used by WOPR Hosted mode: the platform injects the gateway URL
+   * (e.g., "https://api.wopr.bot/v1") so traffic flows through the
+   * platform for metering, billing, and arbitrage.
+   *
+   * When undefined/omitted (BYOK mode), the SDK uses its default endpoint
+   * and the tenant pays the provider directly.
+   */
+  baseUrl?: string;
 }
 
 /**

--- a/tests/unit/provider-base-url.test.ts
+++ b/tests/unit/provider-base-url.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Provider base URL override tests (WOP-465)
+ *
+ * Tests that baseUrl on ProviderConfig flows through resolveProvider()
+ * into the options passed to createClient(), enabling hosted-mode
+ * gateway routing.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock logger
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("ProviderConfig.baseUrl", () => {
+  describe("type definition", () => {
+    it("should allow baseUrl to be omitted (BYOK mode)", () => {
+      const config: import("../../src/types/provider.js").ProviderConfig = {
+        name: "anthropic",
+      };
+      expect(config.baseUrl).toBeUndefined();
+    });
+
+    it("should allow baseUrl to be set (hosted mode)", () => {
+      const config: import("../../src/types/provider.js").ProviderConfig = {
+        name: "anthropic",
+        source: "hosted",
+        baseUrl: "https://api.wopr.bot/v1",
+      };
+      expect(config.baseUrl).toBe("https://api.wopr.bot/v1");
+    });
+
+    it("should allow baseUrl with source byok (user override)", () => {
+      const config: import("../../src/types/provider.js").ProviderConfig = {
+        name: "openai",
+        source: "byok",
+        baseUrl: "https://my-proxy.example.com/v1",
+      };
+      expect(config.baseUrl).toBe("https://my-proxy.example.com/v1");
+      expect(config.source).toBe("byok");
+    });
+  });
+
+  describe("resolveProvider baseUrl threading", () => {
+    let ProviderRegistry: typeof import("../../src/core/providers.js").ProviderRegistry;
+    let createClientSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      vi.resetModules();
+      const mod = await import("../../src/core/providers.js");
+      ProviderRegistry = mod.ProviderRegistry;
+      createClientSpy = vi.fn().mockResolvedValue({
+        query: vi.fn(),
+        listModels: vi.fn().mockResolvedValue([]),
+        healthCheck: vi.fn().mockResolvedValue(true),
+      });
+    });
+
+    function makeRegistry(spy: ReturnType<typeof vi.fn>) {
+      // Use a fresh instance, not the singleton
+      const registry = new ProviderRegistry();
+      registry.register({
+        id: "test-provider",
+        name: "Test Provider",
+        description: "Mock provider for testing",
+        defaultModel: "test-model",
+        supportedModels: ["test-model"],
+        validateCredentials: vi.fn().mockResolvedValue(true),
+        createClient: spy,
+        getCredentialType: () => "api-key",
+      });
+      return registry;
+    }
+
+    it("should pass baseUrl in options to createClient when baseUrl is set", async () => {
+      const registry = makeRegistry(createClientSpy);
+
+      // Set a credential so resolution doesn't skip the provider
+      await registry.setCredential("test-provider", "test-key-123");
+
+      await registry.resolveProvider({
+        name: "test-provider",
+        baseUrl: "https://api.wopr.bot/v1",
+      });
+
+      expect(createClientSpy).toHaveBeenCalledWith(
+        "test-key-123",
+        expect.objectContaining({ baseUrl: "https://api.wopr.bot/v1" }),
+      );
+    });
+
+    it("should NOT inject baseUrl into options when baseUrl is omitted", async () => {
+      const registry = makeRegistry(createClientSpy);
+      await registry.setCredential("test-provider", "test-key-123");
+
+      await registry.resolveProvider({
+        name: "test-provider",
+      });
+
+      // options should be undefined (no baseUrl, no options on config)
+      expect(createClientSpy).toHaveBeenCalledWith("test-key-123", undefined);
+    });
+
+    it("should merge baseUrl with existing options", async () => {
+      const registry = makeRegistry(createClientSpy);
+      await registry.setCredential("test-provider", "test-key-123");
+
+      await registry.resolveProvider({
+        name: "test-provider",
+        options: { temperature: 0.7 },
+        baseUrl: "https://api.wopr.bot/v1",
+      });
+
+      expect(createClientSpy).toHaveBeenCalledWith(
+        "test-key-123",
+        expect.objectContaining({
+          temperature: 0.7,
+          baseUrl: "https://api.wopr.bot/v1",
+        }),
+      );
+    });
+
+    it("should preserve existing options when baseUrl is not set", async () => {
+      const registry = makeRegistry(createClientSpy);
+      await registry.setCredential("test-provider", "test-key-123");
+
+      await registry.resolveProvider({
+        name: "test-provider",
+        options: { temperature: 0.7 },
+      });
+
+      expect(createClientSpy).toHaveBeenCalledWith(
+        "test-key-123",
+        { temperature: 0.7 },
+      );
+    });
+
+    it("should work with hosted source + baseUrl (full hosted-mode config)", async () => {
+      const registry = makeRegistry(createClientSpy);
+      await registry.setCredential("test-provider", "tenant-token-abc");
+
+      const resolved = await registry.resolveProvider({
+        name: "test-provider",
+        source: "hosted",
+        baseUrl: "https://api.wopr.bot/v1",
+        model: "claude-sonnet-4-20250514",
+      });
+
+      expect(createClientSpy).toHaveBeenCalledWith(
+        "tenant-token-abc",
+        expect.objectContaining({ baseUrl: "https://api.wopr.bot/v1" }),
+      );
+      expect(resolved.name).toBe("test-provider");
+      expect(resolved.credential).toBe("tenant-token-abc");
+    });
+  });
+
+  describe("session provider config persistence", () => {
+    it("should round-trip baseUrl through JSON serialization", () => {
+      const config: import("../../src/types/provider.js").ProviderConfig = {
+        name: "anthropic",
+        source: "hosted",
+        baseUrl: "https://api.wopr.bot/v1",
+        model: "claude-sonnet-4-20250514",
+      };
+
+      const serialized = JSON.stringify(config);
+      const deserialized = JSON.parse(serialized);
+
+      expect(deserialized.baseUrl).toBe("https://api.wopr.bot/v1");
+      expect(deserialized.source).toBe("hosted");
+      expect(deserialized.name).toBe("anthropic");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-465

- Adds `baseUrl?: string` field to `ProviderConfig` in `src/types/provider.ts` — enables provider SDKs to target WOPR's gateway instead of calling providers directly
- Threads `baseUrl` through `ProviderRegistry.resolveProvider()` into `createClient()` options so provider plugin implementations receive the override URL
- Adds 9 unit tests covering type contracts, resolution threading, option merging, and JSON round-trip persistence

### How it works

**Hosted mode** (platform-managed): Platform injects `baseUrl: "https://api.wopr.bot/v1"` + `source: "hosted"` into provider config. SDK calls WOPR gateway, which meters, bills, and routes to cheapest provider.

**BYOK mode** (bring-your-own-key): `baseUrl` is omitted. SDK calls provider directly using tenant's own API key. No metering, no billing.

### What this does NOT change
- No individual provider plugin implementations modified (separate stories: WOP-466, WOP-467)
- No gateway-side changes
- No arbitrage routing logic (WOP-463)

## Test plan
- [x] `npm run build` passes (TypeScript compilation clean)
- [x] `npm test` passes (all 1289 tests across 46 files)
- [x] New test file `tests/unit/provider-base-url.test.ts` (9 tests) covers:
  - Type allows `baseUrl` to be omitted (BYOK) or set (hosted)
  - `resolveProvider()` passes `baseUrl` to `createClient()` options
  - `baseUrl` merges correctly with existing provider options
  - Existing options preserved when `baseUrl` is absent
  - Full hosted-mode config round-trips through JSON serialization

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseUrl configuration option to allow overriding the API endpoint for providers.

* **Tests**
  * Added comprehensive unit tests for baseUrl configuration, provider resolution, and endpoint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->