### PR TITLE
feat: migrate crons to SQL (WOP-541)

### DIFF
--- a/src/core/cron-migrate.ts
+++ b/src/core/cron-migrate.ts
@@ -1,0 +1,66 @@
+/**
+ * Cron migration - migrate from JSON files to SQL
+ */
+
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import { logger } from "../logger.js";
+import { CRON_HISTORY_FILE, CRONS_FILE } from "../paths.js";
+import type { CronHistoryEntry, CronJob } from "../types.js";
+import { addCron, addCronRun } from "./cron-repository.js";
+
+/**
+ * Migrate cron data from JSON files to SQL
+ * Renames JSON files to .backup after successful migration
+ */
+export async function migrateCronsToSql(): Promise<void> {
+  let jobsMigrated = 0;
+  let runsMigrated = 0;
+
+  // Migrate cron jobs
+  if (existsSync(CRONS_FILE)) {
+    try {
+      const jobs: CronJob[] = JSON.parse(readFileSync(CRONS_FILE, "utf-8"));
+      for (const job of jobs) {
+        await addCron(job);
+        jobsMigrated++;
+      }
+      // Rename to backup
+      renameSync(CRONS_FILE, `${CRONS_FILE}.backup`);
+      logger.info(`[cron-migrate] Migrated ${jobsMigrated} jobs from ${CRONS_FILE}`);
+    } catch (err) {
+      logger.error(`[cron-migrate] Failed to migrate jobs: ${err}`);
+      throw err;
+    }
+  }
+
+  // Migrate cron history
+  if (existsSync(CRON_HISTORY_FILE)) {
+    try {
+      const history: CronHistoryEntry[] = JSON.parse(readFileSync(CRON_HISTORY_FILE, "utf-8"));
+      for (const entry of history) {
+        // Map old CronHistoryEntry to new CronRunRow format
+        await addCronRun({
+          cronName: entry.name,
+          session: entry.session,
+          startedAt: entry.timestamp,
+          status: entry.success ? "success" : "failure",
+          durationMs: entry.durationMs,
+          error: entry.error,
+          message: entry.message,
+          scriptResults: entry.scriptResults,
+        });
+        runsMigrated++;
+      }
+      // Rename to backup
+      renameSync(CRON_HISTORY_FILE, `${CRON_HISTORY_FILE}.backup`);
+      logger.info(`[cron-migrate] Migrated ${runsMigrated} history entries from ${CRON_HISTORY_FILE}`);
+    } catch (err) {
+      logger.error(`[cron-migrate] Failed to migrate history: ${err}`);
+      throw err;
+    }
+  }
+
+  if (jobsMigrated === 0 && runsMigrated === 0) {
+    logger.info("[cron-migrate] No JSON files found - clean SQL start");
+  }
+}

--- a/src/core/cron-repository.ts
+++ b/src/core/cron-repository.ts
@@ -1,0 +1,140 @@
+/**
+ * Cron repository - async CRUD operations for cron jobs and runs
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Repository } from "../storage/api/plugin-storage.js";
+import { getStorage } from "../storage/public.js";
+import type { CronJobRow, CronRunRow } from "./cron-schema.js";
+import { cronPluginSchema } from "./cron-schema.js";
+
+let jobsRepo: Repository<CronJobRow, "name", string> | null = null;
+let runsRepo: Repository<CronRunRow, "id", string> | null = null;
+
+/**
+ * Initialize cron storage (registers schema and gets repositories)
+ */
+export async function initCronStorage(): Promise<void> {
+  const storage = getStorage();
+  await storage.register(cronPluginSchema);
+  jobsRepo = storage.getRepository<CronJobRow>("cron", "jobs");
+  runsRepo = storage.getRepository<CronRunRow>("cron", "runs");
+}
+
+function ensureInitialized(): void {
+  if (!jobsRepo || !runsRepo) {
+    throw new Error("Cron storage not initialized - call initCronStorage() first");
+  }
+}
+
+/**
+ * Get all cron jobs
+ */
+export async function getCrons(): Promise<CronJobRow[]> {
+  ensureInitialized();
+  return await jobsRepo!.findMany();
+}
+
+/**
+ * Get a specific cron job by name
+ */
+export async function getCron(name: string): Promise<CronJobRow | null> {
+  ensureInitialized();
+  return await jobsRepo!.findById(name);
+}
+
+/**
+ * Add or update a cron job (upsert by name)
+ */
+export async function addCron(job: CronJobRow): Promise<void> {
+  ensureInitialized();
+  const existing = await jobsRepo!.findById(job.name);
+  if (existing) {
+    await jobsRepo!.update(job.name, job);
+  } else {
+    await jobsRepo!.insert(job);
+  }
+}
+
+/**
+ * Remove a cron job by name
+ */
+export async function removeCron(name: string): Promise<boolean> {
+  ensureInitialized();
+  return await jobsRepo!.delete(name);
+}
+
+/**
+ * Add a cron run entry to history
+ */
+export async function addCronRun(run: Omit<CronRunRow, "id">): Promise<void> {
+  ensureInitialized();
+  const id = randomUUID();
+  await runsRepo!.insert({ id, ...run });
+}
+
+/**
+ * Get cron run history with filtering and pagination
+ */
+export async function getCronHistory(options?: {
+  name?: string;
+  session?: string;
+  limit?: number;
+  offset?: number;
+  since?: number;
+  successOnly?: boolean;
+  failedOnly?: boolean;
+}): Promise<{ entries: CronRunRow[]; total: number; hasMore: boolean }> {
+  ensureInitialized();
+
+  // Build query
+  const query = runsRepo!.query();
+
+  // Apply filters
+  if (options?.name) {
+    query.where("cronName", options.name);
+  }
+  if (options?.session) {
+    query.where("session", options.session);
+  }
+  if (options?.since) {
+    query.where("startedAt", "$gte", options.since);
+  }
+  if (options?.successOnly) {
+    query.where("status", "success");
+  } else if (options?.failedOnly) {
+    query.where("status", "failure");
+  }
+
+  // Order by most recent first
+  query.orderBy("startedAt", "desc");
+
+  // Get total count before pagination
+  const total = await query.count();
+
+  // Apply pagination
+  const offset = options?.offset ?? 0;
+  const limit = options?.limit ?? 50;
+  query.offset(offset).limit(limit);
+
+  const entries = await query.execute();
+  const hasMore = offset + entries.length < total;
+
+  return { entries, total, hasMore };
+}
+
+/**
+ * Clear cron run history with optional filtering
+ */
+export async function clearCronHistory(options?: { name?: string; session?: string }): Promise<number> {
+  ensureInitialized();
+
+  if (options?.name) {
+    return await runsRepo!.deleteMany({ cronName: options.name });
+  }
+  if (options?.session) {
+    return await runsRepo!.deleteMany({ session: options.session });
+  }
+  // Clear all
+  return await runsRepo!.deleteMany({});
+}

