### PR TITLE
docs: add session memory recall to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,9 @@ Issue descriptions start with `**Repo:** wopr-network/wopr` (required for CodeRa
 - Conventional commits: `feat:`, `fix:`, `test:`, `refactor:`, `security:`, `docs:`, `chore:`
 - `npm run check` must pass before every commit (lint + type check)
 - Daemon is Hono-based (not Express). WebSocket via `@hono/node-ws`.
+
+## Session Memory
+
+At the start of every WOPR session, **read `~/.wopr-memory.md` if it exists.** It contains recent session context: which repos were active, what branches are in flight, and how many uncommitted changes exist. Use it to orient quickly without re-investigating.
+
+The `Stop` hook writes to this file automatically at session end. Only non-main branches are recorded — if everything is on `main`, nothing is written for that repo.


### PR DESCRIPTION
Adds instruction for Claude Code agents to read `~/.wopr-memory.md` at session start for instant context on active branches and in-progress work.