### PR TITLE
fix: correct phantom repo refs in capability catalog (WOP-616)

### DIFF
--- a/src/core/a2a-tools/memory.ts
+++ b/src/core/a2a-tools/memory.ts
@@ -279,7 +279,8 @@ export function createMemoryTools(sessionName: string): unknown[] {
             if (!sessionMatch) return true;
             return canIndexSession(sessionName, sessionMatch[1], indexablePatterns);
           });
-          if (filteredFilesToSearch.length === 0) return { content: [{ type: "text", text: "No memory files found." }] };
+          if (filteredFilesToSearch.length === 0)
+            return { content: [{ type: "text", text: "No memory files found." }] };
           const queryTerms = query
             .toLowerCase()
             .split(/\s+/)

--- a/src/core/a2a-tools/security.ts
+++ b/src/core/a2a-tools/security.ts
@@ -84,11 +84,7 @@ export function createSecurityTools(sessionName: string): unknown[] {
             content: [
               {
                 type: "text",
-                text: JSON.stringify(
-                  { allowed: true, reason: "No security context available" },
-                  null,
-                  2,
-                ),
+                text: JSON.stringify({ allowed: true, reason: "No security context available" }, null, 2),
               },
             ],
           };

--- a/src/core/capability-catalog.ts
+++ b/src/core/capability-catalog.ts
@@ -55,8 +55,8 @@ export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
         hostedConfig: { ...hostedDefaults(), capability: "tts" },
       },
       {
-        source: "github:wopr-network/wopr-plugin-voice-whisper",
-        name: "wopr-plugin-voice-whisper",
+        source: "github:wopr-network/wopr-plugin-voice-whisper-local",
+        name: "wopr-plugin-voice-whisper-local",
         hostedConfig: { ...hostedDefaults(), capability: "stt" },
       },
     ],
@@ -68,33 +68,13 @@ export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
     description: "Generate images from text prompts",
     icon: "🎨",
     plugins: [
-      // Plugin repo created in WOP-571 — catalog entry is a forward reference
       {
         source: "github:wopr-network/wopr-plugin-imagegen",
         name: "wopr-plugin-imagegen",
         hostedConfig: { ...hostedDefaults(), capability: "image-gen" },
       },
-      {
-        source: "github:wopr-network/wopr-plugin-image-sdxl",
-        name: "wopr-plugin-image-sdxl",
-        hostedConfig: { ...hostedDefaults(), capability: "image-gen" },
-      },
     ],
     activatedMessage: "Image generation activated! 🎨",
-  },
-  {
-    id: "embeddings",
-    label: "Embeddings",
-    description: "Vector embeddings for semantic search and memory",
-    icon: "🧠",
-    plugins: [
-      {
-        source: "github:wopr-network/wopr-plugin-embeddings",
-        name: "wopr-plugin-embeddings",
-        hostedConfig: { ...hostedDefaults(), capability: "embeddings" },
-      },
-    ],
-    activatedMessage: "Embeddings activated! 🧠",
   },
   {
     id: "video-gen",
@@ -103,8 +83,8 @@ export const CAPABILITY_CATALOG: CapabilityCatalogEntry[] = [
     icon: "🎬",
     plugins: [
       {
-        source: "github:wopr-network/wopr-plugin-video",
-        name: "wopr-plugin-video",
+        source: "github:wopr-network/wopr-plugin-videogen",
+        name: "wopr-plugin-videogen",
         hostedConfig: { ...hostedDefaults(), capability: "video-gen" },
       },
     ],


### PR DESCRIPTION
**Repo:** wopr-network/wopr

## Summary

Fixes 4 incorrect/phantom repo references in `src/core/capability-catalog.ts` that would cause 404s when users try to install capabilities — breaking the plugin flywheel (revenue-critical).

- **Voice STT**: renamed `wopr-plugin-voice-whisper` → `wopr-plugin-voice-whisper-local` (correct repo name)
- **Image Gen SDXL**: removed entire entry — `wopr-plugin-image-sdxl` repo does not exist; `wopr-plugin-imagegen` remains as the sole image-gen plugin
- **Embeddings**: removed entire entry — `wopr-plugin-embeddings` repo does not exist
- **Video Gen**: renamed `wopr-plugin-video` → `wopr-plugin-videogen` (correct repo name)
- Updated `tests/unit/capability-activation.test.ts` to reflect corrected catalog (18/18 tests pass)
- Fixed pre-existing biome format issues in `src/core/a2a-tools/` (required by CI gate)

## Test plan

- [x] `npm run build` passes
- [x] `npm run check` (biome + tsc) passes
- [x] `npm test` passes — 985/985 tests across 39 files
- [x] `tests/unit/capability-activation.test.ts` — 18/18 tests pass specifically

Fixes WOP-616.