--- a/src/core/cron-schema.ts
+++ b/src/core/cron-schema.ts
@@ -1,0 +1,83 @@
+/**
+ * Cron storage schema - SQL-based cron job and execution history
+ */
+
+import { z } from "zod";
+import type { PluginSchema } from "../storage/api/plugin-storage.js";
+
+// Schema for CronScript - stored as JSON in scripts column
+export const cronScriptSchema = z.object({
+  name: z.string(),
+  command: z.string(),
+  timeout: z.number().optional(),
+  cwd: z.string().optional(),
+});
+
+export const cronScriptResultSchema = z.object({
+  name: z.string(),
+  exitCode: z.number(),
+  stdout: z.string(),
+  stderr: z.string(),
+  durationMs: z.number(),
+  error: z.string().optional(),
+});
+
+// Table: cron_jobs
+// Primary key: name (the job name is the ID for backwards compat)
+export const cronJobSchema = z.object({
+  name: z.string(), // Primary key
+  schedule: z.string(),
+  session: z.string(),
+  message: z.string(),
+  scripts: z.array(cronScriptSchema).optional(),
+  once: z.boolean().optional(),
+  runAt: z.number().optional(),
+});
+
+export type CronJobRow = z.infer<typeof cronJobSchema>;
+
+// Table: cron_runs
+// Stores execution history with auto-generated ID
+export const cronRunSchema = z.object({
+  id: z.string(), // Auto-generated UUID primary key
+  cronName: z.string(), // Denormalized job name
+  session: z.string(),
+  startedAt: z.number(), // Timestamp when execution started
+  status: z.enum(["success", "failure"]), // success or failure
+  durationMs: z.number(),
+  error: z.string().optional(),
+  message: z.string(), // The resolved message that was sent
+  scriptResults: z.array(cronScriptResultSchema).optional(),
+});
+
+export type CronRunRow = z.infer<typeof cronRunSchema>;
+
+/**
+ * Plugin schema definition for cron storage
+ * Namespace: "cron" → tables: cron_jobs, cron_runs
+ */
+export const cronPluginSchema: PluginSchema = {
+  namespace: "cron",
+  version: 1,
+  tables: {
+    jobs: {
+      schema: cronJobSchema,
+      primaryKey: "name",
+      indexes: [
+        { fields: ["session"] },
+        { fields: ["schedule"] },
+        { fields: ["runAt"] },
+      ],
+    },
+    runs: {
+      schema: cronRunSchema,
+      primaryKey: "id",
+      indexes: [
+        { fields: ["cronName"] },
+        { fields: ["session"] },
+        { fields: ["startedAt"] },
+        { fields: ["status"] },
+      ],
+    },
+  },
+};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,6 +3,8 @@
  */
 
 export * from "./cron.js";
