### PR TITLE
fix: restrict daemon CORS to localhost origins (WOP-622)

### DIFF
--- a/src/daemon/cors.ts
+++ b/src/daemon/cors.ts
@@ -1,0 +1,30 @@
+/**
+ * CORS configuration for the WOPR daemon (WOP-622)
+ *
+ * Restricts cross-origin requests to known localhost origins only.
+ * The daemon port is read from WOPR_DAEMON_PORT (default: 7437) so
+ * the allowlist stays in sync when the port is customised.
+ */
+
+const DEFAULT_DAEMON_PORT = 7437;
+
+/**
+ * Build the list of allowed CORS origins for the daemon.
+ *
+ * Always includes:
+ *   - http://localhost:<port>     — daemon itself / CLI tools
+ *   - http://127.0.0.1:<port>    — same, numeric loopback
+ *   - http://localhost:3000       — wopr-platform-ui dev server
+ *
+ * The daemon port is resolved from `WOPR_DAEMON_PORT` at call time so
+ * that tests can override it via environment variable.
+ */
+export function buildCorsOrigins(): string[] {
+  const port = parseInt(process.env.WOPR_DAEMON_PORT || String(DEFAULT_DAEMON_PORT), 10);
+
+  return [
+    `http://localhost:${port}`,
+    `http://127.0.0.1:${port}`,
+    "http://localhost:3000", // wopr-platform-ui dev
+  ];
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -13,6 +13,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import { logger } from "hono/logger";
+import { buildCorsOrigins } from "./cors.js";
 // Core imports for daemon functionality
 import { getCapabilityHealthProber } from "../core/capability-health.js";
 import { config as centralConfig } from "../core/config.js";
@@ -81,8 +82,8 @@ export interface DaemonConfig {
 export function createApp(healthMonitor?: HealthMonitor) {
   const app = new Hono();
 
-  // Middleware
-  app.use("*", cors());
+  // Middleware — restrict CORS to known localhost origins (WOP-622)
+  app.use("*", cors({ origin: buildCorsOrigins(), credentials: true }));
   app.use("*", logger());
   app.use("*", rateLimit());
   app.use("*", bearerAuth());

--- a/tests/unit/cors.test.ts
+++ b/tests/unit/cors.test.ts
@@ -1,0 +1,147 @@
+/**
+ * CORS Configuration Tests (WOP-622)
+ *
+ * Verifies that the daemon CORS policy:
+ * - Allows requests from known localhost origins
+ * - Rejects cross-origin requests from unknown origins
+ * - Allows requests with credentials from whitelisted origins
+ * - Reflects the daemon port from WOPR_DAEMON_PORT env var
+ */
+
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildCorsOrigins } from "../../src/daemon/cors.js";
+
+function createTestApp(origins: string[]) {
+  const app = new Hono();
+  app.use(
+    "*",
+    cors({
+      origin: origins,
+      credentials: true,
+    }),
+  );
+  app.get("/health", (c) => c.json({ status: "ok" }));
+  return app;
+}
+
+describe("buildCorsOrigins", () => {
+  const originalEnv = process.env.WOPR_DAEMON_PORT;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.WOPR_DAEMON_PORT;
+    } else {
+      process.env.WOPR_DAEMON_PORT = originalEnv;
+    }
+  });
+
+  it("includes localhost and 127.0.0.1 on the default port 7437", () => {
+    delete process.env.WOPR_DAEMON_PORT;
+    const origins = buildCorsOrigins();
+    expect(origins).toContain("http://localhost:7437");
+    expect(origins).toContain("http://127.0.0.1:7437");
+  });
+
+  it("includes platform-ui dev server origin http://localhost:3000", () => {
+    delete process.env.WOPR_DAEMON_PORT;
+    const origins = buildCorsOrigins();
+    expect(origins).toContain("http://localhost:3000");
+  });
+
+  it("reflects custom port from WOPR_DAEMON_PORT env var", () => {
+    process.env.WOPR_DAEMON_PORT = "9000";
+    const origins = buildCorsOrigins();
+    expect(origins).toContain("http://localhost:9000");
+    expect(origins).toContain("http://127.0.0.1:9000");
+  });
+
+  it("does not include wildcard origin", () => {
+    const origins = buildCorsOrigins();
+    expect(origins.some((o) => o === "*")).toBe(false);
+  });
+
+  it("returns only string origins (no wildcard function)", () => {
+    const origins = buildCorsOrigins();
+    for (const origin of origins) {
+      expect(typeof origin).toBe("string");
+    }
+  });
+});
+
+describe("CORS middleware with localhost whitelist", () => {
+  it("reflects http://localhost:7437 in Access-Control-Allow-Origin", async () => {
+    const app = createTestApp(buildCorsOrigins());
+    const res = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:7437",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect([200, 204]).toContain(res.status);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:7437");
+  });
+
+  it("reflects http://127.0.0.1:7437 in Access-Control-Allow-Origin", async () => {
+    const app = createTestApp(buildCorsOrigins());
+    const res = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://127.0.0.1:7437",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect([200, 204]).toContain(res.status);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://127.0.0.1:7437");
+  });
+
+  it("reflects http://localhost:3000 in Access-Control-Allow-Origin", async () => {
+    const app = createTestApp(buildCorsOrigins());
+    const res = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:3000",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect([200, 204]).toContain(res.status);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+  });
+
+  it("does not allow unknown external origin https://evil.example.com", async () => {
+    const app = createTestApp(buildCorsOrigins());
+    const res = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://evil.example.com",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    const allowOrigin = res.headers.get("Access-Control-Allow-Origin");
+    expect(allowOrigin).not.toBe("*");
+    expect(allowOrigin).not.toBe("https://evil.example.com");
+  });
+
+  it("does not set * for simple GET from unknown origin", async () => {
+    const app = createTestApp(buildCorsOrigins());
+    const res = await app.request("/health", {
+      headers: { Origin: "https://malicious.example.com" },
+    });
+    const allowOrigin = res.headers.get("Access-Control-Allow-Origin");
+    expect(allowOrigin).not.toBe("*");
+  });
+
+  it("sets Access-Control-Allow-Credentials: true for whitelisted origin", async () => {
+    const app = createTestApp(buildCorsOrigins());
+    const res = await app.request("/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:3000",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+});


### PR DESCRIPTION
**Repo:** wopr-network/wopr

## Summary
Closes WOP-622

- Replace bare `cors()` call (which sets `Access-Control-Allow-Origin: *`) with an explicit localhost whitelist
- Extract `buildCorsOrigins()` into `src/daemon/cors.ts` — reads `WOPR_DAEMON_PORT` dynamically so the allowed origins stay in sync with whatever port the daemon is configured to use
- Add `credentials: true` so browser clients can send bearer tokens from whitelisted origins
- Add 11 tests in `tests/unit/cors.test.ts` covering: default port, custom port via env var, no wildcard, correct origin reflection for each whitelisted origin, unknown origin rejection, and credentials header

## Allowed origins
- `http://localhost:7437` / `http://127.0.0.1:7437` — daemon itself (port from `WOPR_DAEMON_PORT`, default 7437)
- `http://localhost:3000` — wopr-platform-ui dev server

## Test plan
- [x] `bun run build` passes (tsc exit 0)
- [x] `bun test tests/unit/cors.test.ts` — 11/11 pass
- [x] Pre-existing failures in `auth.test.ts` and `readiness.test.ts` confirmed pre-existing on `main` (bun vitest compat issues, not introduced by this change)
- [x] Unknown origin `https://evil.example.com` does not receive `Access-Control-Allow-Origin: *` or its own origin echoed back

Generated with Claude Code