### PR TITLE
fix: remove remaining billing config from WoprConfig (WOP-521 follow-up)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -108,15 +108,6 @@ export interface WoprConfig {
       deny?: string[];
     };
   };
-  /**
-   * Billing configuration for hosted capability usage
-   */
-  billing?: {
-    /** Universal margin multiplier applied to all hosted provider costs (default: 1.3 = 30% margin) */
-    multiplier?: number;
-    /** Enable/disable metering (default: true) */
-    enabled?: boolean;
-  };
 }
 
 const DEFAULT_CONFIG: WoprConfig = {


### PR DESCRIPTION
## Summary

Follow-up to #642 - PR #614 added billing config to `src/core/config.ts` after our cleanup. This removes the remaining billing section from the WoprConfig interface.

## Changes

- Remove `billing?: { multiplier?: number; enabled?: boolean }` from WoprConfig interface

## Related

- WOP-521 epic: Billing Cleanup
- #642: Main billing removal PR
- #614: Accidentally re-added billing config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed billing configuration settings from the application configuration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->