### PR TITLE
ci: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds `merge_group:` trigger to CI workflow so all jobs run in the merge queue context
- Prepares the repo for GitHub merge queue activation when the org upgrades to Team plan
- Matches the pattern already in place on `wopr-platform` and `wopr-platform-ui`

No behaviour change until branch protection + merge queue is enabled in repo settings.