### PR TITLE
test: add unit tests for 4 untested security module files (WOP-1066)

### DIFF
--- a/tests/unit/security/forward.test.ts
+++ b/tests/unit/security/forward.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../../src/security/context.js", () => ({
+  createSecurityContext: vi.fn(),
+  storeContext: vi.fn(),
+  clearContext: vi.fn(),
+}));
+
+vi.mock("../../../src/security/gateway.js", () => ({
+  isGateway: vi.fn(),
+  createForwardRequest: vi.fn(),
+  validateForwardRequest: vi.fn(),
+  getForwardRules: vi.fn(),
+  queueForApproval: vi.fn(),
+  createForwardedContext: vi.fn(),
+  completeRequest: vi.fn(),
+  approveRequest: vi.fn(),
+  requiresGateway: vi.fn(),
+  findGatewayForSource: vi.fn(),
+}));
+
+let forward: typeof import("../../../src/security/forward.js");
+let gw: typeof import("../../../src/security/gateway.js");
+let ctx: typeof import("../../../src/security/context.js");
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  forward = await import("../../../src/security/forward.js");
+  gw = await import("../../../src/security/gateway.js");
+  ctx = await import("../../../src/security/context.js");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("forwardRequest", () => {
+  it("should fail when session is not a gateway", async () => {
+    vi.mocked(gw.isGateway).mockReturnValue(false);
+    vi.mocked(ctx.createSecurityContext).mockReturnValue({} as any);
+    vi.mocked(gw.createForwardRequest).mockReturnValue({ requestId: "fwd-1" } as any);
+    vi.mocked(gw.validateForwardRequest).mockReturnValue({ valid: true });
+
+    const result = await forward.forwardRequest("not-gw", "target", "hello", {
+      type: "p2p",
+      trustLevel: "untrusted",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("is not a gateway");
+  });
+
+  it("should fail when validation fails", async () => {
+    vi.mocked(gw.isGateway).mockReturnValue(true);
+    vi.mocked(ctx.createSecurityContext).mockReturnValue({} as any);
+    vi.mocked(gw.createForwardRequest).mockReturnValue({ requestId: "fwd-1" } as any);
+    vi.mocked(gw.validateForwardRequest).mockReturnValue({ valid: false, reason: "denied" });
+
+    const result = await forward.forwardRequest("gw", "target", "hello", {
+      type: "p2p",
+      trustLevel: "untrusted",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("denied");
+  });
+
+  it("should queue for approval when rules require it", async () => {
+    vi.mocked(gw.isGateway).mockReturnValue(true);
+    vi.mocked(ctx.createSecurityContext).mockReturnValue({} as any);
+    vi.mocked(gw.createForwardRequest).mockReturnValue({ requestId: "fwd-1" } as any);
+    vi.mocked(gw.validateForwardRequest).mockReturnValue({ valid: true });
+    vi.mocked(gw.getForwardRules).mockReturnValue({ allowForwardTo: ["target"], requireApproval: true } as any);
+
+    const result = await forward.forwardRequest("gw", "target", "hello", {
+      type: "p2p",
+      trustLevel: "untrusted",
+    });
+
+    expect(result.requiresApproval).toBe(true);
+    expect(gw.queueForApproval).toHaveBeenCalled();
+  });
+
+  it("should skip approval when skipApproval option is set", async () => {
+    vi.mocked(gw.isGateway).mockReturnValue(true);
+    vi.mocked(ctx.createSecurityContext).mockReturnValue({} as any);
+    const mockReq = { requestId: "fwd-1", sourceSession: "gw", targetSession: "target", message: "hello" };
+    vi.mocked(gw.createForwardRequest).mockReturnValue(mockReq as any);
+    vi.mocked(gw.validateForwardRequest).mockReturnValue({ valid: true });
+    vi.mocked(gw.getForwardRules).mockReturnValue({ allowForwardTo: ["target"], requireApproval: true } as any);
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+    vi.mocked(gw.completeRequest).mockReturnValue(null);
+
+    const injectFn = vi.fn().mockResolvedValue({ response: "ok" });
+
+    const result = await forward.forwardRequest(
+      "gw",
+      "target",
+      "hello",
+      { type: "p2p", trustLevel: "untrusted" },
+      { skipApproval: true, injectFn },
+    );
+
+    expect(gw.queueForApproval).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("executeForward", () => {
+  it("should fail when no injectFn provided", async () => {
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+
+    const result = await forward.executeForward({ requestId: "fwd-1" } as any);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No inject function");
+  });
+
+  it("should execute injection and complete request", async () => {
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: { type: "gateway" }, session: "target" } as any);
+    vi.mocked(gw.completeRequest).mockReturnValue(null);
+
+    const injectFn = vi.fn().mockResolvedValue({ response: "result" });
+    const result = await forward.executeForward(
+      { requestId: "fwd-1", sourceSession: "gw", targetSession: "target" } as any,
+      injectFn,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.response).toBe("result");
+    expect(ctx.storeContext).toHaveBeenCalled();
+    expect(ctx.clearContext).toHaveBeenCalledWith("target");
+    expect(gw.completeRequest).toHaveBeenCalledWith("fwd-1", "result");
+  });
+
+  it("should handle injection errors gracefully", async () => {
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+
+    const injectFn = vi.fn().mockRejectedValue(new Error("injection failed"));
+    const result = await forward.executeForward(
+      { requestId: "fwd-1", sourceSession: "gw", targetSession: "target" } as any,
+      injectFn,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Forward execution failed");
+  });
+
+  it("should clear context even on error", async () => {
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+
+    const injectFn = vi.fn().mockRejectedValue(new Error("boom"));
+    await forward.executeForward(
+      { requestId: "fwd-1", sourceSession: "gw", targetSession: "target" } as any,
+      injectFn,
+    );
+
+    expect(ctx.clearContext).toHaveBeenCalledWith("target");
+  });
+});
+
+describe("approveAndExecute", () => {
+  it("should fail when request not found", async () => {
+    vi.mocked(gw.approveRequest).mockReturnValue(null);
+
+    const result = await forward.approveAndExecute("nonexistent");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found or not pending");
+  });
+
+  it("should approve and execute", async () => {
+    const req = { requestId: "fwd-1", sourceSession: "gw", targetSession: "target" } as any;
+    vi.mocked(gw.approveRequest).mockReturnValue(req);
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+    vi.mocked(gw.completeRequest).mockReturnValue(null);
+
+    const injectFn = vi.fn().mockResolvedValue({ response: "ok" });
+    const result = await forward.approveAndExecute("fwd-1", injectFn);
+
+    expect(result.success).toBe(true);
+    expect(result.response).toBe("ok");
+  });
+});
+
+describe("routeThroughGateway", () => {
+  it("should return null when gateway not required", async () => {
+    vi.mocked(gw.requiresGateway).mockReturnValue(false);
+
+    const result = await forward.routeThroughGateway({ type: "cli", trustLevel: "owner" }, "target", "hello");
+
+    expect(result).toBeNull();
+  });
+
+  it("should fail when no gateway available", async () => {
+    vi.mocked(gw.requiresGateway).mockReturnValue(true);
+    vi.mocked(gw.findGatewayForSource).mockReturnValue(null);
+
+    const result = await forward.routeThroughGateway(
+      { type: "p2p", trustLevel: "untrusted" },
+      "target",
+      "hello",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(false);
+    expect(result!.error).toContain("No gateway available");
+  });
+
+  it("should forward through found gateway", async () => {
+    vi.mocked(gw.requiresGateway).mockReturnValue(true);
+    vi.mocked(gw.findGatewayForSource).mockReturnValue("gw1");
+    vi.mocked(gw.isGateway).mockReturnValue(true);
+    vi.mocked(ctx.createSecurityContext).mockReturnValue({} as any);
+    vi.mocked(gw.createForwardRequest).mockReturnValue({ requestId: "fwd-1" } as any);
+    vi.mocked(gw.validateForwardRequest).mockReturnValue({ valid: true });
+    vi.mocked(gw.getForwardRules).mockReturnValue({ allowForwardTo: ["target"] } as any);
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+    vi.mocked(gw.completeRequest).mockReturnValue(null);
+
+    const injectFn = vi.fn().mockResolvedValue({ response: "routed" });
+    const result = await forward.routeThroughGateway(
+      { type: "p2p", trustLevel: "untrusted" },
+      "target",
+      "hello",
+      injectFn,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(true);
+  });
+});
+
+describe("handleGatewayForward", () => {
+  it("should fail on context mismatch", async () => {
+    const mockCtx = { session: "wrong-session" } as any;
+    const result = await forward.handleGatewayForward("gw", "target", "hello", mockCtx);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Context mismatch");
+  });
+
+  it("should forward when context matches", async () => {
+    const mockCtx = { session: "gw", trustLevel: "semi-trusted" } as any;
+    vi.mocked(gw.isGateway).mockReturnValue(true);
+    vi.mocked(ctx.createSecurityContext).mockReturnValue({} as any);
+    vi.mocked(gw.createForwardRequest).mockReturnValue({ requestId: "fwd-1" } as any);
+    vi.mocked(gw.validateForwardRequest).mockReturnValue({ valid: true });
+    vi.mocked(gw.getForwardRules).mockReturnValue({ allowForwardTo: ["target"] } as any);
+    vi.mocked(gw.createForwardedContext).mockReturnValue({ source: {}, session: "target" } as any);
+    vi.mocked(gw.completeRequest).mockReturnValue(null);
+
+    const injectFn = vi.fn().mockResolvedValue({ response: "ok" });
+    const result = await forward.handleGatewayForward("gw", "target", "hello", mockCtx, injectFn);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("gatewayToolDefinitions", () => {
+  it("should export tool definitions", () => {
+    expect(forward.gatewayToolDefinitions).toBeDefined();
+    expect(forward.gatewayToolDefinitions.gateway_forward).toBeDefined();
+    expect(forward.gatewayToolDefinitions.gateway_queue).toBeDefined();
+    expect(forward.gatewayToolDefinitions.gateway_approve).toBeDefined();
+    expect(forward.gatewayToolDefinitions.gateway_reject).toBeDefined();
+  });
+});

--- a/tests/unit/security/gateway.test.ts
+++ b/tests/unit/security/gateway.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../../../src/security/policy.js", () => ({
+  isGatewaySession: vi.fn(),
+  canGatewayForward: vi.fn(),
+  getGatewayRules: vi.fn(),
+  getSecurityConfig: vi.fn(),
+}));
+
+vi.mock("../../../src/security/context.js", () => ({
+  createSecurityContext: vi.fn(),
+}));
+
+let gateway: typeof import("../../../src/security/gateway.js");
+let policy: typeof import("../../../src/security/policy.js");
+let context: typeof import("../../../src/security/context.js");
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.resetModules();
+  gateway = await import("../../../src/security/gateway.js");
+  policy = await import("../../../src/security/policy.js");
+  context = await import("../../../src/security/context.js");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("isGateway", () => {
+  it("should delegate to isGatewaySession from policy", () => {
+    vi.mocked(policy.isGatewaySession).mockReturnValue(true);
+    expect(gateway.isGateway("gw-session")).toBe(true);
+    expect(policy.isGatewaySession).toHaveBeenCalledWith("gw-session");
+  });
+
+  it("should return false when policy says no", () => {
+    vi.mocked(policy.isGatewaySession).mockReturnValue(false);
+    expect(gateway.isGateway("not-a-gateway")).toBe(false);
+  });
+});
+
+describe("getForwardRules", () => {
+  it("should return rules from policy", () => {
+    const rules = { allowForwardTo: ["main"], allowActions: ["chat"] };
+    vi.mocked(policy.getGatewayRules).mockReturnValue(rules as any);
+    expect(gateway.getForwardRules("gw")).toEqual(rules);
+  });
+
+  it("should return null when no rules", () => {
+    vi.mocked(policy.getGatewayRules).mockReturnValue(undefined);
+    expect(gateway.getForwardRules("gw")).toBeNull();
+  });
+});
+
+describe("canForwardTo", () => {
+  it("should return true when policy allows", () => {
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: true } as any);
+    expect(gateway.canForwardTo("gw", "target")).toBe(true);
+  });
+
+  it("should return false when policy denies", () => {
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: false, reason: "denied" } as any);
+    expect(gateway.canForwardTo("gw", "target")).toBe(false);
+  });
+});
+
+describe("createForwardRequest", () => {
+  it("should create a pending request with correct fields", () => {
+    const source = { type: "p2p" as const, trustLevel: "untrusted" as const };
+    const req = gateway.createForwardRequest("gw", "target", "hello", source, "chat");
+
+    expect(req.requestId).toMatch(/^fwd-/);
+    expect(req.sourceSession).toBe("gw");
+    expect(req.targetSession).toBe("target");
+    expect(req.message).toBe("hello");
+    expect(req.originalSource).toBe(source);
+    expect(req.actionType).toBe("chat");
+    expect(req.status).toBe("pending");
+    expect(req.timestamp).toBeTypeOf("number");
+  });
+});
+
+describe("validateForwardRequest", () => {
+  it("should reject when context cannot forward", () => {
+    const mockCtx = { canForward: () => false } as any;
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    const result = gateway.validateForwardRequest(req, mockCtx);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("not authorized to forward");
+  });
+
+  it("should reject when target is not allowed", () => {
+    const mockCtx = { canForward: () => true } as any;
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: false, reason: "nope" } as any);
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    const result = gateway.validateForwardRequest(req, mockCtx);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("Cannot forward to session");
+  });
+
+  it("should reject when no forward rules", () => {
+    const mockCtx = { canForward: () => true } as any;
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: true } as any);
+    vi.mocked(policy.getGatewayRules).mockReturnValue(undefined);
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    const result = gateway.validateForwardRequest(req, mockCtx);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("No forward rules");
+  });
+
+  it("should reject disallowed action type", () => {
+    const mockCtx = { canForward: () => true } as any;
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: true } as any);
+    vi.mocked(policy.getGatewayRules).mockReturnValue({ allowForwardTo: ["target"], allowActions: ["chat"] } as any);
+    const req = gateway.createForwardRequest(
+      "gw",
+      "target",
+      "hi",
+      { type: "p2p" as const, trustLevel: "untrusted" as const },
+      "exec",
+    );
+    const result = gateway.validateForwardRequest(req, mockCtx);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("Action type not allowed");
+  });
+
+  it("should pass valid request", () => {
+    const mockCtx = { canForward: () => true } as any;
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: true } as any);
+    vi.mocked(policy.getGatewayRules).mockReturnValue({ allowForwardTo: ["target"] } as any);
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    const result = gateway.validateForwardRequest(req, mockCtx);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should enforce rate limit", () => {
+    const mockCtx = { canForward: () => true } as any;
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: true } as any);
+    vi.mocked(policy.getGatewayRules).mockReturnValue({
+      allowForwardTo: ["target"],
+      rateLimit: { perMinute: 2 },
+    } as any);
+
+    const source = { type: "p2p" as const, trustLevel: "untrusted" as const };
+
+    // First two should pass
+    const req1 = gateway.createForwardRequest("gw", "target", "hi", source);
+    expect(gateway.validateForwardRequest(req1, mockCtx).valid).toBe(true);
+
+    const req2 = gateway.createForwardRequest("gw", "target", "hi", source);
+    expect(gateway.validateForwardRequest(req2, mockCtx).valid).toBe(true);
+
+    // Third should hit rate limit
+    const req3 = gateway.createForwardRequest("gw", "target", "hi", source);
+    const result = gateway.validateForwardRequest(req3, mockCtx);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toContain("Rate limit exceeded");
+  });
+
+  it("should reset rate limit after window expires", () => {
+    const mockCtx = { canForward: () => true } as any;
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: true } as any);
+    vi.mocked(policy.getGatewayRules).mockReturnValue({
+      allowForwardTo: ["target"],
+      rateLimit: { perMinute: 1 },
+    } as any);
+
+    const source = { type: "p2p" as const, trustLevel: "untrusted" as const };
+
+    // First passes
+    const req1 = gateway.createForwardRequest("gw", "target", "hi", source);
+    expect(gateway.validateForwardRequest(req1, mockCtx).valid).toBe(true);
+
+    // Second blocked
+    const req2 = gateway.createForwardRequest("gw", "target", "hi", source);
+    expect(gateway.validateForwardRequest(req2, mockCtx).valid).toBe(false);
+
+    // Advance past 60s window
+    vi.advanceTimersByTime(61000);
+
+    // Third passes (new window)
+    const req3 = gateway.createForwardRequest("gw", "target", "hi", source);
+    expect(gateway.validateForwardRequest(req3, mockCtx).valid).toBe(true);
+  });
+});
+
+describe("queueForApproval / approveRequest / rejectRequest", () => {
+  it("should queue and retrieve pending requests", () => {
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    gateway.queueForApproval(req);
+
+    const pending = gateway.getPendingRequests("gw");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].requestId).toBe(req.requestId);
+  });
+
+  it("should approve a pending request", () => {
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    gateway.queueForApproval(req);
+
+    const approved = gateway.approveRequest(req.requestId);
+    expect(approved).not.toBeNull();
+    expect(approved!.status).toBe("approved");
+  });
+
+  it("should return null when approving non-existent request", () => {
+    expect(gateway.approveRequest("nonexistent")).toBeNull();
+  });
+
+  it("should reject a pending request", () => {
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    gateway.queueForApproval(req);
+
+    const rejected = gateway.rejectRequest(req.requestId, "not allowed");
+    expect(rejected).not.toBeNull();
+    expect(rejected!.status).toBe("rejected");
+    expect(rejected!.rejectionReason).toBe("not allowed");
+
+    // Should be removed from pending
+    expect(gateway.getPendingRequests()).toHaveLength(0);
+  });
+
+  it("should return null when rejecting non-existent request", () => {
+    expect(gateway.rejectRequest("nonexistent", "reason")).toBeNull();
+  });
+});
+
+describe("completeRequest", () => {
+  it("should complete a queued request with response", () => {
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    gateway.queueForApproval(req);
+
+    const completed = gateway.completeRequest(req.requestId, "done");
+    expect(completed).not.toBeNull();
+    expect(completed!.status).toBe("completed");
+    expect(completed!.response).toBe("done");
+    expect(gateway.getPendingRequests()).toHaveLength(0);
+  });
+
+  it("should return null for non-existent request", () => {
+    expect(gateway.completeRequest("nonexistent", "done")).toBeNull();
+  });
+});
+
+describe("getPendingRequests", () => {
+  it("should filter by gateway session", () => {
+    const req1 = gateway.createForwardRequest("gw1", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    const req2 = gateway.createForwardRequest("gw2", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    gateway.queueForApproval(req1);
+    gateway.queueForApproval(req2);
+
+    expect(gateway.getPendingRequests("gw1")).toHaveLength(1);
+    expect(gateway.getPendingRequests("gw2")).toHaveLength(1);
+    expect(gateway.getPendingRequests()).toHaveLength(2);
+  });
+});
+
+describe("createForwardedContext", () => {
+  it("should create a gateway-sourced security context", () => {
+    const mockCtx = { session: "target" } as any;
+    vi.mocked(context.createSecurityContext).mockReturnValue(mockCtx);
+
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+      identity: { publicKey: "pk123" },
+    });
+
+    const result = gateway.createForwardedContext(req);
+    expect(context.createSecurityContext).toHaveBeenCalled();
+    // First arg should be gateway-type source with semi-trusted
+    const callArgs = vi.mocked(context.createSecurityContext).mock.calls[0];
+    expect(callArgs[0].type).toBe("gateway");
+    expect(callArgs[0].trustLevel).toBe("semi-trusted");
+    expect(callArgs[1]).toBe("target");
+    expect(result).toBe(mockCtx);
+  });
+});
+
+describe("findGatewayForSource", () => {
+  it("should find a gateway that can forward to target", () => {
+    vi.mocked(policy.getSecurityConfig).mockReturnValue({
+      gateways: { sessions: ["gw1", "gw2"] },
+    } as any);
+    vi.mocked(policy.canGatewayForward)
+      .mockReturnValueOnce({ allowed: false, reason: "no" } as any)
+      .mockReturnValueOnce({ allowed: true } as any);
+
+    const source = { type: "p2p" as const, trustLevel: "untrusted" as const };
+    expect(gateway.findGatewayForSource(source, "target")).toBe("gw2");
+  });
+
+  it("should return null when no gateway can forward", () => {
+    vi.mocked(policy.getSecurityConfig).mockReturnValue({
+      gateways: { sessions: ["gw1"] },
+    } as any);
+    vi.mocked(policy.canGatewayForward).mockReturnValue({ allowed: false, reason: "no" } as any);
+
+    const source = { type: "p2p" as const, trustLevel: "untrusted" as const };
+    expect(gateway.findGatewayForSource(source, "target")).toBeNull();
+  });
+
+  it("should return null when no gateways configured", () => {
+    vi.mocked(policy.getSecurityConfig).mockReturnValue({} as any);
+    const source = { type: "p2p" as const, trustLevel: "untrusted" as const };
+    expect(gateway.findGatewayForSource(source, "target")).toBeNull();
+  });
+});
+
+describe("requiresGateway", () => {
+  it("should return false for owner trust", () => {
+    expect(gateway.requiresGateway({ type: "cli", trustLevel: "owner" }, "target")).toBe(false);
+  });
+
+  it("should return false for trusted trust", () => {
+    expect(gateway.requiresGateway({ type: "plugin", trustLevel: "trusted" }, "target")).toBe(false);
+  });
+
+  it("should return false for internal source type", () => {
+    expect(gateway.requiresGateway({ type: "internal", trustLevel: "semi-trusted" }, "target")).toBe(false);
+  });
+
+  it("should return false for cli source type", () => {
+    expect(gateway.requiresGateway({ type: "cli", trustLevel: "semi-trusted" }, "target")).toBe(false);
+  });
+
+  it("should return false for daemon source type", () => {
+    expect(gateway.requiresGateway({ type: "daemon", trustLevel: "semi-trusted" }, "target")).toBe(false);
+  });
+
+  it("should return false when target is a gateway session", () => {
+    vi.mocked(policy.isGatewaySession).mockReturnValue(true);
+    expect(gateway.requiresGateway({ type: "p2p", trustLevel: "untrusted" }, "gw-session")).toBe(false);
+  });
+
+  it("should return true for untrusted p2p targeting non-gateway", () => {
+    vi.mocked(policy.isGatewaySession).mockReturnValue(false);
+    expect(gateway.requiresGateway({ type: "p2p", trustLevel: "untrusted" }, "privileged")).toBe(true);
+  });
+
+  it("should return true for semi-trusted api targeting non-gateway", () => {
+    vi.mocked(policy.isGatewaySession).mockReturnValue(false);
+    expect(gateway.requiresGateway({ type: "api", trustLevel: "semi-trusted" }, "privileged")).toBe(true);
+  });
+});
+
+describe("cleanupExpiredRequests", () => {
+  it("should remove expired pending requests", () => {
+    const req = gateway.createForwardRequest("gw", "target", "hi", {
+      type: "p2p" as const,
+      trustLevel: "untrusted" as const,
+    });
+    gateway.queueForApproval(req);
+    expect(gateway.getPendingRequests()).toHaveLength(1);
+
+    // Advance past 5 minute expiry
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    gateway.cleanupExpiredRequests();
+
+    expect(gateway.getPendingRequests()).toHaveLength(0);
+  });
+});

