### PR TITLE
refactor: eliminate any type annotations in wopr core (WOP-745)

### DIFF
--- a/src/core/a2a-mcp.ts
+++ b/src/core/a2a-mcp.ts
@@ -78,8 +78,7 @@ export function getA2AMcpServer(sessionName: string): ReturnType<typeof createSd
 
   logger.info(`[a2a-mcp] Building MCP server with ${pluginTools.size} plugin tools`);
 
-  // biome-ignore lint/suspicious/noExplicitAny: SDK tool definitions have complex generic types
-  const tools: any[] = [
+  const tools: unknown[] = [
     ...createSessionTools(sessionName),
     ...createConfigTools(sessionName),
     ...createMemoryTools(sessionName),
@@ -108,7 +107,8 @@ export function getA2AMcpServer(sessionName: string): ReturnType<typeof createSd
   const server = createSdkMcpServer({
     name: "wopr-a2a",
     version: "1.0.0",
-    tools,
+    // biome-ignore lint/suspicious/noExplicitAny: createXTools() return unknown[] matching the SDK's SdkMcpToolDefinition<any>[] parameter
+    tools: tools as Parameters<typeof createSdkMcpServer>[0]["tools"],
   });
 
   setCachedServer(server);

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -257,7 +257,10 @@ export interface WOPREventBus {
 // ============================================================================
 
 // General-purpose callable type for handler/wrapper tracking.
-// biome-ignore lint/suspicious/noExplicitAny: WeakMap keys require contravariant parameter types; unknown[] is too narrow for generic EventHandler<T>
+// This `any` is unavoidable: WeakMap<AnyFunction, ...> requires parameter contravariance.
+// Using `unknown[]` would make this type incompatible with typed EventHandler<T> callbacks
+// because (...args: unknown[]) => unknown is NOT assignable from (payload: SomeEvent) => void.
+// biome-ignore lint/suspicious/noExplicitAny: WeakMap keys require contravariant parameter types
 type AnyFunction = (...args: any[]) => any;
 
 class WOPREventBusImpl implements WOPREventBus {

--- a/src/plugins/loading.ts
+++ b/src/plugins/loading.ts
@@ -216,11 +216,11 @@ export async function loadPlugin(
  * Read a plugin manifest from package.json "wopr" field or wopr-plugin.json.
  * Returns undefined if no manifest is found (backward compat).
  */
-// biome-ignore lint/suspicious/noExplicitAny: package.json shape is untyped
-export function readPluginManifest(pluginPath: string, pkg?: any): PluginManifest | undefined {
+export function readPluginManifest(pluginPath: string, pkg?: Record<string, unknown>): PluginManifest | undefined {
   // 1. Check package.json "wopr" field (top-level manifest)
-  if (pkg?.wopr?.name && pkg.wopr.capabilities) {
-    return pkg.wopr as PluginManifest;
+  const wopr = pkg?.wopr as Record<string, unknown> | undefined;
+  if (wopr?.name && wopr.capabilities) {
+    return wopr as unknown as PluginManifest;
   }
 
   // 2. Check standalone wopr-plugin.json

--- a/src/plugins/schema-converter.ts
+++ b/src/plugins/schema-converter.ts
@@ -16,7 +16,7 @@ import type { A2AServerConfig } from "../types.js";
  */
 export function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodTypeAny {
   if (!schema || typeof schema !== "object") {
-    return z.any();
+    return z.unknown();
   }
 
   const type = schema.type as string;
@@ -39,7 +39,7 @@ export function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodTypeAny {
       zodSchema = z.boolean();
       break;
     case "array":
-      zodSchema = items ? z.array(jsonSchemaToZod(items)) : z.array(z.any());
+      zodSchema = items ? z.array(jsonSchemaToZod(items)) : z.array(z.unknown());
       break;
     case "object":
       if (properties) {
@@ -59,11 +59,11 @@ export function jsonSchemaToZod(schema: Record<string, unknown>): z.ZodTypeAny {
         }
         zodSchema = z.object(shape);
       } else {
-        zodSchema = z.record(z.string(), z.any());
+        zodSchema = z.record(z.string(), z.unknown());
       }
       break;
     default:
-      zodSchema = z.any();
+      zodSchema = z.unknown();
   }
 
   if (description) {


### PR DESCRIPTION
## Summary
Closes WOP-745

- Replace `pkg?: any` with `pkg?: Record<string, unknown>` in `readPluginManifest` (`src/plugins/loading.ts`)
- Replace all four `z.any()` calls with `z.unknown()` in `src/plugins/schema-converter.ts` (invalid schema, array fallback, open record, unknown type fallback)
- Replace `any[]` with `unknown[]` for the tools assembly array in `src/core/a2a-mcp.ts`, with a single cast only at the `createSdkMcpServer` call site using the SDK's own parameter type
- Enhance documentation comment on the unavoidable `AnyFunction` variance case in `src/core/events.ts` (kept as-is per architect spec)

Reduces explicit `any` type annotations from 6 to 1 (the unavoidable WeakMap contravariance case in `events.ts`).

## Test plan
- [x] `npm run build` passes
- [x] `npx vitest run tests/unit/plugin-loading.test.ts` — 17/17 pass
- [x] Pre-existing failures in `sessions.test.ts` and `plugin-tool-security.test.ts` confirmed pre-existing on `origin/main` (SQLite init, unrelated to this change)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `any` with `unknown` across WOPR core and adjust `src/core/a2a-mcp.ts:getA2AMcpServer` to cast tools via `Parameters<typeof createSdkMcpServer>[0]["tools"]`
> Switch types from `any` to `unknown` in core code, update `getA2AMcpServer` tool typing in [a2a-mcp.ts](https://github.com/wopr-network/wopr/pull/1274/files#diff-01c4a468fc535edcc4988ab53eb4a449708250a625f16c0108380be381833a44), keep `events.AnyFunction` using `any` with clarified comments in [events.ts](https://github.com/wopr-network/wopr/pull/1274/files#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8), change `readPluginManifest` to accept `Record<string, unknown>` and adjust casts in [loading.ts](https://github.com/wopr-network/wopr/pull/1274/files#diff-ba055517e71685b635ba42fef3dacd58a0adaa4305acf4a9d21f8c3dc95be42c), and replace `z.any()` with `z.unknown()` in schema conversion logic in [schema-converter.ts](https://github.com/wopr-network/wopr/pull/1274/files#diff-64b48ed8a62d99c743e1b94e3bae8496fbee2a5b6ff2704e608b3178d90526d5).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-745](ticket:jira/WOP-745) by removing `any` type annotations across core modules.
>
> #### 📍Where to Start
> Start with `getA2AMcpServer` in [src/core/a2a-mcp.ts](https://github.com/wopr-network/wopr/pull/1274/files#diff-01c4a468fc535edcc4988ab53eb4a449708250a625f16c0108380be381833a44), then review the `tools` typing and cast. Proceed to type changes in [src/plugins/schema-converter.ts](https://github.com/wopr-network/wopr/pull/1274/files#diff-64b48ed8a62d99c743e1b94e3bae8496fbee2a5b6ff2704e608b3178d90526d5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 759404d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->