### PR TITLE
feat: migrate skills state to SQL (WOP-543)

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,3 +11,6 @@ export * from "./pairing-commands.js";
 export * from "./registries.js";
 export * from "./sessions.js";
 export * from "./skills.js";
+export * from "./skills-schema.js";
+export * from "./skills-repository.js";
+export * from "./skills-migrate.js";

--- a/src/core/skills-migrate.ts
+++ b/src/core/skills-migrate.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { logger } from "../logger.js";
+import { WOPR_HOME } from "../paths.js";
+import type { Repository } from "../storage/api/plugin-storage.js";
+import { getStorage } from "../storage/index.js";
+import { initSkillsStorage } from "./skills-repository.js";
+import type { SkillStateRecord } from "./skills-schema.js";
+
+const SKILLS_STATE_FILE = join(WOPR_HOME, "skills-state.json");
+
+/** Main migration entry point — idempotent */
+export async function migrateSkillsToSQL(): Promise<void> {
+  // Check if skills-state.json exists — if not, nothing to migrate
+  if (!existsSync(SKILLS_STATE_FILE)) {
+    logger.info("[migration] No skills-state.json found, skipping migration");
+    return;
+  }
+
+  logger.info("[migration] Starting skills state migration from JSON to SQL");
+
+  // Ensure storage is initialized
+  await initSkillsStorage();
+  const storage = getStorage();
+  const skillsRepo = storage.getRepository<SkillStateRecord>("skills", "skills_state");
+
+  // Read skills-state.json
+  let skillsState: Record<string, { enabled: boolean }>;
+  try {
+    const raw = readFileSync(SKILLS_STATE_FILE, "utf-8");
+    skillsState = JSON.parse(raw) as Record<string, { enabled: boolean }>;
+  } catch (error) {
+    logger.error("[migration] Failed to parse skills-state.json:", error);
+    return;
+  }
+
+  // Migrate each skill state entry
+  let migratedCount = 0;
+  for (const [skillName, state] of Object.entries(skillsState)) {
+    try {
+      await migrateSkillState(skillName, state, skillsRepo);
+      migratedCount++;
+    } catch (error) {
+      logger.error(`[migration] Failed to migrate skill state "${skillName}":`, error);
+    }
+  }
+
+  logger.info(`[migration] Migrated ${migratedCount} skill states to SQL`);
+
+  // Backup old file
+  backupFile(SKILLS_STATE_FILE);
+
+  logger.info("[migration] Backup of skills-state.json complete");
+}
+
+async function migrateSkillState(
+  skillName: string,
+  state: { enabled: boolean },
+  skillsRepo: Repository<SkillStateRecord>,
+): Promise<void> {
+  logger.debug(`[migration] Migrating skill state "${skillName}" (enabled: ${state.enabled})`);
+
+  // Insert skill state record
+  const now = new Date().toISOString();
+  await skillsRepo.insert({
+    id: skillName,
+    enabled: state.enabled,
+    installed: true,
+    enabledAt: state.enabled ? now : undefined,
+    useCount: 0,
+  });
+}
+
+function backupFile(filePath: string): void {
+  if (existsSync(filePath)) {
+    renameSync(filePath, `${filePath}.backup`);
+    logger.debug(`[migration] Backed up ${filePath}`);
+  }
+}