--- a/tests/unit/security/schema.test.ts
+++ b/tests/unit/security/schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { securityConfigSchema, securityPluginRuleSchema } from "../../../src/security/schema.js";
+
+describe("securityConfigSchema", () => {
+  it("should accept a valid config row", () => {
+    const valid = { id: "global", config: '{"enforcement":"enforce"}', updatedAt: Date.now() };
+    expect(securityConfigSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("should reject missing id", () => {
+    expect(() => securityConfigSchema.parse({ config: "{}", updatedAt: 1 })).toThrow();
+  });
+
+  it("should reject missing config", () => {
+    expect(() => securityConfigSchema.parse({ id: "global", updatedAt: 1 })).toThrow();
+  });
+
+  it("should reject missing updatedAt", () => {
+    expect(() => securityConfigSchema.parse({ id: "global", config: "{}" })).toThrow();
+  });
+
+  it("should reject non-string config", () => {
+    expect(() => securityConfigSchema.parse({ id: "global", config: 123, updatedAt: 1 })).toThrow();
+  });
+
+  it("should reject non-number updatedAt", () => {
+    expect(() => securityConfigSchema.parse({ id: "global", config: "{}", updatedAt: "not-a-number" })).toThrow();
+  });
+});
+
+describe("securityPluginRuleSchema", () => {
+  const validRule = {
+    id: "abc-123",
+    pluginName: "my-plugin",
+    ruleType: "trust-override" as const,
+    ruleData: "{}",
+    createdAt: Date.now(),
+  };
+
+  it("should accept a valid rule row", () => {
+    expect(securityPluginRuleSchema.parse(validRule)).toEqual(validRule);
+  });
+
+  it("should accept optional targetSession and targetTrust", () => {
+    const withOptionals = { ...validRule, targetSession: "main", targetTrust: "trusted" };
+    expect(securityPluginRuleSchema.parse(withOptionals)).toEqual(withOptionals);
+  });
+
+  it("should accept all valid ruleType values", () => {
+    for (const rt of ["trust-override", "session-access", "capability-grant", "tool-policy"]) {
+      expect(securityPluginRuleSchema.parse({ ...validRule, ruleType: rt })).toBeTruthy();
+    }
+  });
+
+  it("should reject invalid ruleType", () => {
+    expect(() => securityPluginRuleSchema.parse({ ...validRule, ruleType: "invalid" })).toThrow();
+  });
+
+  it("should reject missing pluginName", () => {
+    const { pluginName: _p, ...rest } = validRule;
+    expect(() => securityPluginRuleSchema.parse(rest)).toThrow();
+  });
+
+  it("should reject missing ruleData", () => {
+    const { ruleData: _r, ...rest } = validRule;
+    expect(() => securityPluginRuleSchema.parse(rest)).toThrow();
+  });
+});

--- a/tests/unit/security/store.test.ts
+++ b/tests/unit/security/store.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SecurityStore } from "../../../src/security/store.js";
+import { DEFAULT_SECURITY_CONFIG } from "../../../src/security/types.js";
+
+vi.mock("../../../src/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+function createMockRepo() {
+  return {
+    insert: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn().mockResolvedValue(null),
+    update: vi.fn().mockResolvedValue(undefined),
+    findMany: vi.fn().mockResolvedValue([]),
+    deleteMany: vi.fn().mockResolvedValue(0),
+  };
+}
+
+describe("SecurityStore", () => {
+  let configRepo: ReturnType<typeof createMockRepo>;
+  let rulesRepo: ReturnType<typeof createMockRepo>;
+  let store: SecurityStore;
+
+  beforeEach(() => {
+    configRepo = createMockRepo();
+    rulesRepo = createMockRepo();
+    store = new SecurityStore(
+      "/tmp/wopr-test",
+      () => configRepo as any,
+      () => rulesRepo as any,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("init", () => {
+    it("should insert default config when none exists", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+
+      expect(configRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "global",
+          updatedAt: expect.any(Number),
+        }),
+      );
+      // Config string should be valid JSON with enforcement field
+      const insertArg = configRepo.insert.mock.calls[0][0];
+      expect(JSON.parse(insertArg.config).enforcement).toBe("enforce");
+    });
+
+    it("should not insert when config already exists", async () => {
+      configRepo.findById.mockResolvedValue({
+        id: "global",
+        config: JSON.stringify(DEFAULT_SECURITY_CONFIG),
+        updatedAt: 1,
+      });
+      await store.init();
+      expect(configRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it("should migrate from JSON when file exists", async () => {
+      const fs = await import("node:fs");
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ enforcement: "warn" }));
+
+      // findById returns the migrated row after migration
+      configRepo.findById.mockResolvedValue({
+        id: "global",
+        config: JSON.stringify({ ...DEFAULT_SECURITY_CONFIG, enforcement: "warn" }),
+        updatedAt: 1,
+      });
+
+      await store.init();
+
+      expect(fs.readFileSync).toHaveBeenCalled();
+      expect(fs.renameSync).toHaveBeenCalled();
+      expect(configRepo.insert).toHaveBeenCalled();
+    });
+
+    it("should prime cache after init", async () => {
+      const savedConfig = { ...DEFAULT_SECURITY_CONFIG, enforcement: "warn" as const };
+      configRepo.findById.mockResolvedValue({
+        id: "global",
+        config: JSON.stringify(savedConfig),
+        updatedAt: 1,
+      });
+
+      await store.init();
+      expect(store.configCache).not.toBeNull();
+    });
+  });
+
+  describe("getConfig", () => {
+    it("should return cached config", async () => {
+      const cached = { ...DEFAULT_SECURITY_CONFIG, enforcement: "warn" as const };
+      store.configCache = cached;
+      const result = await store.getConfig();
+      expect(result).toBe(cached);
+    });
+
+    it("should return DEFAULT_SECURITY_CONFIG when not initialized", async () => {
+      const result = await store.getConfig();
+      expect(result).toEqual(DEFAULT_SECURITY_CONFIG);
+    });
+
+    it("should fetch from repo and cache when no cache", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+      store.clearCache();
+
+      const savedConfig = { ...DEFAULT_SECURITY_CONFIG, enforcement: "warn" as const };
+      configRepo.findById.mockResolvedValue({
+        id: "global",
+        config: JSON.stringify(savedConfig),
+        updatedAt: 1,
+      });
+
+      const result = await store.getConfig();
+      expect(result.enforcement).toBe("warn");
+      expect(store.configCache).not.toBeNull();
+    });
+
+    it("should return default on parse error", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+      store.clearCache();
+
+      configRepo.findById.mockResolvedValue({
+        id: "global",
+        config: "not-json",
+        updatedAt: 1,
+      });
+
+      const result = await store.getConfig();
+      expect(result).toEqual(DEFAULT_SECURITY_CONFIG);
+    });
+  });
+
+  describe("saveConfig", () => {
+    it("should save config and update cache", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+
+      const newConfig = { ...DEFAULT_SECURITY_CONFIG, enforcement: "off" as const };
+      await store.saveConfig(newConfig);
+
+      expect(configRepo.update).toHaveBeenCalledWith("global", expect.objectContaining({ id: "global" }));
+      expect(store.configCache).toBe(newConfig);
+    });
+
+    it("should warn when store not initialized and not throw", async () => {
+      const freshStore = new SecurityStore("/tmp/test", () => configRepo as any, () => rulesRepo as any);
+      // Should not throw, just warn
+      await expect(freshStore.saveConfig(DEFAULT_SECURITY_CONFIG)).resolves.toBeUndefined();
+      expect(configRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("registerPluginRule", () => {
+    it("should insert a rule and return an id", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+
+      const id = await store.registerPluginRule({
+        pluginName: "test-plugin",
+        ruleType: "trust-override",
+        ruleData: { level: "trusted" },
+      });
+
+      expect(id).toBeTypeOf("string");
+      expect(id.length).toBeGreaterThan(0);
+      expect(rulesRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pluginName: "test-plugin",
+          ruleType: "trust-override",
+          ruleData: '{"level":"trusted"}',
+        }),
+      );
+    });
+
+    it("should throw when store not initialized", async () => {
+      const freshStore = new SecurityStore("/tmp/test", () => configRepo as any, () => rulesRepo as any);
+      await expect(
+        freshStore.registerPluginRule({ pluginName: "p", ruleType: "trust-override", ruleData: {} }),
+      ).rejects.toThrow("Security store not initialized");
+    });
+  });
+
+  describe("removePluginRules", () => {
+    it("should delete rules by plugin name", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+      rulesRepo.deleteMany.mockResolvedValue(3);
+
+      const count = await store.removePluginRules("test-plugin");
+      expect(count).toBe(3);
+      expect(rulesRepo.deleteMany).toHaveBeenCalledWith({ pluginName: "test-plugin" });
+    });
+
+    it("should throw when store not initialized", async () => {
+      const freshStore = new SecurityStore("/tmp/test", () => configRepo as any, () => rulesRepo as any);
+      await expect(freshStore.removePluginRules("p")).rejects.toThrow("Security store not initialized");
+    });
+  });
+
+  describe("getPluginRules", () => {
+    it("should return parsed rules", async () => {
+      configRepo.findById.mockResolvedValue(null);
+      await store.init();
+
+      rulesRepo.findMany.mockResolvedValue([
+        {
+          id: "r1",
+          pluginName: "p1",
+          ruleType: "trust-override",
+          targetSession: "main",
+          targetTrust: "trusted",
+          ruleData: '{"custom":true}',
+          createdAt: 1000,
+        },
+      ]);
+
+      const rules = await store.getPluginRules();
+      expect(rules).toHaveLength(1);
+      expect(rules[0].ruleData).toEqual({ custom: true });
+      expect(rules[0].pluginName).toBe("p1");
+    });
+
+    it("should return empty array when not initialized", async () => {
+      const freshStore = new SecurityStore("/tmp/test", () => configRepo as any, () => rulesRepo as any);
+      const rules = await freshStore.getPluginRules();
+      expect(rules).toEqual([]);
+    });
+  });
+
+  describe("clearCache", () => {
+    it("should set configCache to null", () => {
+      store.configCache = DEFAULT_SECURITY_CONFIG;
+      store.clearCache();
+      expect(store.configCache).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1066

- Added `tests/unit/security/schema.test.ts` — 12 tests for Zod schema validation (`securityConfigSchema`, `securityPluginRuleSchema`)
- Added `tests/unit/security/gateway.test.ts` — 35 tests for gateway request lifecycle, rate limiting, approval queue, cleanup, and forwarded context
- Added `tests/unit/security/store.test.ts` — 17 tests for `SecurityStore` init, config CRUD, plugin rule management, JSON migration, and cache
- Added `tests/unit/security/forward.test.ts` — 16 tests for cross-session forwarding, approval flow, gateway routing, and tool definitions

Total: 80 new tests across 4 files covering all previously untested security module files.

## Test plan
- [x] `pnpm lint` passes (pre-existing warning unrelated to this PR)
- [x] `pnpm build` passes
- [x] `npx vitest run tests/unit/security/schema.test.ts tests/unit/security/gateway.test.ts tests/unit/security/store.test.ts tests/unit/security/forward.test.ts` — 80/80 pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for security forwarding, gateway routing, schema validation, and store behaviors to cover previously untested modules (WOP-1066)
> Add vitest suites that exercise `security/forward` request flows, gateway routing and rate limits (including 5-minute cleanup), schema parsing for config and plugin rules, and store init/migration/cache operations. Key paths include validation failures, approval queues, injection execution, and request lifecycle transitions.
>
> #### 📍Where to Start
> Start with `forward.forwardRequest` tests in [forward.test.ts](https://github.com/wopr-network/wopr/pull/1301/files#diff-00841bd5771146b757992c24d6f2d3e11e832fd55f4bd1bd35e82581f3e499d3) to see the main flow and mocked dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c25e44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->