+export * from "./cron-schema.js";
+export * from "./cron-repository.js";
 export * from "./events.js";
 export * from "./pairing.js";
 export * from "./pairing-commands.js";

--- a/src/daemon/routes/crons.ts
+++ b/src/daemon/routes/crons.ts
@@ -11,15 +11,15 @@ import type { CronJob } from "../../types.js";
 export const cronsRouter = new Hono();
 
 // List all crons
-cronsRouter.get("/", (c) => {
-  const crons = getCrons();
+cronsRouter.get("/", async (c) => {
+  const crons = await getCrons();
   return c.json({ crons });
 });
 
 // Get specific cron
-cronsRouter.get("/:name", (c) => {
+cronsRouter.get("/:name", async (c) => {
   const name = c.req.param("name");
-  const cron = getCron(name);
+  const cron = await getCron(name);
 
   if (!cron) {
     return c.json({ error: "Cron not found" }, 404);
@@ -70,7 +70,7 @@ cronsRouter.post("/", async (c) => {
     once: once || undefined,
   };
 
-  addCron(job);
+  await addCron(job);
 
   // Optionally run immediately
   if (runNow) {
@@ -91,7 +91,7 @@ cronsRouter.post("/once", async (c) => {
 
   try {
     const job = createOnceJob(time, session, message);
-    addCron(job);
+    await addCron(job);
 
     return c.json(
       {
@@ -125,9 +125,9 @@ cronsRouter.post("/now", async (c) => {
 });
 
 // Delete cron
-cronsRouter.delete("/:name", (c) => {
+cronsRouter.delete("/:name", async (c) => {
   const name = c.req.param("name");
-  const removed = removeCron(name);
+  const removed = await removeCron(name);
 
   if (!removed) {
     return c.json({ error: "Cron not found" }, 404);


### PR DESCRIPTION
## Summary

Migrates cron job storage and execution history from JSON files (`crons.json`, `cron-history.json`) to SQL using the Storage API.

## Implementation Details

### New Files
- **`src/core/cron-schema.ts`**: Zod schemas for `cron_jobs` and `cron_runs` tables, PluginSchema definition
- **`src/core/cron-repository.ts`**: Async CRUD functions wrapping Storage API repositories
- **`src/core/cron-migrate.ts`**: JSON-to-SQL migration reading old files, inserting to SQL, renaming to .backup

### Modified Files
- **`src/core/cron.ts`**: Removed JSON I/O functions, kept pure functions (parseCronSchedule, shouldRunCron, executeCronScript), re-exported repository functions
- **`src/daemon/index.ts`**: Added `initCronStorage()` + `migrateCronsToSql()` at startup, made all cron calls async
- **`src/daemon/routes/crons.ts`**: Made all route handlers async with `await`
- **`src/core/a2a-tools/cron.ts`**: Made all cron calls async, updated field names (name→cronName, timestamp→startedAt, success→status==="success")
- **`src/core/index.ts`**: Exported new cron-schema and cron-repository modules

## Schema Design

### Tables
- **`cron_jobs`**: Primary key = `name` (job name as ID for backwards compat)
  - Indexes: session, schedule, runAt
  - `scripts` stored as JSON TEXT column
- **`cron_runs`**: Auto-generated UUID primary key, denormalized `cronName` field
  - Indexes: cronName, session, startedAt, status
  - No artificial history cap (SQL handles large tables natively)

### Migration Strategy
- Reads existing `crons.json` and `cron-history.json`
- Inserts all data into SQL tables
- Renames JSON files to `.backup` after successful migration
- One-time migration on daemon startup

## API Changes

### Breaking Changes
All cron CRUD functions are now **async** (require `await`):
- `getCrons()` → `await getCrons()`
- `getCron(name)` → `await getCron(name)`
- `addCron(job)` → `await addCron(job)`
- `removeCron(name)` → `await removeCron(name)`
- `getCronHistory(options)` → `await getCronHistory(options)`

### Renamed Functions
- `addCronHistory(entry)` → `addCronRun(run)` with updated field names:
  - `name` → `cronName`
  - `timestamp` → `startedAt`
  - `success` → `status` ("success" | "failure")

### Signature Changes
- `getCronHistory()` returns same structure: `{ entries, total, hasMore }`
- Pagination support unchanged (limit, offset)

## Test Plan

- [ ] Clean install: Daemon starts with empty SQL tables
- [ ] Migration: Existing JSON files migrate to SQL and rename to .backup
- [ ] CRUD operations: Create, read, update, delete cron jobs via API
- [ ] Cron execution: Jobs run on schedule and history records correctly
- [ ] A2A tools: `cron_schedule`, `cron_once`, `cron_list`, `cron_cancel`, `cron_history` work correctly
- [ ] Pagination: History queries with limit/offset work correctly
- [ ] Backward compat: Existing cron jobs continue working after migration

## Related Issues

Closes WOP-541

---

🤖 Generated by coder-541 (Claude Code Agent)