--- a/src/core/skills-repository.ts
+++ b/src/core/skills-repository.ts
@@ -1,0 +1,154 @@
+import { logger } from "../logger.js";
+import type { Repository } from "../storage/api/plugin-storage.js";
+import { getStorage } from "../storage/index.js";
+import type { SkillStateRecord } from "./skills-schema.js";
+import { skillsPluginSchema } from "./skills-schema.js";
+
+let initialized = false;
+
+/** Initialize schema — idempotent, call on first access */
+export async function initSkillsStorage(): Promise<void> {
+  if (initialized) return;
+  const storage = getStorage();
+  await storage.register(skillsPluginSchema);
+  initialized = true;
+}
+
+/** Reset for testing */
+export function resetSkillsStorageInit(): void {
+  initialized = false;
+}
+
+// ---------- Helper to get repo (ensures init) ----------
+function skillsStateRepo(): Repository<SkillStateRecord> {
+  return getStorage().getRepository<SkillStateRecord>("skills", "skills_state");
+}
+
+// ---------- Skills State CRUD ----------
+
+/** Get skill state by name */
+export async function getSkillState(name: string): Promise<SkillStateRecord | null> {
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const existing = await repo.findFirst({ id: name } as any);
+  return existing ?? null;
+}
+
+/** Get all skill states */
+export async function getAllSkillStates(): Promise<Record<string, { enabled: boolean }>> {
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const rows = await repo.findMany({});
+  const state: Record<string, { enabled: boolean }> = {};
+  for (const row of rows) {
+    state[row.id] = { enabled: row.enabled };
+  }
+  return state;
+}
+
+/** Check if a skill is enabled (async version) */
+export async function isSkillEnabledAsync(name: string): Promise<boolean> {
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const existing = await repo.findFirst({ id: name } as any);
+  // Skills are enabled by default if not explicitly disabled
+  return existing?.enabled !== false;
+}
+
+/** Get all skill states (async version) */
+export async function readAllSkillStatesAsync(): Promise<Record<string, { enabled: boolean }>> {
+  return getAllSkillStates();
+}
+
+/** Enable a skill - validates skill exists first */
+export async function enableSkillAsync(name: string): Promise<boolean> {
+  // Check if skill exists by discovering
+  const { discoverSkills } = await import("./skills.js");
+  const { skills } = discoverSkills();
+  const skill = skills.find((s) => s.name === name);
+  if (!skill) return false;
+
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const existing = await repo.findFirst({ id: name } as any);
+  const now = new Date().toISOString();
+
+  if (existing) {
+    // Update existing
+    await repo.update(existing.id, { enabled: true, enabledAt: now });
+  } else {
+    // Create new
+    await repo.insert({
+      id: name,
+      enabled: true,
+      installed: true,
+      enabledAt: now,
+      useCount: 0,
+    });
+  }
+  return true;
+}
+
+/** Disable a skill - validates skill exists first */
+export async function disableSkillAsync(name: string): Promise<boolean> {
+  // Check if skill exists by discovering
+  const { discoverSkills } = await import("./skills.js");
+  const { skills } = discoverSkills();
+  const skill = skills.find((s) => s.name === name);
+  if (!skill) return false;
+
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const existing = await repo.findFirst({ id: name } as any);
+
+  if (existing) {
+    // Update existing
+    await repo.update(existing.id, { enabled: false, enabledAt: undefined });
+  } else {
+    // Create new entry as disabled
+    await repo.insert({
+      id: name,
+      enabled: false,
+      installed: true,
+      useCount: 0,
+    });
+  }
+  return true;
+}
+
+/** Record skill usage */
+export async function recordSkillUsage(name: string): Promise<void> {
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const existing = await repo.findFirst({ id: name } as any);
+  const now = new Date().toISOString();
+
+  if (existing) {
+    await repo.update(existing.id, {
+      lastUsedAt: now,
+      useCount: (existing.useCount ?? 0) + 1,
+    });
+  } else {
+    // Auto-create on first use
+    await repo.insert({
+      id: name,
+      enabled: true,
+      installed: true,
+      enabledAt: now,
+      lastUsedAt: now,
+      useCount: 1,
+    });
+  }
+  logger.debug(`[skills-repository] Recorded usage for skill "${name}"`);
+}
+
+/** Remove skill state (for cleanup when skill is uninstalled) */
+export async function removeSkillState(name: string): Promise<void> {
+  await initSkillsStorage();
+  const repo = skillsStateRepo();
+  const existing = await repo.findFirst({ id: name } as any);
+  if (existing) {
+    await repo.delete(existing.id);
+    logger.debug(`[skills-repository] Removed state for skill "${name}"`);
+  }
+}

