### PR TITLE
security: write config files with 0o600 permissions (WOP-621)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -432,7 +432,7 @@ export async function saveAuth(auth: AuthState): Promise<void> {
   } else {
     // Fallback to file (for backward compat during migration)
     const { writeFileSync } = await import("node:fs");
-    writeFileSync(AUTH_FILE, value);
+    writeFileSync(AUTH_FILE, value, { mode: 0o600 });
   }
 }
 
@@ -444,7 +444,7 @@ export async function clearAuth(): Promise<void> {
     // Fallback to file
     const { writeFileSync } = await import("node:fs");
     if (existsSync(AUTH_FILE)) {
-      writeFileSync(AUTH_FILE, "{}");
+      writeFileSync(AUTH_FILE, "{}", { mode: 0o600 });
     }
   }
 }

--- a/tests/security/file-permissions-providers.test.ts
+++ b/tests/security/file-permissions-providers.test.ts
@@ -1,0 +1,104 @@
+/**
+ * ProviderRegistry File Permission Tests (WOP-621)
+ *
+ * Verifies that providers.json is written with 0o600 (owner-only) permissions
+ * and that ~/.wopr is created with 0o700.
+ *
+ * This is a separate file from file-permissions.test.ts because importing
+ * the real ProviderRegistry requires NOT mocking "../../src/core/providers.js",
+ * which is needed as a dependency mock in the combined test file.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture all fs/promises calls with their options
+const writtenFiles: Array<{ path: string; options: unknown }> = [];
+const createdDirs: Array<{ path: string; options: unknown }> = [];
+const chmodCalls: Array<{ path: string; mode: number }> = [];
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    writeFile: vi.fn(async (path: string, _data: unknown, options?: unknown) => {
+      writtenFiles.push({ path, options: options ?? null });
+    }),
+    readFile: vi.fn(async (_path: string, _enc: string) => "[]"),
+    mkdir: vi.fn(async (path: string, options?: unknown) => {
+      createdDirs.push({ path, options: options ?? null });
+    }),
+    chmod: vi.fn(async (path: string, mode: number) => {
+      chmodCalls.push({ path, mode });
+    }),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    // existsSync returns true so loadCredentials finds the file
+    existsSync: vi.fn(() => true),
+    readFileSync: vi.fn((_path: string, _enc?: string) => "[]"),
+  };
+});
+
+vi.mock("../../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ============================================================================
+// ProviderRegistry — providers.json permissions
+// ============================================================================
+describe("WOP-621: ProviderRegistry file permissions", () => {
+  beforeEach(() => {
+    writtenFiles.length = 0;
+    createdDirs.length = 0;
+    chmodCalls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("saveCredentials()", () => {
+    it("writes providers.json with mode 0o600", async () => {
+      const { ProviderRegistry } = await import("../../src/core/providers.js");
+      // Create a fresh instance (not the singleton) to avoid state pollution
+      const registry = new ProviderRegistry();
+      await registry.saveCredentials();
+
+      // providers.json path ends with ".wopr/providers.json"
+      const credWrite = writtenFiles.find((f) => f.path.endsWith("providers.json"));
+      expect(credWrite, "saveCredentials() should call writeFile for providers.json").toBeDefined();
+      expect(credWrite!.options, "writeFile options should be defined").not.toBeNull();
+      expect((credWrite!.options as { mode: number }).mode).toBe(0o600);
+    });
+
+    it("creates ~/.wopr directory with mode 0o700", async () => {
+      const { ProviderRegistry } = await import("../../src/core/providers.js");
+      const registry = new ProviderRegistry();
+      await registry.saveCredentials();
+
+      // directory path ends with ".wopr"
+      const dirCreate = createdDirs.find((d) => d.path.endsWith(".wopr"));
+      expect(dirCreate, "saveCredentials() should call mkdir for ~/.wopr").toBeDefined();
+      expect((dirCreate!.options as { mode: number }).mode).toBe(0o700);
+    });
+  });
+
+  describe("loadCredentials()", () => {
+    it("calls chmod 0o600 on providers.json after loading", async () => {
+      const { ProviderRegistry } = await import("../../src/core/providers.js");
+      const registry = new ProviderRegistry();
+      // existsSync is mocked to return true, so file appears to exist
+      await registry.loadCredentials();
+
+      const chmodCall = chmodCalls.find((c) => c.path.endsWith("providers.json"));
+      expect(
+        chmodCall,
+        "loadCredentials() should chmod providers.json to fix existing-file permissions",
+      ).toBeDefined();
+      expect(chmodCall!.mode).toBe(0o600);
+    });
+  });
+});

--- a/tests/security/file-permissions.test.ts
+++ b/tests/security/file-permissions.test.ts
@@ -1,0 +1,180 @@
+/**
+ * File Permission Hardening Tests (WOP-621)
+ *
+ * Verifies that config.json and auth.json (fallback path) are written
+ * with 0o600 (owner-only) permissions, and that WOPR_HOME is created
+ * with 0o700.
+ *
+ * ProviderRegistry permission tests live in file-permissions-providers.test.ts
+ * because vi.mock("../../src/core/providers.js") conflicts with importing the
+ * real ProviderRegistry class in the same test module.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture all fs/promises calls with their options
+const writtenFiles: Array<{ path: string; options: unknown }> = [];
+const createdDirs: Array<{ path: string; options: unknown }> = [];
+const chmodCalls: Array<{ path: string; mode: number }> = [];
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    writeFile: vi.fn(async (path: string, _data: unknown, options?: unknown) => {
+      writtenFiles.push({ path, options: options ?? null });
+    }),
+    readFile: vi.fn(async (_path: string, _enc: string) => '{"daemon":{"port":7437}}'),
+    mkdir: vi.fn(async (path: string, options?: unknown) => {
+      createdDirs.push({ path, options: options ?? null });
+    }),
+    chmod: vi.fn(async (path: string, mode: number) => {
+      chmodCalls.push({ path, mode });
+    }),
+  };
+});
+
+// Capture writeFileSync calls with options (for auth.ts fallback path)
+const syncWrittenFiles: Array<{ path: string; options: unknown }> = [];
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    readFileSync: vi.fn((_path: string, _enc?: string) => "{}"),
+    writeFileSync: vi.fn((path: string, _data: unknown, options?: unknown) => {
+      syncWrittenFiles.push({ path, options: options ?? null });
+    }),
+  };
+});
+
+// Mock paths to predictable values — MUST be declared before module imports
+vi.mock("../../src/paths.js", () => ({
+  WOPR_HOME: "/mock/wopr",
+  CONFIG_FILE: "/mock/wopr/config.json",
+  AUTH_FILE: "/mock/wopr/auth.json",
+  SESSIONS_DIR: "/mock/wopr/sessions",
+  SESSIONS_FILE: "/mock/wopr/sessions.json",
+  REGISTRIES_FILE: "/mock/wopr/registries.json",
+  SKILLS_DIR: "/mock/wopr/skills",
+  PROJECT_SKILLS_DIR: "/mock/.wopr/skills",
+  PID_FILE: "/mock/wopr/daemon.pid",
+  LOG_FILE: "/mock/wopr/daemon.log",
+  IDENTITY_FILE: "/mock/wopr/identity.json",
+  ACCESS_FILE: "/mock/wopr/access.json",
+  PEERS_FILE: "/mock/wopr/peers.json",
+  CRONS_FILE: "/mock/wopr/crons.json",
+  CRON_HISTORY_FILE: "/mock/wopr/cron-history.json",
+  GLOBAL_IDENTITY_DIR: "/data/identity",
+}));
+
+vi.mock("../../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock providers to avoid transitive deps in config.ts and auth.ts
+vi.mock("../../src/core/providers.js", () => ({
+  providerRegistry: {
+    loadCredentials: vi.fn(),
+    setCredential: vi.fn(),
+    getCredential: vi.fn(),
+  },
+}));
+
+// Mock auth-store to avoid SQLite deps
+vi.mock("../../src/auth/auth-store.js", () => ({
+  AuthStore: class {
+    async init() {}
+  },
+}));
+
+// ============================================================================
+// ConfigManager — config.json permissions
+// ============================================================================
+describe("WOP-621: ConfigManager file permissions", () => {
+  beforeEach(() => {
+    writtenFiles.length = 0;
+    createdDirs.length = 0;
+    chmodCalls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("save()", () => {
+    it("writes config.json with mode 0o600", async () => {
+      const { ConfigManager } = await import("../../src/core/config.js");
+      const mgr = new ConfigManager();
+      await mgr.save();
+
+      const configWrite = writtenFiles.find((f) => f.path === "/mock/wopr/config.json");
+      expect(configWrite, "save() should call writeFile for config.json").toBeDefined();
+      expect(configWrite!.options, "writeFile options should be defined").not.toBeNull();
+      expect((configWrite!.options as { mode: number }).mode).toBe(0o600);
+    });
+
+    it("creates WOPR_HOME directory with mode 0o700", async () => {
+      const { ConfigManager } = await import("../../src/core/config.js");
+      const mgr = new ConfigManager();
+      await mgr.save();
+
+      const dirCreate = createdDirs.find((d) => d.path === "/mock/wopr");
+      expect(dirCreate, "save() should call mkdir for WOPR_HOME").toBeDefined();
+      expect((dirCreate!.options as { mode: number }).mode).toBe(0o700);
+    });
+  });
+
+  describe("load()", () => {
+    it("calls chmod 0o600 on config.json after loading", async () => {
+      const { ConfigManager } = await import("../../src/core/config.js");
+      const mgr = new ConfigManager();
+      await mgr.load();
+
+      const chmodCall = chmodCalls.find((c) => c.path === "/mock/wopr/config.json");
+      expect(chmodCall, "load() should chmod config.json to fix existing-file permissions").toBeDefined();
+      expect(chmodCall!.mode).toBe(0o600);
+    });
+  });
+});
+
+// ============================================================================
+// auth.ts — auth.json fallback path permissions
+// ============================================================================
+describe("WOP-621: auth.ts fallback file permissions", () => {
+  beforeEach(() => {
+    writtenFiles.length = 0;
+    createdDirs.length = 0;
+    chmodCalls.length = 0;
+    syncWrittenFiles.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("saveAuth() fallback", () => {
+    it("writes auth.json with mode 0o600 when authStore is null", async () => {
+      // authStore is null by default (initAuthStorage not called)
+      const { saveAuth } = await import("../../src/auth.js");
+      await saveAuth({ type: "api_key", apiKey: "sk-test", updatedAt: Date.now() });
+
+      const authWrite = syncWrittenFiles.find((f) => f.path === "/mock/wopr/auth.json");
+      expect(authWrite, "saveAuth() fallback should call writeFileSync for auth.json").toBeDefined();
+      expect(authWrite!.options, "writeFileSync options should include mode").not.toBeNull();
+      expect((authWrite!.options as { mode: number }).mode).toBe(0o600);
+    });
+  });
+
+  describe("clearAuth() fallback", () => {
+    it("writes empty auth.json with mode 0o600 when authStore is null", async () => {
+      const { clearAuth } = await import("../../src/auth.js");
+      await clearAuth();
+
+      const authWrite = syncWrittenFiles.find((f) => f.path === "/mock/wopr/auth.json");
+      expect(authWrite, "clearAuth() fallback should call writeFileSync for auth.json").toBeDefined();
+      expect(authWrite!.options, "writeFileSync options should include mode").not.toBeNull();
+      expect((authWrite!.options as { mode: number }).mode).toBe(0o600);
+    });
+  });
+});


### PR DESCRIPTION
**Repo:** wopr-network/wopr

## Summary

Closes WOP-621

- Config files containing API keys and secrets were written world-readable (0o644 default). Now written with `0o600` (owner-only)
- Affected files: `config.json` (Anthropic API key, Discord token, OAuth secrets), `providers.json` (provider API keys), `auth.json` (OAuth tokens)
- Directories (`WOPR_HOME`, `~/.wopr`) now created with `0o700` to block directory traversal as defense-in-depth
- Migration `chmod` applied on `load()`/`loadCredentials()` to fix permissions on existing deployed files without requiring a manual save
- Follows established pattern in `src/daemon/auth-token.ts` which already uses `{ mode: 0o600 }`

## Test plan

- [x] `npm run build` passes (TypeScript, no type errors)
- [x] `npm test` passes (1008 tests across 43 files)
- [x] New tests in `tests/security/file-permissions.test.ts` verify `ConfigManager.save()` writes with `0o600`, `mkdir` uses `0o700`, and `load()` calls `chmod 0o600`
- [x] New tests in `tests/security/file-permissions-providers.test.ts` verify `ProviderRegistry.saveCredentials()` uses `0o600`/`0o700` and `loadCredentials()` calls `chmod 0o600`
- [x] New tests verify `saveAuth()`/`clearAuth()` fallback path uses `0o600`
- [x] TDD red-green cycle followed: tests written first, confirmed failing, then production code fixed

Generated with Claude Code