### PR TITLE
feat: add superpower category and marketplace metadata to PluginManifest (WOP-1010)

### DIFF
--- a/src/daemon/openapi/manifest-schema.ts
+++ b/src/daemon/openapi/manifest-schema.ts
@@ -121,4 +121,9 @@ export const PluginManifestSchema = z.object({
   dependencies: z.array(z.string()).optional(),
   conflicts: z.array(z.string()).optional(),
   lifecycle: PluginLifecycleSchema.optional(),
+  marketplace: z
+    .object({
+      pitch: z.string().optional(),
+    })
+    .optional(),
 });

--- a/src/daemon/routes/marketplace.ts
+++ b/src/daemon/routes/marketplace.ts
@@ -108,30 +108,34 @@ marketplaceRouter.get(
               author: manifest.author,
               license: manifest.license,
               homepage: manifest.homepage,
+              marketplace: manifest.marketplace,
             }
           : null,
       });
     }
 
     // 2. Append discoverable plugins from npm/GitHub (not installed)
-    try {
-      const discovered = await searchPlugins(query);
-      for (const d of discovered) {
-        if (seen.has(d.name)) continue;
-        seen.add(d.name);
-        results.push({
-          name: d.name,
-          version: d.version || "unknown",
-          description: d.description || null,
-          source: d.source,
-          installed: d.installed || false,
-          enabled: false,
-          loaded: false,
-          manifest: null,
-        });
+    // Skip if category or capability filter is active — discovered plugins have no manifest to filter on
+    if (!category && !capability) {
+      try {
+        const discovered = await searchPlugins(query);
+        for (const d of discovered) {
+          if (seen.has(d.name)) continue;
+          seen.add(d.name);
+          results.push({
+            name: d.name,
+            version: d.version || "unknown",
+            description: d.description || null,
+            source: d.source,
+            installed: d.installed || false,
+            enabled: false,
+            loaded: false,
+            manifest: null,
+          });
+        }
+      } catch {
+        // Search failed (offline, etc.) — return installed-only results
       }
-    } catch {
-      // Search failed (offline, etc.) — return installed-only results
     }
 
     return c.json({
@@ -231,6 +235,7 @@ marketplaceRouter.get(
       conflicts: manifest.conflicts || null,
       minCoreVersion: manifest.minCoreVersion || null,
       lifecycle: manifest.lifecycle || null,
+      marketplace: manifest.marketplace || null,
     });
   },
 );

--- a/src/plugin-types/index.ts
+++ b/src/plugin-types/index.ts
@@ -91,6 +91,7 @@ export type {
   CapabilityRequirement,
   InstallMethod,
   ManifestProviderEntry,
+  MarketplaceMetadata,
   NetworkRequirements,
   PluginCapability,
   PluginCategory,

--- a/src/plugin-types/manifest.ts
+++ b/src/plugin-types/manifest.ts
@@ -131,6 +131,20 @@ export interface SetupStep {
  * the basic WOPRPlugin interface to support WaaS marketplace and
  * auto-configuration features.
  */
+
+/**
+ * Marketplace metadata for plugin discovery and presentation.
+ * Used by the platform UI to render plugin detail pages.
+ */
+export interface MarketplaceMetadata {
+  /**
+   * Relative path to the plugin's pitch markdown file (e.g., "./SUPERPOWER.md").
+   * The platform renders this file as the marketplace detail page.
+   * Falls back to manifest.description if the file is absent.
+   */
+  pitch?: string;
+}
+
 export interface PluginManifest {
   /** Plugin package name (e.g., "@wopr-network/plugin-discord") */
   name: string;
@@ -199,6 +213,9 @@ export interface PluginManifest {
 
   /** Lifecycle behavior declarations */
   lifecycle?: PluginLifecycle;
+
+  /** Marketplace presentation metadata */
+  marketplace?: MarketplaceMetadata;
 }
 
 /**

--- a/tests/unit/marketplace.test.ts
+++ b/tests/unit/marketplace.test.ts
@@ -40,6 +40,15 @@ const installedPlugins = [
     enabled: false,
     installedAt: 1700000001000,
   },
+  {
+    name: "voice-superpower",
+    version: "1.0.0",
+    description: "Voice superpower",
+    source: "npm",
+    path: "/plugins/voice-superpower",
+    enabled: true,
+    installedAt: 1700000002000,
+  },
 ];
 
 const discordManifest = {
@@ -83,10 +92,28 @@ const discordManifest = {
   conflicts: null,
   minCoreVersion: "1.0.0",
   lifecycle: { hotReload: true, shutdownBehavior: "graceful" },
+  marketplace: {
+    pitch: "./SUPERPOWER.md",
+  },
+};
+
+const voiceSuperpowerManifest = {
+  name: "voice-superpower",
+  version: "1.0.0",
+  description: "Give your bot a voice",
+  author: "WOPR Team",
+  capabilities: ["voice", "persona"],
+  category: "superpower",
+  tags: ["voice", "tts", "stt"],
+  marketplace: {
+    pitch: "./SUPERPOWER.md",
+  },
+  dependencies: ["@wopr-network/plugin-tts", "@wopr-network/plugin-stt"],
 };
 
 const mockManifests = new Map<string, any>();
 mockManifests.set("discord", discordManifest);
+mockManifests.set("voice-superpower", voiceSuperpowerManifest);
 
 const mockLoadedPlugins = new Map<string, any>();
 mockLoadedPlugins.set("discord", { plugin: {}, context: {} });
@@ -97,6 +124,7 @@ vi.mock("../../src/plugins.js", () => ({
   getAllPluginManifests: vi.fn(() => mockManifests),
   readPluginManifest: vi.fn((path: string) => {
     if (path.includes("discord")) return mockManifests.get("discord");
+    if (path.includes("voice-superpower")) return mockManifests.get("voice-superpower");
     return undefined;
   }),
   getLoadedPlugin: vi.fn((name: string) => mockLoadedPlugins.get(name)),
@@ -201,6 +229,24 @@ describe("GET /api/marketplace", () => {
 
     expect(body.plugins).toHaveLength(1);
   });
+
+  it("should include marketplace metadata in browse results", async () => {
+    const res = await app.request("/api/marketplace");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const discord = body.plugins.find((p: any) => p.name === "discord");
+    expect(discord.manifest.marketplace).toEqual({ pitch: "./SUPERPOWER.md" });
+  });
+
+  it("should filter by superpower category", async () => {
+    const res = await app.request("/api/marketplace?category=superpower");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plugins.length).toBe(1);
+    expect(body.plugins[0].name).toBe("voice-superpower");
+    expect(body.plugins[0].manifest.category).toBe("superpower");
+    expect(body.plugins[0].manifest.marketplace).toEqual({ pitch: "./SUPERPOWER.md" });
+  });
 });
 
 describe("GET /api/marketplace/:name", () => {
@@ -240,6 +286,13 @@ describe("GET /api/marketplace/:name", () => {
     expect(body.name).toBe("openai");
     expect(body.manifest).toBeNull();
     expect(body.installed).toBe(true);
+  });
+
+  it("should include marketplace metadata in detail response", async () => {
+    const res = await app.request("/api/marketplace/discord");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.marketplace).toEqual({ pitch: "./SUPERPOWER.md" });
   });
 });
 

--- a/tests/unit/plugin-loading.test.ts
+++ b/tests/unit/plugin-loading.test.ts
@@ -140,6 +140,42 @@ describe("readPluginManifest", () => {
     const manifest = readPluginManifest("/nonexistent/path", undefined);
     expect(manifest).toBeUndefined();
   });
+
+  it("should read marketplace metadata from manifest", () => {
+    const mockPkg = {
+      wopr: {
+        name: "test-superpower",
+        version: "1.0.0",
+        description: "A superpower plugin",
+        capabilities: ["voice", "persona"],
+        category: "superpower",
+        marketplace: {
+          pitch: "./SUPERPOWER.md",
+        },
+        dependencies: ["@wopr-network/plugin-tts", "@wopr-network/plugin-stt"],
+      },
+    };
+
+    const result = readPluginManifest("/fake/path", mockPkg);
+    expect(result).toBeDefined();
+    expect(result!.category).toBe("superpower");
+    expect(result!.marketplace).toEqual({ pitch: "./SUPERPOWER.md" });
+  });
+
+  it("should handle manifest without marketplace field", () => {
+    const mockPkg = {
+      wopr: {
+        name: "test-utility",
+        version: "1.0.0",
+        description: "A utility plugin",
+        capabilities: ["tool"],
+      },
+    };
+
+    const result = readPluginManifest("/fake/path", mockPkg);
+    expect(result).toBeDefined();
+    expect(result!.marketplace).toBeUndefined();
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Closes WOP-1010

- Add `MarketplaceMetadata` interface (`pitch` field) to `src/plugin-types/manifest.ts`
- Add optional `marketplace` field to `PluginManifest` interface
- Re-export `MarketplaceMetadata` from `src/plugin-types/index.ts`
- Update Zod validation schema in `src/daemon/openapi/manifest-schema.ts`
- Surface `marketplace` in both browse and detail responses in `src/daemon/routes/marketplace.ts`
- Fix: skip discovered (no-manifest) plugins when `category` or `capability` filter is active

## Test plan
- [x] `npm run build` passes (tsc exit 0)
- [x] `tests/unit/marketplace.test.ts` — 15/15 pass (includes new tests for marketplace metadata in browse/detail and superpower category filter)
- [x] `tests/unit/plugin-loading.test.ts` — 17/17 pass (includes new tests for marketplace field passthrough)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `marketplace` metadata to plugin manifests and include it in `GET /api/marketplace` and `GET /api/marketplace/:name` responses for superpower categorization (WOP-1010)
> Add optional `marketplace.pitch` to manifest validation and expose `manifest.marketplace` in marketplace browse and detail responses; skip remote discovery when `category` or `capability` filters are present and ignore discovery errors.
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1010](ticket:jira/WOP-1010) by adding manifest `marketplace` metadata and wiring it through marketplace APIs.
>
> #### 📍Where to Start
> Start with the `marketplaceRouter.get("/")` handler in [marketplace.ts](https://github.com/wopr-network/wopr/pull/1242/files#diff-189903f86703e487c61d9195c904f52194bee1b4e561a1675ca330bca109572c), then review the schema change in [manifest-schema.ts](https://github.com/wopr-network/wopr/pull/1242/files#diff-3a39aeee3b433a9fa8621b886ee2408f765cead6ae7bcf3ed457dd0aa7107d87).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab3ae63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->