--- a/src/core/skills-schema.ts
+++ b/src/core/skills-schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import type { PluginSchema } from "../storage/api/plugin-storage.js";
+
+// ---------- skills_state table ----------
+export const skillStateSchema = z.object({
+  id: z.string(), // Skill name (primary key)
+  enabled: z.boolean(), // Whether skill is enabled
+  installed: z.boolean(), // Whether skill is installed
+  enabledAt: z.string().optional(), // ISO timestamp when enabled
+  lastUsedAt: z.string().optional(), // ISO timestamp of last use
+  useCount: z.number(), // Number of times skill has been used
+});
+export type SkillStateRecord = z.infer<typeof skillStateSchema>;
+
+// ---------- PluginSchema ----------
+export const skillsPluginSchema: PluginSchema = {
+  namespace: "skills",
+  version: 1,
+  tables: {
+    skills_state: {
+      schema: skillStateSchema,
+      primaryKey: "id",
+      indexes: [{ fields: ["enabled"] }, { fields: ["lastUsedAt"] }],
+    },
+  },
+};

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -200,6 +200,14 @@ export async function startDaemon(config: DaemonConfig = {}): Promise<void> {
   await migrateCronsToSql();
   daemonLog("Cron storage initialized");
 
+  // Initialize skills storage and migrate from JSON
+  daemonLog("Initializing skills storage...");
+  const { initSkillsStorage } = await import("../core/skills-repository.js");
+  const { migrateSkillsToSQL } = await import("../core/skills-migrate.js");
+  await initSkillsStorage();
+  await migrateSkillsToSQL();
+  daemonLog("Skills storage initialized");
+
   // Ensure bearer token exists for API authentication
   ensureToken();
   daemonLog("Bearer token ready for API authentication");

--- a/src/daemon/routes/skills.ts
+++ b/src/daemon/routes/skills.ts
@@ -7,21 +7,21 @@ import { addRegistry, getRegistries, removeRegistry, searchAllRegistries } from 
 import {
   clearSkillCache,
   createSkill,
-  disableSkill,
+  disableSkillAsync,
   discoverSkills,
-  enableSkill,
+  enableSkillAsync,
   installSkillFromGitHub,
   installSkillFromUrl,
-  readAllSkillStates,
+  readAllSkillStatesAsync,
   removeSkill,
 } from "../../core/skills.js";
 
 export const skillsRouter = new Hono();
 
 // List installed skills
-skillsRouter.get("/", (c) => {
+skillsRouter.get("/", async (c) => {
   const { skills, warnings } = discoverSkills();
-  const skillStates = readAllSkillStates();
+  const skillStates = await readAllSkillStatesAsync();
   return c.json({
     skills: skills.map((s) => ({
       name: s.name,
@@ -127,10 +127,10 @@ skillsRouter.delete("/:name", (c) => {
 });
 
 // Enable a skill
-skillsRouter.post("/:name/enable", (c) => {
+skillsRouter.post("/:name/enable", async (c) => {
   const name = c.req.param("name");
   try {
-    const found = enableSkill(name);
+    const found = await enableSkillAsync(name);
 
     if (!found) {
       return c.json({ error: "Skill not found" }, 404);
@@ -144,10 +144,10 @@ skillsRouter.post("/:name/enable", (c) => {
 });
 
 // Disable a skill
-skillsRouter.post("/:name/disable", (c) => {
+skillsRouter.post("/:name/disable", async (c) => {
   const name = c.req.param("name");
   try {
-    const found = disableSkill(name);
+    const found = await disableSkillAsync(name);
 
     if (!found) {
       return c.json({ error: "Skill not found" }, 404);


### PR DESCRIPTION
Migrates skills-state.json to SQL via Storage API. Follows cron migration pattern (WOP-541).

## Changes

**CREATE 3 files:**
- `src/core/skills-schema.ts` - Zod schema for skills_state table with id (PK), enabled, installed, enabledAt, lastUsedAt, useCount
- `src/core/skills-repository.ts` - Async CRUD operations (initSkillsStorage, getSkillState, enableSkillAsync, disableSkillAsync, recordSkillUsage, removeSkillState)
- `src/core/skills-migrate.ts` - Migration from JSON to SQL with backup

**MODIFY 4 files:**
- `src/core/skills.ts` - Remove sync state management (readSkillsState, writeSkillsState, SkillsState type), re-export async API
- `src/core/index.ts` - Export new modules
- `src/daemon/index.ts` - Add initSkillsStorage + migrateSkillsToSQL to startup sequence
- `src/daemon/routes/skills.ts` - Convert sync handlers to async (readAllSkillStatesAsync, enableSkillAsync, disableSkillAsync)

## Implementation Pattern

Follows exact cron migration pattern:
1. Schema → Repository → Migration
2. Register schema, get repo via Storage API
3. Read JSON, iterate entries, upsert to SQL
4. Rename JSON to .backup

## Testing
- Build passes: `pnpm build`
- Follows WOP-541 precedent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills data now persists in a SQL database for improved reliability
  * Automatic migration of existing skills data from JSON files
  * Enhanced skill usage tracking and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->