### PR TITLE
security: remove raw()/run() from plugin-facing StorageApi (WOP-1379)

### DIFF
--- a/src/core/session-repository.ts
+++ b/src/core/session-repository.ts
@@ -174,11 +174,15 @@ export async function listSessionsAsync(): Promise<
 /** Get next sequence number for a session */
 async function getNextSequence(sessionId: string): Promise<number> {
   const repo = messagesRepo();
-  const rows = await repo.raw(`SELECT MAX(sequence) as maxSeq FROM sessions_session_messages WHERE "sessionId" = ?`, [
-    sessionId,
-  ]);
-  const row = rows[0] as { maxSeq: number | null } | undefined;
-  return (row?.maxSeq ?? -1) + 1;
+  const messages = await repo
+    .query()
+    .where("sessionId", sessionId)
+    .orderBy("sequence", "desc")
+    .limit(1)
+    .select("sequence")
+    .execute();
+  const maxSeq = messages[0]?.sequence as number | undefined;
+  return (maxSeq ?? -1) + 1;
 }
 
 /** Append a conversation entry (replaces appendToConversationLog) */

--- a/src/storage/api/plugin-storage.ts
+++ b/src/storage/api/plugin-storage.ts
@@ -146,11 +146,6 @@ export interface Repository<T extends Record<string, unknown>, PK extends keyof 
   query(): QueryBuilder<T>;
 
   /**
-   * Execute raw SQL (plugins are trusted)
-   */
-  raw(sql: string, params?: unknown[]): Promise<unknown[]>;
-
-  /**
    * Run operation in transaction
    */
   transaction<R>(fn: (repo: Repository<T>) => Promise<R>): Promise<R>;
