### PR TITLE
devops: remove Trivy from Docker build workflow (WOP-1126)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,8 +56,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-,format=short
 
-      # Pass 1: single-platform build for Trivy scanning
-      - name: Build image for scanning
+      # Pass 1: single-platform build (amd64 only, fast — validates the image builds)
+      - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -67,29 +67,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Get short SHA
-        id: short-sha
-        run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-
-      - name: Run Trivy vulnerability scanner
-        id: trivy
-        uses: aquasecurity/trivy-action@0.34.0
-        with:
-          image-ref: ghcr.io/wopr-network/${{ matrix.image }}:sha-${{ steps.short-sha.outputs.sha }}
-          scan-type: image
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '1'
-          format: sarif
-          ignorefile: .trivyignore
-          output: trivy-results.sarif
-
-      - name: Upload Trivy SARIF to GitHub Security
-        if: always() && steps.trivy.outcome != 'skipped'
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
 
       # Pass 2: multi-arch build + push (only on main/tags, reuses GHA cache)
       - name: Build and push multi-arch


### PR DESCRIPTION
## Summary
- Remove `aquasecurity/trivy-action` from `.github/workflows/docker.yml`
- The `ignorefile` param was removed in trivy-action v0.34.0, breaking every Docker build since Feb 26
- This caused `:latest` to go stale, which caused nightly promote-stable to fail with `su-exec: not found` and `tini: not found` (old image artifacts)
- Mirrors the Trivy removal already done in wopr-platform (PR #473)
- Security scanning via npm audit + Dependabot stays in place

## Test plan
- [ ] Docker build workflow passes on merge
- [ ] New `:latest` images pushed for `wopr` and `wopr-slim`
- [ ] Next nightly promote-stable succeeds (or manually re-run it after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Trivy scanning and SARIF upload from the Docker build job in [docker.yml](https://github.com/wopr-network/wopr/pull/1587/files#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94) for WOP-1126
> Delete the Trivy scan and SARIF upload steps and rename the Pass 1 step to `Build image` in [docker.yml](https://github.com/wopr-network/wopr/pull/1587/files#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94).
>
> #### 🖇️ Linked Issues
> This pull request addresses WOP-1126 by removing Trivy integration from the Docker build workflow.
>
> #### 📍Where to Start
> Start with the `build` job changes in [docker.yml](https://github.com/wopr-network/wopr/pull/1587/files#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94), focusing on the removed Trivy and SARIF steps and the renamed Pass 1 step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70b45c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->