### PR TITLE
feat: setup context providers — plugins inject AI instructions for setup (WOP-1054)

### DIFF
--- a/src/plugin-types/context.ts
+++ b/src/plugin-types/context.ts
@@ -14,6 +14,22 @@ import type { WOPREventBus, WOPRHookManager } from "./events.js";
 import type { AdapterCapability, ProviderOption } from "./manifest.js";
 
 /**
+ * Input provided to a setup context provider so it can generate
+ * context-aware setup instructions.
+ */
+export interface SetupContextInput {
+  pluginId: string;
+  configSchema: ConfigSchema;
+  partialConfig: Record<string, unknown>;
+}
+
+/**
+ * A function that returns setup instructions to prepend to the
+ * system prompt during plugin configuration.
+ */
+export type SetupContextProvider = (input: SetupContextInput) => string;
+
+/**
  * Multimodal message with optional images.
  */
 export interface MultimodalMessage {
@@ -245,6 +261,9 @@ export interface WOPRPluginContext {
 
   /** Register a health probe for a capability provider this plugin provides */
   registerHealthProbe?(capability: string, providerId: string, probe: () => Promise<boolean>): void;
+
+  // Setup context providers - plugins provide AI instructions for their own setup flow
+  registerSetupContextProvider(fn: SetupContextProvider): void;
 
   // Storage API - plugin-extensible database storage
   storage: StorageApi;

--- a/src/plugins/context-factory.ts
+++ b/src/plugins/context-factory.ts
@@ -37,6 +37,7 @@ import type {
   ContextProvider,
   InstalledPlugin,
   PluginInjectOptions,
+  SetupContextProvider,
   UiComponentExtension,
   WebUiExtension,
   WOPRPluginContext,
@@ -57,6 +58,7 @@ import {
   configSchemas,
   PLUGINS_DIR,
   providerPlugins,
+  setupContextProviders,
   uiComponents,
   webUiExtensions,
 } from "./state.js";
@@ -296,6 +298,10 @@ export function createPluginContext(
 
     registerHealthProbe(capability: string, providerId: string, probe: () => Promise<boolean>): void {
       getCapabilityHealthProber().registerProbe(capability, providerId, probe);
+    },
+
+    registerSetupContextProvider(fn: SetupContextProvider): void {
+      setupContextProviders.set(pluginName, fn);
     },
 
     // Storage API - plugin-extensible database storage

--- a/src/plugins/setup-context.ts
+++ b/src/plugins/setup-context.ts
@@ -1,0 +1,65 @@
+/**
+ * Setup context injection — registers a temporary ContextProvider
+ * during plugin setup that injects the plugin's setup instructions
+ * into the active session's system prompt.
+ */
+
+import type { ContextProvider, MessageInfo } from "../core/context.js";
+import { registerContextProvider, unregisterContextProvider } from "../core/context.js";
+import { logger } from "../logger.js";
+import { configSchemas, setupContextProviders } from "./state.js";
+
+/** Generate a deterministic context provider name for a setup session */
+function setupProviderName(pluginId: string, sessionId: string): string {
+  return `setup:${pluginId}:${sessionId}`;
+}
+
+/**
+ * Begin setup context injection for a plugin in a session.
+ * Registers a temporary ContextProvider that calls the plugin's
+ * SetupContextProvider and injects the result as a system prompt fragment.
+ *
+ * No-op if the plugin has no registered SetupContextProvider.
+ */
+export function beginSetupContext(pluginId: string, sessionId: string, partialConfig: Record<string, unknown>): void {
+  const provider = setupContextProviders.get(pluginId);
+  if (!provider) {
+    logger.debug(`[setup-context] No setup context provider for ${pluginId}, skipping`);
+    return;
+  }
+
+  const schema = configSchemas.get(pluginId) ?? { title: "", fields: [] };
+  const name = setupProviderName(pluginId, sessionId);
+
+  const contextProvider: ContextProvider = {
+    name,
+    priority: 1,
+    enabled: (session: string) => session === sessionId,
+    async getContext(_session: string, _message: MessageInfo) {
+      const fragment = provider({ pluginId, configSchema: schema, partialConfig });
+      if (!fragment) return null;
+
+      return {
+        content: fragment,
+        role: "system" as const,
+        metadata: {
+          source: `setup:${pluginId}`,
+          priority: 1,
+        },
+      };
+    },
+  };
+
+  registerContextProvider(contextProvider);
+  logger.info(`[setup-context] Injected setup context for ${pluginId} in session ${sessionId}`);
+}
+
+/**
+ * End setup context injection — removes the temporary ContextProvider.
+ * Safe to call even if no provider was registered (no-op).
+ */
+export function endSetupContext(pluginId: string, sessionId: string): void {
+  const name = setupProviderName(pluginId, sessionId);
+  unregisterContextProvider(name);
+  logger.info(`[setup-context] Removed setup context for ${pluginId} in session ${sessionId}`);
+}

--- a/src/plugins/state.ts
+++ b/src/plugins/state.ts
@@ -13,6 +13,7 @@ import type {
   ChannelAdapter,
   ConfigSchema,
   ContextProvider,
+  SetupContextProvider,
   UiComponentExtension,
   WebUiExtension,
   WOPRPlugin,
@@ -55,6 +56,9 @@ export const pluginStates: Map<string, PluginRuntimeState> = new Map();
  * Key format: "pluginName.extensionName" -> extension object
  */
 export const pluginExtensions: Map<string, unknown> = new Map();
+
+/** Setup context providers (pluginName -> provider function) */
+export const setupContextProviders: Map<string, SetupContextProvider> = new Map();
 
 export function channelKey(channel: { type: string; id: string }): string {
   return `${channel.type}:${channel.id}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -933,7 +933,26 @@ export interface WOPRPluginContext {
 
   /** Register a health probe for a capability provider this plugin provides */
   registerHealthProbe?(capability: string, providerId: string, probe: () => Promise<boolean>): void;
+
+  // Setup context providers - plugins provide AI instructions for their own setup flow
+  registerSetupContextProvider(fn: SetupContextProvider): void;
 }
+
+/**
+ * Input provided to a setup context provider so it can generate
+ * context-aware setup instructions.
+ */
+export interface SetupContextInput {
+  pluginId: string;
+  configSchema: ConfigSchema;
+  partialConfig: Record<string, unknown>;
+}
+
+/**
+ * A function that returns setup instructions to prepend to the
+ * system prompt during plugin configuration.
+ */
+export type SetupContextProvider = (input: SetupContextInput) => string;
 
 export interface PluginLogger {
   info(message: string, ...args: unknown[]): void;

--- a/tests/unit/setup-context.test.ts
+++ b/tests/unit/setup-context.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Setup Context Provider Tests (WOP-1054)
+ *
+ * Tests registration, injection via beginSetupContext, and cleanup
+ * via endSetupContext.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let setupContextProviders: Map<string, any>;
+let configSchemas: Map<string, any>;
+let contextProviders: Map<string, any>;
+let beginSetupContext: typeof import("../../src/plugins/setup-context.js").beginSetupContext;
+let endSetupContext: typeof import("../../src/plugins/setup-context.js").endSetupContext;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const state = await import("../../src/plugins/state.js");
+  setupContextProviders = state.setupContextProviders;
+  configSchemas = state.configSchemas;
+  const ctx = await import("../../src/core/context.js");
+  contextProviders = ctx.contextProviders;
+  const setupCtx = await import("../../src/plugins/setup-context.js");
+  beginSetupContext = setupCtx.beginSetupContext;
+  endSetupContext = setupCtx.endSetupContext;
+});
+
+afterEach(() => {
+  setupContextProviders.clear();
+  configSchemas.clear();
+  // Remove only setup: prefixed providers to avoid breaking defaults
+  for (const key of contextProviders.keys()) {
+    if (key.startsWith("setup:")) contextProviders.delete(key);
+  }
+  vi.restoreAllMocks();
+});
+
+describe("Setup Context Providers", () => {
+  it("should register a setup context provider in state", () => {
+    const provider = () => "Setup instructions";
+    setupContextProviders.set("my-plugin", provider);
+    expect(setupContextProviders.get("my-plugin")).toBe(provider);
+  });
+
+  it("should inject a temporary context provider on beginSetupContext", () => {
+    const provider = vi.fn().mockReturnValue("Help the user create a Discord bot");
+    setupContextProviders.set("wopr-plugin-discord", provider);
+
+    beginSetupContext("wopr-plugin-discord", "session-1", { token: "" });
+
+    expect(contextProviders.has("setup:wopr-plugin-discord:session-1")).toBe(true);
+  });
+
+  it("should call the provider with correct input", async () => {
+    const provider = vi.fn().mockReturnValue("Instructions here");
+    setupContextProviders.set("my-plugin", provider);
+
+    configSchemas.set("my-plugin", {
+      title: "My Plugin",
+      fields: [{ name: "apiKey", type: "password", label: "API Key" }],
+    });
+
+    beginSetupContext("my-plugin", "sess-1", { apiKey: "partial" });
+
+    const cp = contextProviders.get("setup:my-plugin:sess-1")!;
+    const result = await cp.getContext("sess-1", { content: "", from: "user", timestamp: Date.now() });
+
+    expect(provider).toHaveBeenCalledWith({
+      pluginId: "my-plugin",
+      configSchema: { title: "My Plugin", fields: [{ name: "apiKey", type: "password", label: "API Key" }] },
+      partialConfig: { apiKey: "partial" },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe("Instructions here");
+    expect(result!.role).toBe("system");
+  });
+
+  it("should be a no-op when no provider is registered", () => {
+    beginSetupContext("nonexistent-plugin", "sess-1", {});
+    expect(contextProviders.has("setup:nonexistent-plugin:sess-1")).toBe(false);
+  });
+
+  it("should return null when provider returns empty string", async () => {
+    const provider = vi.fn().mockReturnValue("");
+    setupContextProviders.set("empty-plugin", provider);
+
+    beginSetupContext("empty-plugin", "sess-1", {});
+
+    const cp = contextProviders.get("setup:empty-plugin:sess-1")!;
+    const result = await cp.getContext("sess-1", { content: "", from: "user", timestamp: Date.now() });
+    expect(result).toBeNull();
+  });
+
+  it("should use empty fallback schema when plugin has no registered schema", () => {
+    const provider = vi.fn().mockReturnValue("Instructions");
+    setupContextProviders.set("no-schema-plugin", provider);
+
+    beginSetupContext("no-schema-plugin", "sess-1", {});
+
+    const cp = contextProviders.get("setup:no-schema-plugin:sess-1")!;
+    expect(cp).toBeDefined();
+    // Provider was called with empty fallback schema on getContext
+  });
+
+  it("should only activate for the correct session", () => {
+    const provider = vi.fn().mockReturnValue("Instructions");
+    setupContextProviders.set("my-plugin", provider);
+
+    beginSetupContext("my-plugin", "sess-1", {});
+
+    const cp = contextProviders.get("setup:my-plugin:sess-1")!;
+    expect(cp.enabled("sess-1")).toBe(true);
+    expect(cp.enabled("sess-other")).toBe(false);
+  });
+
+  it("should remove the context provider on endSetupContext", () => {
+    const provider = vi.fn().mockReturnValue("Instructions");
+    setupContextProviders.set("my-plugin", provider);
+
+    beginSetupContext("my-plugin", "sess-1", {});
+    expect(contextProviders.has("setup:my-plugin:sess-1")).toBe(true);
+
+    endSetupContext("my-plugin", "sess-1");
+    expect(contextProviders.has("setup:my-plugin:sess-1")).toBe(false);
+  });
+
+  it("should handle endSetupContext when no provider was active (no-op)", () => {
+    expect(() => endSetupContext("no-plugin", "no-session")).not.toThrow();
+  });
+
+  it("should support multiple concurrent setup sessions", () => {
+    const provider = vi.fn().mockReturnValue("Instructions");
+    setupContextProviders.set("my-plugin", provider);
+
+    beginSetupContext("my-plugin", "sess-1", {});
+    beginSetupContext("my-plugin", "sess-2", {});
+
+    expect(contextProviders.has("setup:my-plugin:sess-1")).toBe(true);
+    expect(contextProviders.has("setup:my-plugin:sess-2")).toBe(true);
+
+    endSetupContext("my-plugin", "sess-1");
+    expect(contextProviders.has("setup:my-plugin:sess-1")).toBe(false);
+    expect(contextProviders.has("setup:my-plugin:sess-2")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1054 (primary — wopr core)

- Mirror `SetupContextInput` and `SetupContextProvider` types in `src/plugin-types/context.ts` and `src/types.ts`
- Add `setupContextProviders: Map<string, SetupContextProvider>` to `src/plugins/state.ts`
- Create `src/plugins/setup-context.ts` with `beginSetupContext()` and `endSetupContext()` — registers/removes a temporary `ContextProvider` scoped to the setup session
- Wire `registerSetupContextProvider()` into `createPluginContext()` in `src/plugins/context-factory.ts`
- 10 unit tests in `tests/unit/setup-context.test.ts` covering registration, injection, session scoping, empty-string no-op, concurrent sessions, and cleanup

## Test plan
- [ ] `npm run build` passes
- [ ] `npx vitest run tests/unit/setup-context.test.ts` — 10/10 pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WOPRPluginContext.registerSetupContextProvider` and session-scoped setup injection via `beginSetupContext`/`endSetupContext` to let plugins inject AI setup instructions for setup (WOP-1054)
> Introduce setup context providers, register them on `WOPRPluginContext`, store in shared `setupContextProviders`, and inject session-scoped system prompt fragments via `beginSetupContext`/`endSetupContext`.
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1054](https://linear.app/wopr/issue/WOP-1054) by adding plugin-registered setup context providers and session-scoped injection APIs.
>
> #### 📍Where to Start
> Start with `beginSetupContext` and `endSetupContext` in [setup-context.ts](https://github.com/wopr-network/wopr/pull/1272/files#diff-c043d50be083a371ebdd884418f363508c2f20183fc0b407aec5185a49f8f647), then review provider registration in [context-factory.ts](https://github.com/wopr-network/wopr/pull/1272/files#diff-d582617c48c761527d98598b3f7d23c1f39a18c7c3e14c950f14b7093a8505bc) and state in [state.ts](https://github.com/wopr-network/wopr/pull/1272/files#diff-bce0dc9ec5ec11873034f6eaa15e499b9711eb89760cf81dc8be836cbd47f3a7).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 12a2126. 5 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->