### PR TITLE
fix: remove circular init side-effect in sessions.ts

### DIFF
--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -15,7 +15,7 @@ import {
 import type { ProviderConfig } from "../types/provider.js";
 import type { ChannelRef, ConversationEntry, StreamMessage } from "../types.js";
 import { getA2AMcpServer, isA2AEnabled, setSessionFunctions } from "./a2a-mcp.js";
-import { assembleContext, initContextSystem, type MessageInfo } from "./context.js";
+import { assembleContext, type MessageInfo } from "./context.js";
 import {
   emitMutableIncoming,
   emitMutableOutgoing,
@@ -45,10 +45,6 @@ export {
   type ToolContext,
   unregisterA2ATool,
 } from "./a2a-mcp.js";
-
-// Initialize context system with defaults (async)
-initContextSystem();
-// Don't block - let it initialize in background
 
 // Export functions for A2A MCP server (deferred to avoid circular imports)
 // This is called after module initialization

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -251,6 +251,11 @@ export async function startDaemon(config: DaemonConfig = {}): Promise<void> {
   await migrateSessionContextFromFilesystem(sDir, gDir);
   daemonLog("Session context storage initialized");
 
+  // Initialize context system with default providers
+  const { initContextSystem } = await import("../core/context.js");
+  await initContextSystem();
+  daemonLog("Context system initialized");
+
   // Ensure bearer token exists for API authentication
   ensureToken();
   daemonLog("Bearer token ready for API authentication");


### PR DESCRIPTION
## Summary
- `sessions.ts` called `initContextSystem()` at module level as a side effect
- When `context-factory.ts` imported `sessions.ts`, the call fired mid-evaluation of `context.ts`, hitting `contextProviders` before it was initialized
- Caused `ReferenceError: Cannot access 'contextProviders' before initialization` in all tests that imported from the plugin context chain

## Fix
- Remove the top-level `initContextSystem()` call from `sessions.ts`
- Call it explicitly in `startDaemon()` in `daemon/index.ts` after session context storage init

## Test plan
- [x] `tests/unit/setup-context.test.ts` — 10/10 passing (was 0/10)
- [x] `tests/unit/voice-broadcast.test.ts` — 15/15 passing
- [x] `pnpm run check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove circular init side-effect in `core.sessions` and initialize context system in `daemon.startDaemon` in [index.ts](https://github.com/wopr-network/wopr/pull/1300/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078)
> `src/core/sessions.ts` stops initializing the context system on import; `daemon.startDaemon` dynamically imports `initContextSystem` and awaits its execution after session storage setup in [index.ts](https://github.com/wopr-network/wopr/pull/1300/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078).
>
> #### 📍Where to Start
> Start with `startDaemon` in [index.ts](https://github.com/wopr-network/wopr/pull/1300/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078), then review the removed init in [sessions.ts](https://github.com/wopr-network/wopr/pull/1300/files#diff-367d072b442cb63ae6a6e617c4f11539ca690563d6f79e932c36d519cebbe997).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc01a7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->