### PR TITLE
chore: migrate base image from Alpine to Debian bookworm-slim (WOP-1039)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 # Stage 1: Build
-FROM node:24-alpine AS builder
+FROM node:24-bookworm-slim AS builder
 
 WORKDIR /app
 
-# build-base + python3 needed for better-sqlite3 native addon (node-gyp)
-RUN apk add --no-cache build-base python3
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential python3 && rm -rf /var/lib/apt/lists/*
 
-# Install pnpm
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
 # Copy package files
@@ -24,7 +23,7 @@ RUN pnpm run build
 RUN pnpm prune --prod
 
 # Stage 2: Runtime
-FROM node:24-alpine
+FROM node:24-bookworm-slim
 
 # Patch npm's bundled transitive deps and install pnpm via npm (not corepack)
 # Installing via npm avoids the corepack cache with its bundled vulnerable node-tar
@@ -32,8 +31,10 @@ RUN npm install -g npm@latest pnpm@latest
 
 WORKDIR /app
 
-# Runtime system deps only — no build-base, no python3
-RUN apk add --no-cache git sudo curl ca-certificates jq docker-cli su-exec
+# Runtime system deps only — no build-essential, no python3
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git sudo curl ca-certificates jq docker.io && \
+    rm -rf /var/lib/apt/lists/*
 
 # Make node user a passwordless sudoer
 RUN echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -1,15 +1,15 @@
 # Slim multi-tenant service image for WOPR bots
 # - Multi-stage build: build deps stay out of runtime image
-# - Alpine base for minimal footprint
+# - Debian bookworm-slim base for glibc + apt compatibility
 # - Production deps only, non-root user
 # - V8 heap capped at 96MB per container
 #
-# Target: < 150MB image, < 100MB idle memory
+# Target: < 200MB image, < 100MB idle memory
 #
 # For self-hosted power-user image, see Dockerfile
 
 # --- Build stage ---
-FROM node:24-alpine AS build
+FROM node:24-bookworm-slim AS build
 
 WORKDIR /app
 
@@ -29,12 +29,13 @@ COPY src/ ./src/
 RUN pnpm run build
 
 # --- Production deps stage ---
-FROM node:24-alpine AS deps
+FROM node:24-bookworm-slim AS deps
 
 WORKDIR /app
 
-# build-base + python3 needed for better-sqlite3 native addon (node-gyp)
-RUN apk add --no-cache build-base python3
+# build-essential + python3 needed for better-sqlite3 native addon (node-gyp)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential python3 && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable && corepack prepare pnpm@9.15.4 --activate
 
@@ -44,10 +45,10 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
 # Remove corepack cache — not needed after install, must not leak into runtime
-RUN rm -rf /root/.cache/node/corepack /root/.local/share/pnpm
+RUN rm -rf /root/.cache
 
 # --- Runtime stage ---
-FROM node:24-alpine
+FROM node:24-bookworm-slim
 
 WORKDIR /app
 
@@ -59,7 +60,9 @@ WORKDIR /app
 # Patch npm's bundled transitive deps (tar, minimatch CVEs)
 RUN npm install -g npm@latest
 
-RUN apk add --no-cache git ca-certificates jq tini
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates jq tini && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy production node_modules from deps stage
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
Closes WOP-1039

- Replace `node:24-alpine` with `node:24-bookworm-slim` in all stages of both `Dockerfile` and `Dockerfile.service`
- Replace `apk add` with `apt-get update && apt-get install -y --no-install-recommends ... && rm -rf /var/lib/apt/lists/*`
- Replace `build-base` with `build-essential`
- Remove `su-exec` (not needed on Debian — node user sudoer pattern works natively)
- Install `tini` via `apt-get` instead of `apk`
- Replace `docker-cli` with `docker.io` (Debian package name)
- Update size target comment in `Dockerfile.service` from `< 150MB` to `< 200MB` (Debian base is larger than Alpine)

## Test plan
- [ ] `Dockerfile` builds cleanly in CI
- [ ] `Dockerfile.service` builds cleanly in CI
- [ ] Trivy scan passes on both images
- [ ] `better-sqlite3` native addon compiles without extra workarounds
- [ ] Both entrypoint scripts work unchanged

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate Docker build and runtime images from `node:24-alpine` to `node:24-bookworm-slim` to align with WOP-1039
> Switch base images to Debian bookworm-slim and replace `apk` installs with `apt-get` for build tools and runtime packages, removing `su-exec` and adding APT cache cleanup in both Dockerfiles.
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1039](ticket:jira/WOP-1039) by moving images to Debian bookworm-slim and updating package management to `apt-get`.
>
> #### 📍Where to Start
> Start with the base image and package changes in [Dockerfile](https://github.com/wopr-network/wopr/pull/1254/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557), then review analogous updates in [Dockerfile.service](https://github.com/wopr-network/wopr/pull/1254/files#diff-bf20ab3538b5a513fc4ad507d35f57acb2a2eb8120f462a3d326342b98617810).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8800b2f. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base images from Alpine to Debian bookworm-slim across build and runtime stages.
  * Adjusted package managers and dependencies to align with Debian-based images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->