### PR TITLE
fix: MetricsStore API mismatch with Storage and test timing (WOP-577)

### DIFF
--- a/src/daemon/observability/metrics.ts
+++ b/src/daemon/observability/metrics.ts
@@ -82,12 +82,7 @@ export class MetricsStore {
   /**
    * Record a metric data point.
    */
-  async record(
-    name: string,
-    value: number,
-    instanceId?: string,
-    tags: Record<string, string> = {},
-  ): Promise<void> {
+  async record(name: string, value: number, instanceId?: string, tags: Record<string, string> = {}): Promise<void> {
     await this.storage.run(
       "INSERT INTO metrics_rows (id, timestamp, metric_name, metric_value, instance_id, tags) VALUES (?, ?, ?, ?, ?, ?)",
       [randomUUID(), Date.now(), name, value, instanceId ?? null, JSON.stringify(tags)],

--- a/tests/daemon/observability/metrics.test.ts
+++ b/tests/daemon/observability/metrics.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { MetricsStore, metricsPluginSchema } from "../../../src/daemon/observability/metrics.js";
+import { MetricsStore } from "../../../src/daemon/observability/metrics.js";
 import { getStorage, resetStorage } from "../../../src/storage/index.js";
 
 describe("MetricsStore", () => {


### PR DESCRIPTION
## Summary
Closes WOP-577

Fixed MetricsStore test failures after WOP-547 Storage API migration:

### Test Updates
- Updated test setup to use `getStorage()` + `MetricsStore.create()` factory pattern
- Changed teardown to use `resetStorage()` instead of non-existent `store.close()`
- Made all test methods `async` with `await` on store operations (were comparing Promises to values)

### Schema Fix
- Changed `instance_id` from `.nullable()` to `.optional()` in schema
- Reason: Storage table generation only handles `ZodOptional`, not `ZodNullable`
- Updated `MetricRecord` interface and method signatures to match

### Timing Fix
- Added 2ms delays between records in "gets latest value" test
- Ensures distinct timestamps so `ORDER BY timestamp DESC` returns correct record

## Test plan
- [x] `npx vitest run tests/daemon/observability/metrics.test.ts` - All 13 tests pass
- [x] `npx tsc --noEmit` - TypeScript compilation passes

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated metrics recording and querying API to handle optional instance identifiers, improving type consistency across metrics operations.

* **Chores**
  * Migrated metrics test infrastructure to asynchronous patterns with enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->