@@ -229,16 +224,6 @@ export interface StorageApi {
   getVersion(namespace: string): Promise<number>;
 
   /**
-   * Execute raw SQL across the database (for SELECT queries)
-   */
-  raw(sql: string, params?: unknown[]): Promise<unknown[]>;
-
-  /**
-   * Execute a statement that doesn't return rows (INSERT, UPDATE, DELETE)
-   */
-  run(sql: string, params?: unknown[]): Promise<{ changes: number; lastInsertRowid: number | bigint }>;
-
-  /**
    * Run cross-table transaction
    */
   transaction<R>(fn: (storage: StorageApi) => Promise<R>): Promise<R>;
@@ -248,4 +233,32 @@ export interface StorageApi {
    * Safe to call multiple times. No-op if already closed.
    */
   close(): void;
+}
+
+/**
+ * Internal repository interface — extends Repository with raw SQL access.
+ * ONLY for core code. Never exposed to plugins.
+ */
+export interface InternalRepository<T extends Record<string, unknown>, PK extends keyof T = "id", PKType = T[PK]>
+  extends Repository<T, PK, PKType> {
+  /**
+   * Execute raw SQL (core-only, not available to plugins)
+   */
+  raw(sql: string, params?: unknown[]): Promise<unknown[]>;
+}
+
+/**
+ * Internal storage API — extends StorageApi with raw SQL access.
+ * ONLY for core code. Never exposed to plugins.
+ */
+export interface InternalStorageApi extends StorageApi {
+  /**
+   * Execute raw SQL across the database (core-only)
+   */
+  raw(sql: string, params?: unknown[]): Promise<unknown[]>;
+
+  /**
+   * Execute a statement that doesn't return rows (core-only)
+   */
+  run(sql: string, params?: unknown[]): Promise<{ changes: number; lastInsertRowid: number | bigint }>;
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -15,7 +15,7 @@ import { type blob, integer, type real, sqliteTable, text } from "drizzle-orm/sq
 import { z } from "zod";
 import { logger } from "../logger.js";
 import { WOPR_HOME } from "../paths.js";
-import type { PluginSchema, Repository, StorageApi, TableSchema } from "./api/plugin-storage.js";
+import type { InternalStorageApi, PluginSchema, Repository, StorageApi, TableSchema } from "./api/plugin-storage.js";
 import { DrizzleRepository } from "./repositories/drizzle-repository.js";
 
 /**
@@ -154,7 +154,7 @@ function generateCreateTableSQL(namespace: string, tableName: string, tableSchem
 /**
  * Storage implementation
  */
-export class Storage implements StorageApi {
+export class Storage implements InternalStorageApi {
   readonly driver: "sqlite" | "postgres" = "sqlite";
   readonly dbPath: string;
   private db: BetterSQLite3Database;
@@ -382,7 +382,7 @@ export class Storage implements StorageApi {
 /**
  * Transaction-aware storage wrapper
  */
-class TransactionStorage implements StorageApi {
+class TransactionStorage implements InternalStorageApi {
   readonly driver: "sqlite" | "postgres" = "sqlite";
 
   constructor(

--- a/src/storage/public.ts
+++ b/src/storage/public.ts
@@ -10,6 +10,8 @@ export type {
   Filter,
   FilterCondition,
   FilterOperator,
+  InternalRepository,
+  InternalStorageApi,
   OrderDirection,
   PluginSchema,
   QueryBuilder,

--- a/tests/unit/drizzle-repository.test.ts
+++ b/tests/unit/drizzle-repository.test.ts
@@ -38,7 +38,7 @@ vi.mock("../../src/paths.js", () => ({
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { getStorage, resetStorage } from "../../src/storage/public.js";
-import type { StorageApi } from "../../src/storage/api/plugin-storage.js";
+import type { InternalRepository, StorageApi } from "../../src/storage/api/plugin-storage.js";
 
 // Test schema with boolean field for serialization tests
 const testSchema = z.object({
@@ -271,14 +271,14 @@ describe("DrizzleRepository gap coverage (WOP-954)", () => {
     });
 
     it("should execute SELECT with params and return matching rows", async () => {
-      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const repo = storage.getRepository<TestRecord>("drepo", "items") as InternalRepository<TestRecord>;
       const result = await repo.raw("SELECT * FROM drepo_items WHERE age > ?", [26]);
       expect(result).toHaveLength(1);
       expect((result[0] as TestRecord).name).toBe("Alice");
     });
 
     it("should execute INSERT via raw and report changes", async () => {
-      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const repo = storage.getRepository<TestRecord>("drepo", "items") as InternalRepository<TestRecord>;
       const result = await repo.raw(
         "INSERT INTO drepo_items (id, name, age) VALUES (?, ?, ?)",
         ["3", "Charlie", 35],
@@ -288,25 +288,25 @@ describe("DrizzleRepository gap coverage (WOP-954)", () => {
     });
 
     it("should execute UPDATE via raw and report changes", async () => {
-      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const repo = storage.getRepository<TestRecord>("drepo", "items") as InternalRepository<TestRecord>;
       const result = await repo.raw("UPDATE drepo_items SET age = ? WHERE name = ?", [31, "Alice"]);
       expect((result[0] as { changes: number }).changes).toBe(1);
     });
 
     it("should execute DELETE via raw and report changes", async () => {
-      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const repo = storage.getRepository<TestRecord>("drepo", "items") as InternalRepository<TestRecord>;
       const result = await repo.raw("DELETE FROM drepo_items WHERE id = ?", ["1"]);
       expect((result[0] as { changes: number }).changes).toBe(1);
     });
 
     it("should execute PRAGMA queries and return results", async () => {
-      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const repo = storage.getRepository<TestRecord>("drepo", "items") as InternalRepository<TestRecord>;
       const result = await repo.raw("PRAGMA table_info('drepo_items')");
       expect(result.length).toBeGreaterThan(0);
     });
 
     it("should return empty array for SELECT with no matching rows", async () => {
-      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const repo = storage.getRepository<TestRecord>("drepo", "items") as InternalRepository<TestRecord>;
       const result = await repo.raw("SELECT * FROM drepo_items WHERE age > ?", [999]);
       expect(result).toHaveLength(0);
     });

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../src/paths.js", () => ({
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { getStorage, resetStorage } from "../../src/storage/public.js";
-import type { StorageApi } from "../../src/storage/api/plugin-storage.js";
+import type { InternalRepository, StorageApi } from "../../src/storage/api/plugin-storage.js";
 
 // Test schema
 const testSchema = z.object({
@@ -129,22 +129,26 @@ describe("Storage Module (WOP-545)", () => {
     });
 
     it("should set WAL journal mode", async () => {
-      const result = await storage.getRepository("test", "users").raw("PRAGMA journal_mode");
+      const repo = storage.getRepository("test", "users") as InternalRepository<Record<string, unknown>>;
+      const result = await repo.raw("PRAGMA journal_mode");
       expect(result[0]).toHaveProperty("journal_mode", "wal");
     });
 
     it("should set busy timeout to 5000ms", async () => {
-      const result = await storage.getRepository("test", "users").raw("PRAGMA busy_timeout");
+      const repo = storage.getRepository("test", "users") as InternalRepository<Record<string, unknown>>;
+      const result = await repo.raw("PRAGMA busy_timeout");
       expect(result[0]).toHaveProperty("timeout", 5000);
     });
 
     it("should enable foreign keys", async () => {
-      const result = await storage.getRepository("test", "users").raw("PRAGMA foreign_keys");
+      const repo = storage.getRepository("test", "users") as InternalRepository<Record<string, unknown>>;
+      const result = await repo.raw("PRAGMA foreign_keys");
       expect(result[0]).toHaveProperty("foreign_keys", 1);
     });
 
     it("should set synchronous to NORMAL", async () => {
-      const result = await storage.getRepository("test", "users").raw("PRAGMA synchronous");
+      const repo = storage.getRepository("test", "users") as InternalRepository<Record<string, unknown>>;
+      const result = await repo.raw("PRAGMA synchronous");
       expect(result[0]).toHaveProperty("synchronous", 1); // NORMAL = 1
     });
   });
@@ -204,7 +208,7 @@ describe("Storage Module (WOP-545)", () => {
     });
 
     it("should create single-column index", async () => {
-      const repo = storage.getRepository<TestRecord>("test", "users");
+      const repo = storage.getRepository<TestRecord>("test", "users") as InternalRepository<TestRecord>;
       const result = await repo.raw('PRAGMA index_list("test_users")');
       const indexes = result as Array<{ name: string }>;
       const nameIndex = indexes.find(idx => idx.name === "idx_test_users_name");
@@ -212,7 +216,7 @@ describe("Storage Module (WOP-545)", () => {
     });
 
     it("should create multi-column index", async () => {
-      const repo = storage.getRepository<TestRecord>("test", "users");
+      const repo = storage.getRepository<TestRecord>("test", "users") as InternalRepository<TestRecord>;
       const result = await repo.raw('PRAGMA index_list("test_users")');
       const indexes = result as Array<{ name: string }>;
       const multiIndex = indexes.find(idx => idx.name === "idx_test_users_age_name");
@@ -220,7 +224,7 @@ describe("Storage Module (WOP-545)", () => {
     });
 
     it("should create non-unique index by default", async () => {
-      const repo = storage.getRepository<TestRecord>("test", "users");
+      const repo = storage.getRepository<TestRecord>("test", "users") as InternalRepository<TestRecord>;
       const result = await repo.raw('PRAGMA index_list("test_users")');
       const indexes = result as Array<{ unique: number }>;
       const nameIndex = indexes.find(idx => (idx as unknown as { name: string }).name === "idx_test_users_name");


### PR DESCRIPTION
## Summary
Closes WOP-1379

- Remove `raw()` from `Repository` interface — plugins can no longer execute arbitrary SQL via `repo.raw()`
- Remove `raw()` and `run()` from `StorageApi` interface — plugins can no longer execute arbitrary SQL via `storage.raw()`/`storage.run()`
- Add `InternalRepository` and `InternalStorageApi` interfaces (extend the plugin-facing types with `raw()`/`run()`) for core-internal use only
- `Storage` and `TransactionStorage` now implement `InternalStorageApi` (no runtime change)
- Replace the one `repo.raw()` call in `session-repository.ts` with the query builder API to eliminate raw SQL from core code paths
- Export new internal types from `storage/public.ts` for core callers
- Update test files to cast to `InternalRepository` where `raw()` is exercised

**OWASP A03 Injection** — malicious or compromised plugins could previously call `StorageApi.raw("DROP TABLE ...")` or read any table across any namespace. After this change the plugin-visible surface has no raw SQL escape hatch.

## Test plan
- [x] `npm run check` passes (lint + tsc --noEmit)
- [x] Type errors confirm: plugin code calling `.raw()` on `Repository` or `StorageApi` will fail to compile
- [x] `InternalRepository`/`InternalStorageApi` available for core callers that legitimately need raw access
- [ ] Full test suite passes in CI (storage tests require better-sqlite3 native binary, unavailable in local WSL env — pre-existing)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict plugin-facing `StorageApi` and `Repository<T>` by removing `raw()` and `run()` and update session sequence retrieval in `src/core/session-repository.ts` to use a QueryBuilder query for the next sequence
> Plugin-visible storage and repositories drop raw SQL methods; internal-only interfaces (`InternalStorageApi`, `InternalRepository`) retain them, and the next session sequence now reads the top `sequence` via QueryBuilder instead of `MAX`. Implementations switch to internal interfaces, and tests cast to `InternalRepository` for `raw()` calls.
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1379](ticket:jira/WOP-1379) by removing `raw()`/`run()` from plugin-facing storage APIs.
>
> #### 📍Where to Start
> Start with the interface changes in [plugin-storage.ts](https://github.com/wopr-network/wopr/pull/1638/files#diff-ff8237a0384ad9492b2d6f3aefde6d9041e37a0e7c765a16acede19aa2ce361b), then review the QueryBuilder sequence logic in [session-repository.ts](https://github.com/wopr-network/wopr/pull/1638/files#diff-1e944286a21764cc92d8ec46bc6a3b93e2f65b9e21caf810a78f93bd10bfa0ae).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7497959. 4 files reviewed, 5 issues evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/storage/index.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 366](https://github.com/wopr-network/wopr/blob/74979593b9c20787bac34661a996f4dd3d861902/src/storage/index.ts#L366): The `Storage.transaction` implementation performs a manual `BEGIN` on the shared synchronous `sqliteRaw` connection but allows asynchronous execution of the callback. Since the `Storage` instance is a singleton sharing one database connection, initiating a second transaction (concurrently via `Storage.transaction` or nested via `repo.transaction`) while the first is awaiting an async operation will attempt a second `BEGIN` on the same connection. `better-sqlite3` throws a runtime error ("cannot start a transaction within a transaction") in this scenario, causing crashes under concurrent load or when using repository transactions inside a storage transaction. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->