### PR TITLE
docs: Add nvm use and native dependencies note (WOP-573)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,10 @@ docs(readme): Update installation instructions
 git clone https://github.com/wopr-network/wopr.git
 cd wopr
 
-# Install dependencies
+# Use the correct Node.js version (see .nvmrc)
+nvm use
+
+# Install dependencies (includes native modules like better-sqlite3)
 npm install
 
 # Build
@@ -96,6 +99,8 @@ npm test
 # Start daemon in dev mode
 npm run dev
 ```
+
+> **Note on native dependencies:** WOPR uses `better-sqlite3` (a native C++ addon) and `sqlite-vec` for storage. After cloning, after pulling changes that modify storage dependencies, or after switching Node.js versions, always run `npm install` to ensure native modules are compiled for your platform and Node version. If you see errors like `Cannot find package 'better-sqlite3'`, run `npm install` to fix it.
 
 ### Project Structure
 


### PR DESCRIPTION
## Summary
Closes WOP-573

- Added `nvm use` step to Development Setup in CONTRIBUTING.md
- Added note about native dependencies (better-sqlite3, sqlite-vec)
- Documents when to run `npm install` (after cloning, pulling storage deps changes, switching Node versions)

## Test plan
- [x] Verified `.nvmrc` contains `24`
- [x] Verified `package.json` has `engines.node: ">=24.0.0"`
- [x] Verified CONTRIBUTING.md renders correctly with new native dependencies note
- [x] `npm install` completes successfully and installs better-sqlite3, drizzle-orm, sqlite-vec
- [x] `npm run build` passes

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contribution guidelines with clearer setup instructions, including guidance on installing native dependencies, using the correct Node.js version, and rebuilding native modules after cloning, pulling storage-related changes, or switching Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->