### PR TITLE
fix: use node fetch for promotion smoke test health check (WOP-943)

### DIFF
--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -42,13 +42,13 @@ jobs:
           docker run -d --name "$CONTAINER_NAME" \
             ghcr.io/wopr-network/${{ matrix.image }}:latest
 
-          # Poll health from INSIDE the container using curl (installed in both
-          # wopr and wopr-slim Debian bookworm-slim images).
+          # Poll health from INSIDE the container using Node's built-in fetch().
+          # Both wopr and wopr-slim are Node 24 Debian images — no wget/curl needed.
           # This avoids DinD networking issues: runner and smoke containers are
           # siblings sharing a Docker daemon but in separate network namespaces,
           # so bridge IPs are unreachable from the runner container.
           HEALTHY=false
-          echo "Polling health from inside container (docker exec curl) ..."
+          echo "Polling health from inside container (docker exec node fetch) ..."
           for i in $(seq 1 30); do
             # Check container is still running
             if ! docker ps --filter "name=$CONTAINER_NAME" --format '{{.Status}}' | grep -q "Up"; then
@@ -57,7 +57,7 @@ jobs:
               break
             fi
             if docker exec "$CONTAINER_NAME" \
-              curl -sf --max-time 5 "http://localhost:7437/health" > /dev/null 2>&1; then
+              node -e "fetch('http://localhost:7437/health').then(r=>{if(!r.ok)throw 1}).catch(()=>process.exit(1))" 2>/dev/null; then
               HEALTHY=true
               break
             fi


### PR DESCRIPTION
## Summary
Closes WOP-943

- Replaces `curl` with `node -e "fetch(...)"` in the promote-stable smoke test
- Node 24's built-in `fetch()` works in both `wopr` and `wopr-slim` images with zero extra dependencies
- Makes the health check independent of which HTTP utilities are installed in the image
- Matches the pattern already used in `src/compose-gen/generate.ts` for container healthchecks

## Test plan
- [ ] `pnpm check` passes (lint + tsc — no src changes)
- [ ] Next nightly `promote-stable.yml` run passes for both `wopr` and `wopr-slim` matrix entries

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace curl-based health check with Node 24 `fetch` in the Smoke test of [promote-stable.yml](https://github.com/wopr-network/wopr/pull/1277/files#diff-6f9705a0226572f4e27f3ee4cb20ea555f4fd17b3ebe263e61c4975f308752f1) to remove wget/curl dependency (WOP-943)
> The Smoke test now runs `docker exec` with `node -e` to call `fetch('http://localhost:7437/health')` and exits non-zero on non-OK responses, updating comments and echo output accordingly in [promote-stable.yml](https://github.com/wopr-network/wopr/pull/1277/files#diff-6f9705a0226572f4e27f3ee4cb20ea555f4fd17b3ebe263e61c4975f308752f1).
>
> #### 🖇️ Linked Issues
> Addresses [WOP-943](ticket:jira/WOP-943) by switching the workflow health check to Node `fetch` within the container.
>
> #### 📍Where to Start
> Start with the Smoke test step in [promote-stable.yml](https://github.com/wopr-network/wopr/pull/1277/files#diff-6f9705a0226572f4e27f3ee4cb20ea555f4fd17b3ebe263e61c4975f308752f1), focusing on the `docker exec` `node -e` health polling command.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 29da0fd. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->