### PR TITLE
fix: Add close() to StorageApi interface for lifecycle consistency (WOP-580)

### DIFF
--- a/src/storage/api/plugin-storage.ts
+++ b/src/storage/api/plugin-storage.ts
@@ -237,4 +237,10 @@ export interface StorageApi {
    * Run cross-table transaction
    */
   transaction<R>(fn: (storage: StorageApi) => Promise<R>): Promise<R>;
+
+  /**
+   * Close the storage connection and release resources.
+   * Safe to call multiple times. No-op if already closed.
+   */
+  close(): void;
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -426,6 +426,11 @@ class TransactionStorage implements StorageApi {
   async transaction<R>(_fn: (storage: StorageApi) => Promise<R>): Promise<R> {
     throw new Error("Nested transactions not supported");
   }
+
+  close(): void {
+    // No-op: TransactionStorage does not own the connection.
+    // The parent Storage instance manages the database lifecycle.
+  }
 }
 
 // Singleton instance


### PR DESCRIPTION
## Summary
Closes WOP-580

- Added `close(): void` to `StorageApi` interface for type safety
- Added no-op `close()` to `TransactionStorage` (parent Storage owns connection)
- Ensures all implementors satisfy the interface contract

## Test plan
- [x] `pnpm build` passes (TypeScript compilation verified)
- [x] Existing storage tests pass (67 tests)
- [x] No regressions in storage lifecycle

Generated with Claude Code