### PR TITLE
test: add return value test for repo.transaction() (WOP-836)

### DIFF
--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -595,6 +595,16 @@ describe("Storage Module (WOP-545)", () => {
       const all = await repo.findMany();
       expect(all).toHaveLength(0);
     });
+
+    it("should return value from repo.transaction() (WOP-836)", async () => {
+      const repo = storage.getRepository<TestRecord>("test", "users");
+      const result = await repo.transaction(async (trxRepo) => {
+        const inserted = await trxRepo.insert({ id: "1", name: "Alice", age: 30 });
+        return inserted;
+      });
+      expect(result.id).toBe("1");
+      expect(result.name).toBe("Alice");
+    });
   });
 
   describe("9. JSON column round-trip", () => {


### PR DESCRIPTION
## Summary
Closes WOP-836

- The `transaction()` method in `DrizzleRepository` already had a real implementation using `BEGIN`/`COMMIT`/`ROLLBACK` (not the no-op described in the original issue description)
- Two of the three required acceptance-criteria tests were already present (atomic commit, rollback on error)
- Adds the missing third test: verifying `repo.transaction()` correctly returns the value produced by its callback

## Test plan
- [x] `npm test` passes (1070 tests, all green)
- [x] New test: `should return value from repo.transaction() (WOP-836)` in `tests/unit/storage.test.ts`
- [x] Existing tests for atomic commit and rollback continue to pass

Generated with Claude Code