### PR TITLE
security: restrict WOPR_SECURITY_ENFORCEMENT override to dev builds only (WOP-1364)

### DIFF
--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -84,10 +84,14 @@ export function getSecurityConfig(): SecurityConfig {
   }
 
   // Allow environment variable override for enforcement mode
-  // This lets developers use WOPR_SECURITY_ENFORCEMENT=warn during local dev
+  // ONLY in non-production environments (dev/test)
+  // In production, env var override is blocked to prevent attackers from
+  // disabling enforcement via environment variable injection (OWASP A01)
   const envEnforcement = process.env.WOPR_SECURITY_ENFORCEMENT;
   if (envEnforcement === "off" || envEnforcement === "warn" || envEnforcement === "enforce") {
-    if (envEnforcement !== config.enforcement) {
+    if (process.env.NODE_ENV === "production") {
+      logger.warn(`[security] WOPR_SECURITY_ENFORCEMENT env var ignored in production (attempted: ${envEnforcement})`);
+    } else if (envEnforcement !== config.enforcement) {
       return { ...config, enforcement: envEnforcement };
     }
   }
@@ -110,10 +114,14 @@ export async function getSecurityConfigAsync(): Promise<SecurityConfig> {
   }
 
   // Allow environment variable override for enforcement mode
-  // This lets developers use WOPR_SECURITY_ENFORCEMENT=warn during local dev
+  // ONLY in non-production environments (dev/test)
+  // In production, env var override is blocked to prevent attackers from
+  // disabling enforcement via environment variable injection (OWASP A01)
   const envEnforcement = process.env.WOPR_SECURITY_ENFORCEMENT;
   if (envEnforcement === "off" || envEnforcement === "warn" || envEnforcement === "enforce") {
-    if (envEnforcement !== config.enforcement) {
+    if (process.env.NODE_ENV === "production") {
+      logger.warn(`[security] WOPR_SECURITY_ENFORCEMENT env var ignored in production (attempted: ${envEnforcement})`);
+    } else if (envEnforcement !== config.enforcement) {
       return { ...config, enforcement: envEnforcement };
     }
   }

--- a/tests/security/policy.test.ts
+++ b/tests/security/policy.test.ts
@@ -743,6 +743,54 @@ describe("Security Policy Module", () => {
       // Async config should apply the same env override as the sync version
       expect(asyncConfig.enforcement).toBe("warn");
     });
+
+    it("should ignore env var override when NODE_ENV is 'production'", () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        process.env.NODE_ENV = "production";
+        process.env.WOPR_SECURITY_ENFORCEMENT = "off";
+        const config = getSecurityConfig();
+        expect(config.enforcement).toBe("enforce"); // default, not overridden
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it("should allow env var override when NODE_ENV is 'development'", () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        process.env.NODE_ENV = "development";
+        process.env.WOPR_SECURITY_ENFORCEMENT = "warn";
+        const config = getSecurityConfig();
+        expect(config.enforcement).toBe("warn");
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it("should allow env var override when NODE_ENV is undefined", () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        delete process.env.NODE_ENV;
+        process.env.WOPR_SECURITY_ENFORCEMENT = "warn";
+        const config = getSecurityConfig();
+        expect(config.enforcement).toBe("warn");
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
+
+    it("should ignore env var override in async version when NODE_ENV is 'production'", async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        process.env.NODE_ENV = "production";
+        process.env.WOPR_SECURITY_ENFORCEMENT = "off";
+        const config = await getSecurityConfigAsync();
+        expect(config.enforcement).toBe("enforce");
+      } finally {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## Summary
Closes WOP-1364

- Blocks `WOPR_SECURITY_ENFORCEMENT` env var from overriding enforcement mode when `NODE_ENV=production`
- In production, the env var is silently ignored with a warning log — no bypass possible
- Override still works in development/test/undefined `NODE_ENV` for local dev workflows
- Adds tests for production guard on both `getSecurityConfig()` (sync) and `getSecurityConfigAsync()`

Fixes OWASP A01 Broken Access Control: attackers could inject env var to disable all policy enforcement.

## Test plan
- [ ] `npm run build` passes
- [ ] `npx vitest run tests/security/policy.test.ts` — new production guard tests pass
- [ ] Existing env var override tests still pass (non-production)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict production overrides of security enforcement and gate `src/security/policy.ts#getSecurityConfig` and `src/security/policy.ts#getSecurityConfigAsync` to apply `WOPR_SECURITY_ENFORCEMENT` only when `process.env.NODE_ENV` is not "production"
> Add production guards that ignore `WOPR_SECURITY_ENFORCEMENT` in `getSecurityConfig` and `getSecurityConfigAsync`, logging a warning in production; tests cover production and non-production behavior in [policy.test.ts](https://github.com/wopr-network/wopr/pull/1635/files#diff-9f39faca706fe5367deb5d1bb58cffc04cb3c1cbc5c9d193c1e8cee959ade364).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1364](ticket:jira/WOP-1364) by preventing production overrides of security enforcement.
>
> #### 📍Where to Start
> Start with the environment override logic in `getSecurityConfig` within [policy.ts](https://github.com/wopr-network/wopr/pull/1635/files#diff-56c1c6f185139c42d133c1c9d4f1b0152c002355efd4b11778ffe5d03de35a36), then review the mirrored changes in `getSecurityConfigAsync`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af3df81.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->