### PR TITLE
fix: use container IP for DinD smoke test (WOP-402)

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -45,7 +45,7 @@ jobs:
           # Get container IP on the bridge network.
           # This avoids DinD networking issues where host port mappings are
           # unreachable from inside a containerised GitHub Actions runner.
-          CONTAINER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$CONTAINER_NAME")
+          CONTAINER_IP=$(docker inspect -f '{{.NetworkSettings.Networks.bridge.IPAddress}}' "$CONTAINER_NAME")
           if [ -z "$CONTAINER_IP" ]; then
             echo "ERROR: Could not resolve container IP for $CONTAINER_NAME"
             docker logs "$CONTAINER_NAME" 2>&1 | tail -20


### PR DESCRIPTION
## Summary
Closes WOP-402

The nightly promotion smoke test has been failing for both `wopr:latest` and `wopr-slim:latest` because of a Docker-in-Docker (DinD) networking mismatch:

- The self-hosted runner is itself a Docker container
- `docker run -p 127.0.0.1:0:7437` creates a port mapping on the **Docker host's** loopback
- `curl localhost:PORT` inside the runner hits the **runner container's** loopback, where nothing is listening
- Result: 60-second timeout, health check fails, :stable/:staging tags never update

Both images start correctly (logs confirm `WOPR daemon listening on http://0.0.0.0:7437`). The health endpoint works fine. The issue is purely networking.

**Fix:** Replace host port mapping with `docker inspect` to get the smoke container's bridge network IP, then curl that IP directly on port 7437. This works in both DinD and standard Docker environments.

## Test plan
- [ ] Trigger `Promote Stable` workflow via `workflow_dispatch` after merge
- [ ] Verify both `wopr` and `wopr-slim` matrix jobs pass the smoke test
- [ ] Verify `:stable` and `:staging` tags are pushed to GHCR

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow health check mechanism for improved reliability during container verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->