### PR TITLE
fix: replace su-exec with gosu and wget with curl for Debian compatibility (WOP-944)

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -42,13 +42,13 @@ jobs:
           docker run -d --name "$CONTAINER_NAME" \
             ghcr.io/wopr-network/${{ matrix.image }}:latest
 
-          # Poll health from INSIDE the container using wget (busybox default on
-          # Alpine -- works on both wopr and wopr-slim images without extra deps).
+          # Poll health from INSIDE the container using curl (installed in both
+          # wopr and wopr-slim Debian bookworm-slim images).
           # This avoids DinD networking issues: runner and smoke containers are
           # siblings sharing a Docker daemon but in separate network namespaces,
           # so bridge IPs are unreachable from the runner container.
           HEALTHY=false
-          echo "Polling health from inside container (docker exec wget) ..."
+          echo "Polling health from inside container (docker exec curl) ..."
           for i in $(seq 1 30); do
             # Check container is still running
             if ! docker ps --filter "name=$CONTAINER_NAME" --format '{{.Status}}' | grep -q "Up"; then
@@ -57,7 +57,7 @@ jobs:
               break
             fi
             if docker exec "$CONTAINER_NAME" \
-              wget -q -O /dev/null --timeout=5 "http://localhost:7437/health" 2>/dev/null; then
+              curl -sf --max-time 5 "http://localhost:7437/health" > /dev/null 2>&1; then
               HEALTHY=true
               break
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /app
 
 # Runtime system deps only — no build-essential, no python3
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git sudo curl ca-certificates jq docker.io && \
+    git sudo curl ca-certificates jq docker.io gosu && \
     rm -rf /var/lib/apt/lists/*
 
 # Make node user a passwordless sudoer

--- a/Dockerfile.service
+++ b/Dockerfile.service
@@ -61,7 +61,7 @@ WORKDIR /app
 RUN npm install -g npm@latest
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates jq tini && \
+    git ca-certificates curl jq tini && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy production node_modules from deps stage

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -58,7 +58,7 @@ export NODE_OPTIONS="--max-old-space-size=4096"
 if [ "$1" = "node" ] && echo "$@" | grep -q "daemon run"; then
   # Restart loop for daemon: exit code 75 = restart requested by restart-on-idle
   while true; do
-    su-exec node "$@"
+    gosu node "$@"
     EXIT_CODE=$?
 
     if [ "$EXIT_CODE" -ne 75 ]; then
@@ -72,5 +72,5 @@ if [ "$1" = "node" ] && echo "$@" | grep -q "daemon run"; then
   done
 else
   # Not daemon command - run normally without restart loop
-  exec su-exec node "$@"
+  exec gosu node "$@"
 fi


### PR DESCRIPTION
## Summary
Closes WOP-944

- Replace `su-exec` with `gosu` in `Dockerfile` (runtime deps) and `docker-entrypoint.sh` — `su-exec` is an Alpine package not available on Debian bookworm-slim
- Add `curl` to `Dockerfile.service` runtime packages — Debian slim does not include `wget`
- Replace `wget` with `curl` in `.github/workflows/promote-stable.yml` smoke test health probe

## Test plan
- [ ] `npm run build` passes
- [ ] Merge triggers `docker.yml` to rebuild images with `gosu` and `curl`
- [ ] Next promotion run (nightly or `workflow_dispatch`) succeeds for both `wopr` and `wopr-slim`

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace in-container health probe with `curl --fail --silent --max-time 5` in [promote-stable.yml](https://github.com/wopr-network/wopr/pull/1275/files#diff-6f9705a0226572f4e27f3ee4cb20ea555f4fd17b3ebe263e61c4975f308752f1) and run entrypoint processes via `gosu` for Debian compatibility
> Switch the smoke test to `curl` for the health check in [promote-stable.yml](https://github.com/wopr-network/wopr/pull/1275/files#diff-6f9705a0226572f4e27f3ee4cb20ea555f4fd17b3ebe263e61c4975f308752f1), add `gosu` and `curl` to runtime images, and execute entrypoint commands as `node` using `gosu` in [docker-entrypoint.sh](https://github.com/wopr-network/wopr/pull/1275/files#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038a).
>
> #### 📍Where to Start
> Start with the health check step in [promote-stable.yml](https://github.com/wopr-network/wopr/pull/1275/files#diff-6f9705a0226572f4e27f3ee4cb20ea555f4fd17b3ebe263e61c4975f308752f1), then review command invocation changes in [docker-entrypoint.sh](https://github.com/wopr-network/wopr/pull/1275/files#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3e3f95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->