### PR TITLE
feat(core): implement unregisterSetupContextProvider in context-factory (WOP-1017)

### DIFF
--- a/src/plugin-types/context.ts
+++ b/src/plugin-types/context.ts
@@ -264,6 +264,7 @@ export interface WOPRPluginContext {
 
   // Setup context providers - plugins provide AI instructions for their own setup flow
   registerSetupContextProvider(fn: SetupContextProvider): void;
+  unregisterSetupContextProvider(): void;
 
   // Storage API - plugin-extensible database storage
   storage: StorageApi;

--- a/src/plugins/context-factory.ts
+++ b/src/plugins/context-factory.ts
@@ -304,6 +304,10 @@ export function createPluginContext(
       setupContextProviders.set(pluginName, fn);
     },
 
+    unregisterSetupContextProvider(): void {
+      setupContextProviders.delete(pluginName);
+    },
+
     // Storage API - plugin-extensible database storage
     storage: getStorage(),
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -936,6 +936,7 @@ export interface WOPRPluginContext {
 
   // Setup context providers - plugins provide AI instructions for their own setup flow
   registerSetupContextProvider(fn: SetupContextProvider): void;
+  unregisterSetupContextProvider(): void;
 }
 
 /**


### PR DESCRIPTION
## Summary
Closes WOP-1017

- Add `unregisterSetupContextProvider(): void` to `WOPRPluginContext` interface in `src/types.ts` and the internal `src/plugin-types/context.ts`
- Implement the method in `src/plugins/context-factory.ts` — removes the plugin's entry from the shared `setupContextProviders` Map, enabling clean plugin shutdown

This closes the minor gap identified by the architect: the type declared the method but it was never implemented, leaving `setupContextProviders` entries orphaned on plugin unload.

## Test plan
- [ ] `npm run check` passes (lint + tsc --noEmit)
- [ ] `npm run build` passes
- [ ] `unregisterSetupContextProvider()` removes the correct plugin entry from the `setupContextProviders` Map

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `WOPRPluginContext.unregisterSetupContextProvider()` to remove a plugin’s setup context provider in [context-factory.ts](https://github.com/wopr-network/wopr/pull/1351/files#diff-d582617c48c761527d98598b3f7d23c1f39a18c7c3e14c950f14b7093a8505bc)
> Introduce `WOPRPluginContext.unregisterSetupContextProvider()` and wire it in `createPluginContext` to call `setupContextProviders.delete(pluginName)`, updating interface definitions in [context.ts](https://github.com/wopr-network/wopr/pull/1351/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6) and [types.ts](https://github.com/wopr-network/wopr/pull/1351/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1017](ticket:jira/WOP-1017) by adding an unregister method to the plugin context API.
>
> #### 📍Where to Start
> Start with `createPluginContext` in [context-factory.ts](https://github.com/wopr-network/wopr/pull/1351/files#diff-d582617c48c761527d98598b3f7d23c1f39a18c7c3e14c950f14b7093a8505bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9a1b00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to dynamically unregister setup context providers. This new capability provides greater flexibility and control over your context management configuration, enabling you to modify provider registrations at runtime based on your needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->