### PR TITLE
feat: read WOPR_PLUGINS_* env vars at daemon startup to auto-install plugins (WOP-1327)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -23,6 +23,7 @@ import { providerRegistry } from "../core/providers.js";
 import { inject } from "../core/sessions.js";
 import { logger as winstonLogger } from "../logger.js";
 import { LOG_FILE, PID_FILE } from "../paths.js";
+import { bootstrapEnvPlugins } from "../plugins/bootstrap.js";
 import { loadAllPlugins, shutdownAllPlugins } from "../plugins.js";
 import { ensureToken } from "./auth-token.js";
 import { buildCorsOrigins } from "./cors.js";
@@ -373,6 +374,20 @@ export async function startDaemon(config: DaemonConfig = {}): Promise<void> {
 
   // Memory system (indexing, FTS5, file watching, session hooks) delegated to memory-semantic plugin
   daemonLog("Memory system delegated to memory-semantic plugin");
+
+  // Bootstrap plugins declared in WOPR_PLUGINS_* env vars (WOP-1327)
+  const bootstrapResult = await bootstrapEnvPlugins();
+  if (bootstrapResult.installed.length > 0) {
+    daemonLog(
+      `Env bootstrap: installed ${bootstrapResult.installed.length} plugin(s): ${bootstrapResult.installed.join(", ")}`,
+    );
+  }
+  if (bootstrapResult.failed.length > 0) {
+    daemonLog(`Env bootstrap: ${bootstrapResult.failed.length} plugin(s) failed`);
+    for (const f of bootstrapResult.failed) {
+      startupWarnings.push(`Env plugin ${f.name}: ${f.error}`);
+    }
+  }
 
   // Load plugins (this is where providers register themselves)
   await loadAllPlugins(injectors);

--- a/src/plugins/bootstrap.ts
+++ b/src/plugins/bootstrap.ts
@@ -1,0 +1,108 @@
+/**
+ * Bootstrap plugins from WOPR_PLUGINS_* environment variables.
+ *
+ * Called during daemon startup to auto-install plugins declared
+ * by the platform's compose-gen in container environment variables.
+ */
+
+import { logger } from "../logger.js";
+import { enablePlugin, installPlugin, listPlugins } from "./installation.js";
+
+const ENV_VAR_NAMES = [
+  "WOPR_PLUGINS_CHANNELS",
+  "WOPR_PLUGINS_PROVIDERS",
+  "WOPR_PLUGINS_VOICE",
+  "WOPR_PLUGINS_OTHER",
+] as const;
+
+/**
+ * Parse all WOPR_PLUGINS_* env vars and return a deduplicated list of plugin short names.
+ */
+export function parsePluginEnvVars(): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const varName of ENV_VAR_NAMES) {
+    const value = process.env[varName];
+    if (!value) continue;
+
+    for (const raw of value.split(",")) {
+      const name = raw.trim();
+      if (name && !seen.has(name)) {
+        seen.add(name);
+        result.push(name);
+      }
+    }
+  }
+
+  return result;
+}
+
+export interface BootstrapResult {
+  installed: string[];
+  skipped: string[];
+  failed: Array<{ name: string; error: string }>;
+}
+
+/**
+ * Read WOPR_PLUGINS_* env vars and install/enable any plugins not already present.
+ *
+ * This runs BEFORE loadAllPlugins() — it only installs and enables.
+ * The actual loading happens in the subsequent loadAllPlugins() call.
+ */
+export async function bootstrapEnvPlugins(): Promise<BootstrapResult> {
+  const names = parsePluginEnvVars();
+  if (names.length === 0) return { installed: [], skipped: [], failed: [] };
+
+  logger.info(`[plugins] Bootstrapping ${names.length} plugin(s) from env vars: ${names.join(", ")}`);
+
+  const existing = await listPlugins();
+  const existingNames = new Set(existing.map((p) => p.name));
+
+  const result: BootstrapResult = { installed: [], skipped: [], failed: [] };
+
+  for (const name of names) {
+    if (existingNames.has(name)) {
+      // Already installed — ensure enabled
+      const plugin = existing.find((p) => p.name === name);
+      if (plugin && !plugin.enabled) {
+        try {
+          await enablePlugin(name);
+          logger.info(`[plugins] Env bootstrap: enabled existing plugin ${name}`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          logger.warn(`[plugins] Env bootstrap: failed to enable ${name}: ${msg}`);
+          result.failed.push({ name, error: msg });
+          continue;
+        }
+      }
+      result.skipped.push(name);
+      logger.info(`[plugins] Env bootstrap: ${name} already installed, skipping`);
+      continue;
+    }
+
+    try {
+      await installPlugin(name);
+      await enablePlugin(name);
+      result.installed.push(name);
+      logger.info(`[plugins] Env bootstrap: installed and enabled ${name}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`[plugins] Env bootstrap: failed to install ${name}: ${msg}`);
+      result.failed.push({ name, error: msg });
+    }
+  }
+
+  if (result.installed.length > 0) {
+    logger.info(
+      `[plugins] Env bootstrap: installed ${result.installed.length} new plugin(s): ${result.installed.join(", ")}`,
+    );
+  }
+  if (result.failed.length > 0) {
+    logger.warn(
+      `[plugins] Env bootstrap: ${result.failed.length} plugin(s) failed: ${result.failed.map((f) => f.name).join(", ")}`,
+    );
+  }
+
+  return result;
+}

--- a/tests/unit/plugin-bootstrap.test.ts
+++ b/tests/unit/plugin-bootstrap.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for src/plugins/bootstrap.ts (WOP-1327)
+ *
+ * Covers:
+ * - parsePluginEnvVars: parsing, deduplication, trimming, empty values
+ * - bootstrapEnvPlugins: install/skip/fail logic, idempotency
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock logger before importing
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock plugin-storage (no real DB)
+vi.mock("../../src/plugins/plugin-storage.js", () => ({
+  ensurePluginSchema: vi.fn(),
+  getPluginRepo: vi.fn(() => ({
+    findMany: vi.fn(async () => []),
+    findById: vi.fn(async () => null),
+    insert: vi.fn(),
+    update: vi.fn(),
+  })),
+  getRegistryRepo: vi.fn(),
+}));
+
+// Mock state.js
+vi.mock("../../src/plugins/state.js", () => ({
+  WOPR_HOME: "/tmp/wopr-test",
+  PLUGINS_DIR: "/tmp/wopr-test/plugins",
+  PLUGINS_FILE: "/tmp/wopr-test/plugins.json",
+  REGISTRIES_FILE: "/tmp/wopr-test/plugin-registries.json",
+  loadedPlugins: new Map(),
+  pluginManifests: new Map(),
+  configSchemas: new Map(),
+  pluginStates: new Map(),
+}));
+
+// Mock child_process
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(() => Buffer.from("")),
+  spawnSync: vi.fn(),
+}));
+
+// Mock installation module for bootstrapEnvPlugins tests
+vi.mock("../../src/plugins/installation.js", () => ({
+  installPlugin: vi.fn(async (name: string) => ({
+    name,
+    version: "1.0.0",
+    path: `/tmp/plugins/${name}`,
+    enabled: false,
+    installedAt: Date.now(),
+    source: "npm",
+  })),
+  enablePlugin: vi.fn(async () => true),
+  listPlugins: vi.fn(async () => []),
+  getInstalledPlugins: vi.fn(async () => []),
+  addInstalledPlugin: vi.fn(),
+}));
+
+import { bootstrapEnvPlugins, parsePluginEnvVars } from "../../src/plugins/bootstrap.js";
+import { enablePlugin, installPlugin, listPlugins } from "../../src/plugins/installation.js";
+
+describe("parsePluginEnvVars", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.WOPR_PLUGINS_CHANNELS;
+    delete process.env.WOPR_PLUGINS_PROVIDERS;
+    delete process.env.WOPR_PLUGINS_VOICE;
+    delete process.env.WOPR_PLUGINS_OTHER;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return empty array when no env vars set", () => {
+    expect(parsePluginEnvVars()).toEqual([]);
+  });
+
+  it("should parse comma-separated plugin names from all four env vars", () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord,telegram";
+    process.env.WOPR_PLUGINS_PROVIDERS = "openrouter";
+    process.env.WOPR_PLUGINS_VOICE = "elevenlabs";
+    process.env.WOPR_PLUGINS_OTHER = "";
+    const result = parsePluginEnvVars();
+    expect(result).toEqual(["discord", "telegram", "openrouter", "elevenlabs"]);
+  });
+
+  it("should deduplicate plugin names across env vars", () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord";
+    process.env.WOPR_PLUGINS_OTHER = "discord";
+    const result = parsePluginEnvVars();
+    expect(result).toEqual(["discord"]);
+  });
+
+  it("should trim whitespace from plugin names", () => {
+    process.env.WOPR_PLUGINS_CHANNELS = " discord , telegram ";
+    const result = parsePluginEnvVars();
+    expect(result).toEqual(["discord", "telegram"]);
+  });
+
+  it("should skip empty strings from trailing commas", () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord,,telegram,";
+    const result = parsePluginEnvVars();
+    expect(result).toEqual(["discord", "telegram"]);
+  });
+});
+
+describe("bootstrapEnvPlugins", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.WOPR_PLUGINS_CHANNELS;
+    delete process.env.WOPR_PLUGINS_PROVIDERS;
+    delete process.env.WOPR_PLUGINS_VOICE;
+    delete process.env.WOPR_PLUGINS_OTHER;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return empty result when no env vars set", async () => {
+    const result = await bootstrapEnvPlugins();
+    expect(result).toEqual({ installed: [], skipped: [], failed: [] });
+    expect(installPlugin).not.toHaveBeenCalled();
+  });
+
+  it("should install and enable plugins not already present", async () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord";
+    vi.mocked(listPlugins).mockResolvedValue([]);
+
+    const result = await bootstrapEnvPlugins();
+
+    expect(installPlugin).toHaveBeenCalledWith("discord");
+    expect(enablePlugin).toHaveBeenCalledWith("discord");
+    expect(result.installed).toEqual(["discord"]);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("should skip already-installed and enabled plugins", async () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord";
+    vi.mocked(listPlugins).mockResolvedValue([
+      { name: "discord", version: "1.0.0", path: "/p", enabled: true, installedAt: 0, source: "npm" },
+    ]);
+
+    const result = await bootstrapEnvPlugins();
+
+    expect(installPlugin).not.toHaveBeenCalled();
+    expect(result.skipped).toEqual(["discord"]);
+    expect(result.installed).toEqual([]);
+  });
+
+  it("should enable already-installed but disabled plugins", async () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord";
+    vi.mocked(listPlugins).mockResolvedValue([
+      { name: "discord", version: "1.0.0", path: "/p", enabled: false, installedAt: 0, source: "npm" },
+    ]);
+
+    const result = await bootstrapEnvPlugins();
+
+    expect(installPlugin).not.toHaveBeenCalled();
+    expect(enablePlugin).toHaveBeenCalledWith("discord");
+    expect(result.skipped).toEqual(["discord"]);
+  });
+
+  it("should warn and skip on install failure without crashing", async () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord,telegram";
+    vi.mocked(listPlugins).mockResolvedValue([]);
+    vi.mocked(installPlugin)
+      .mockRejectedValueOnce(new Error("npm registry unreachable"))
+      .mockResolvedValueOnce({
+        name: "telegram",
+        version: "1.0.0",
+        path: "/p",
+        enabled: false,
+        installedAt: 0,
+        source: "npm",
+      });
+
+    const result = await bootstrapEnvPlugins();
+
+    expect(result.failed).toEqual([{ name: "discord", error: "npm registry unreachable" }]);
+    expect(result.installed).toEqual(["telegram"]);
+  });
+
+  it("should handle multiple plugins across all env vars", async () => {
+    process.env.WOPR_PLUGINS_CHANNELS = "discord,telegram";
+    process.env.WOPR_PLUGINS_PROVIDERS = "openrouter";
+    process.env.WOPR_PLUGINS_VOICE = "elevenlabs";
+    vi.mocked(listPlugins).mockResolvedValue([]);
+
+    const result = await bootstrapEnvPlugins();
+
+    expect(result.installed).toEqual(["discord", "telegram", "openrouter", "elevenlabs"]);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1327

- Adds `src/plugins/bootstrap.ts` with `parsePluginEnvVars()` and `bootstrapEnvPlugins()` functions
- `parsePluginEnvVars()` reads `WOPR_PLUGINS_CHANNELS`, `WOPR_PLUGINS_PROVIDERS`, `WOPR_PLUGINS_VOICE`, and `WOPR_PLUGINS_OTHER` env vars, deduplicates, and returns plugin short names
- `bootstrapEnvPlugins()` checks each plugin against `listPlugins()`, installs missing ones via `installPlugin()`, enables them via `enablePlugin()`, and handles errors gracefully (warn + skip, no crash)
- Wires `bootstrapEnvPlugins()` into `src/daemon/index.ts` between `migratePluginJsonToSql()` and `loadAllPlugins()`
- Plugin install failures are collected into `startupWarnings` for visibility

## Test plan
- [x] `npm run check` passes (lint + tsc --noEmit)
- [x] `npx vitest run tests/unit/plugin-bootstrap.test.ts` passes (11 tests)
- [x] Tests cover: empty env vars, parsing all four vars, deduplication, whitespace trim, empty strings from trailing commas, install+enable new plugins, skip already-installed, enable disabled existing plugins, fail gracefully on install error

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins can now be configured and automatically installed via environment variables.
  * Pre-installed plugins are detected and enabled during startup.
  * Enhanced startup reporting includes plugin installation status and failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-install and enable plugins from `WOPR_PLUGINS_*` env vars during daemon startup in `startDaemon`
> Add `bootstrapEnvPlugins` to daemon startup to parse `WOPR_PLUGINS_*` env vars, install or enable listed plugins, and log results in [index.ts](https://github.com/wopr-network/wopr/pull/1559/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078); implement parsing and bootstrap logic in [bootstrap.ts](https://github.com/wopr-network/wopr/pull/1559/files#diff-1a5a9bae715652a4b9150f11167d36dd52a0bb5ab954a63f97f911a5299b2281); add unit tests for parsing and bootstrap routines.
>
> #### 🖇️ Linked Issues
> This pull request implements the behavior requested in [WOP-1327](ticket:jira/WOP-1327) by installing and enabling plugins from environment variables at daemon startup.
>
> #### 📍Where to Start
> Start with `startDaemon` in [index.ts](https://github.com/wopr-network/wopr/pull/1559/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078), then review `bootstrapEnvPlugins` and `parsePluginEnvVars` in [bootstrap.ts](https://github.com/wopr-network/wopr/pull/1559/files#diff-1a5a9bae715652a4b9150f11167d36dd52a0bb5ab954a63f97f911a5299b2281).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 698cc44. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->