### PR TITLE
test: add coverage for session-migration and auth-migrate (WOP-1367)

### DIFF
--- a/tests/unit/auth/auth-migrate.test.ts
+++ b/tests/unit/auth/auth-migrate.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+vi.mock("../../../src/logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("../../../src/paths.js", () => ({
+  AUTH_FILE: "/fake/auth.json",
+  WOPR_HOME: "/fake",
+}));
+vi.mock("../../../src/auth.js", () => ({
+  isEncryptedData: vi.fn((data: string) => data.startsWith("ENCRYPTED:")),
+}));
+
+// Shared mutable state for controlling MockDatabaseSync.prepare per-test
+const dbState: {
+  prepare: ((sql: string) => { all: () => unknown[] }) | null;
+} = { prepare: null };
+
+vi.mock("node:module", () => {
+  class MockDatabaseSync {
+    constructor(_path: string, _opts?: unknown) {}
+    prepare(sql: string): { all: () => unknown[] } {
+      if (dbState.prepare) return dbState.prepare(sql);
+      return { all: () => [] };
+    }
+    close() {}
+  }
+  const mockRequire = (mod: string) => {
+    if (mod === "node:sqlite") return { DatabaseSync: MockDatabaseSync };
+    throw new Error(`Unexpected require: ${mod}`);
+  };
+  return { createRequire: vi.fn(() => mockRequire) };
+});
+
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import { migrateAuthJson, migrateAuthSqlite } from "../../../src/auth/auth-migrate.js";
+import type { AuthStore } from "../../../src/auth/auth-store.js";
+
+function mockAuthStore(): AuthStore {
+  return {
+    setCredential: vi.fn(async () => {}),
+    importApiKeyRecord: vi.fn(async () => {}),
+    init: vi.fn(async () => {}),
+    getCredential: vi.fn(async () => null),
+    removeCredential: vi.fn(async () => false),
+    listCredentials: vi.fn(async () => []),
+    createApiKey: vi.fn(async () => ({ rawKey: "", keyInfo: {} as never })),
+    validateApiKey: vi.fn(async () => null),
+    revokeApiKey: vi.fn(async () => false),
+    listApiKeys: vi.fn(async () => []),
+    clearCache: vi.fn(),
+    configCache: new Map(),
+  } as unknown as AuthStore;
+}
+
+describe("migrateAuthJson", () => {
+  let store: AuthStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = mockAuthStore();
+  });
+
+  it("skips when auth.json does not exist", async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    await migrateAuthJson(store);
+    expect(store.setCredential).not.toHaveBeenCalled();
+  });
+
+  it("migrates plaintext JSON auth state", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    const authData = { type: "oauth", token: "abc123" };
+    (readFileSync as Mock).mockReturnValue(JSON.stringify(authData));
+
+    await migrateAuthJson(store);
+
+    expect(store.setCredential).toHaveBeenCalledWith(
+      "wopr-auth-state",
+      "wopr",
+      JSON.stringify(authData),
+    );
+    expect(renameSync).toHaveBeenCalledWith("/fake/auth.json", "/fake/auth.json.migrated");
+  });
+
+  it("migrates encrypted auth state without decrypting", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    const encrypted = "ENCRYPTED:abc123deadbeef";
+    (readFileSync as Mock).mockReturnValue(encrypted);
+
+    await migrateAuthJson(store);
+
+    expect(store.setCredential).toHaveBeenCalledWith(
+      "wopr-auth-state",
+      "wopr",
+      encrypted,
+      "aes-256-gcm",
+    );
+    expect(renameSync).toHaveBeenCalled();
+  });
+
+  it("throws on corrupt JSON that is not encrypted", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    (readFileSync as Mock).mockReturnValue("NOT JSON AND NOT ENCRYPTED");
+
+    await expect(migrateAuthJson(store)).rejects.toThrow();
+    expect(store.setCredential).not.toHaveBeenCalled();
+    expect(renameSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("migrateAuthSqlite", () => {
+  let store: AuthStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = mockAuthStore();
+    dbState.prepare = null;
+  });
+
+  afterEach(() => {
+    dbState.prepare = null;
+  });
+
+  it("skips when auth.sqlite does not exist", async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    await migrateAuthSqlite(store);
+    expect(store.importApiKeyRecord).not.toHaveBeenCalled();
+  });
+
+  it("skips when api_keys table does not exist", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+    // dbState.prepare is null → prepare() returns { all: () => [] } → tables empty
+    await migrateAuthSqlite(store);
+    expect(store.importApiKeyRecord).not.toHaveBeenCalled();
+  });
+
+  it("migrates API key rows from SQLite to AuthStore", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+
+    const row = {
+      id: "key1",
+      user_id: "user1",
+      name: "My Key",
+      key_hash: "somehash",
+      key_prefix: "wopr_abc",
+      scope: "full",
+      last_used_at: null,
+      created_at: 1700000000000,
+      expires_at: null,
+    };
+
+    dbState.prepare = (sql: string) => ({
+      all: () => {
+        if (sql.includes("sqlite_master")) return [{ name: "api_keys" }];
+        return [row];
+      },
+    });
+
+    await migrateAuthSqlite(store);
+
+    expect(store.importApiKeyRecord).toHaveBeenCalledWith({
+      id: "key1",
+      userId: "user1",
+      name: "My Key",
+      keyHash: "somehash",
+      keyPrefix: "wopr_abc",
+      scope: "full",
+      lastUsedAt: undefined,
+      createdAt: 1700000000000,
+      expiresAt: undefined,
+    });
+    expect(renameSync).toHaveBeenCalledWith("/fake/auth.sqlite", "/fake/auth.sqlite.migrated");
+  });
+
+  it("maps non-null last_used_at and expires_at correctly", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+
+    const row = {
+      id: "k2",
+      user_id: "u2",
+      name: "Key2",
+      key_hash: "h2",
+      key_prefix: "wopr_def",
+      scope: "read-only",
+      last_used_at: 1700000005000,
+      created_at: 1700000000000,
+      expires_at: 1800000000000,
+    };
+
+    dbState.prepare = (sql: string) => ({
+      all: () => {
+        if (sql.includes("sqlite_master")) return [{ name: "api_keys" }];
+        return [row];
+      },
+    });
+
+    await migrateAuthSqlite(store);
+
+    expect(store.importApiKeyRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastUsedAt: 1700000005000,
+        expiresAt: 1800000000000,
+      }),
+    );
+  });
+
+  it("migrates multiple rows", async () => {
+    (existsSync as Mock).mockReturnValue(true);
+
+    const rows = [
+      { id: "k1", user_id: "u1", name: "K1", key_hash: "h1", key_prefix: "p1", scope: "full", last_used_at: null, created_at: 1, expires_at: null },
+      { id: "k2", user_id: "u2", name: "K2", key_hash: "h2", key_prefix: "p2", scope: "full", last_used_at: null, created_at: 2, expires_at: null },
+    ];
+
+    dbState.prepare = (sql: string) => ({
+      all: () => {
+        if (sql.includes("sqlite_master")) return [{ name: "api_keys" }];
+        return rows;
+      },
+    });
+
+    await migrateAuthSqlite(store);
+
+    expect(store.importApiKeyRecord).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/core/session-migration.test.ts
+++ b/tests/unit/core/session-migration.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  readdirSync: vi.fn(),
+  createReadStream: vi.fn(),
+}));
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(),
+}));
+vi.mock("node:crypto", () => ({
+  randomUUID: vi.fn(() => "test-uuid-0001"),
+}));
+vi.mock("../../../src/logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("../../../src/paths.js", () => ({
+  SESSIONS_FILE: "/fake/sessions.json",
+  SESSIONS_DIR: "/fake/sessions",
+}));
+vi.mock("../../../src/storage/index.js", () => ({
+  getStorage: vi.fn(),
+}));
+vi.mock("../../../src/core/session-repository.js", () => ({
+  initSessionStorage: vi.fn(async () => {}),
+}));
+
+import { existsSync, readFileSync, renameSync, readdirSync, createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import { getStorage } from "../../../src/storage/index.js";
+import { migrateSessionsToSQL } from "../../../src/core/session-migration.js";
+
+function mockRepo() {
+  return {
+    insert: vi.fn(async (data: unknown) => data),
+    insertMany: vi.fn(async (data: unknown[]) => data),
+    findById: vi.fn(async () => null),
+    findMany: vi.fn(async () => []),
+    findFirst: vi.fn(async () => null),
+    update: vi.fn(async (_id: string, data: unknown) => data),
+    delete: vi.fn(async () => true),
+    updateMany: vi.fn(async () => 0),
+    deleteMany: vi.fn(async () => 0),
+    query: vi.fn(),
+    count: vi.fn(async () => 0),
+  };
+}
+
+describe("migrateSessionsToSQL", () => {
+  let sessionsRepo: ReturnType<typeof mockRepo>;
+  let messagesRepo: ReturnType<typeof mockRepo>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionsRepo = mockRepo();
+    messagesRepo = mockRepo();
+    (getStorage as Mock).mockReturnValue({
+      getRepository: vi.fn((ns: string, table: string) => {
+        if (table === "sessions") return sessionsRepo;
+        if (table === "session_messages") return messagesRepo;
+        return mockRepo();
+      }),
+      register: vi.fn(async () => {}),
+    });
+  });
+
+  it("skips migration when sessions.json does not exist", async () => {
+    (existsSync as Mock).mockReturnValue(false);
+    await migrateSessionsToSQL();
+    expect(sessionsRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it("handles corrupt sessions.json gracefully (no crash)", async () => {
+    (existsSync as Mock).mockImplementation((p: string) => p === "/fake/sessions.json");
+    (readFileSync as Mock).mockReturnValue("NOT VALID JSON{{{");
+    (readdirSync as Mock).mockReturnValue([]);
+
+    await migrateSessionsToSQL();
+    expect(sessionsRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it("migrates a session with all file types present", async () => {
+    (existsSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return true;
+      if (path === "/fake/sessions") return true;
+      if (path.endsWith(".created")) return true;
+      if (path.endsWith(".provider.json")) return true;
+      if (path.endsWith(".conversation.jsonl")) return true;
+      if (path.endsWith(".md")) return true;
+      return false;
+    });
+
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return JSON.stringify({ "my-session": "sess-id-1" });
+      if (path.endsWith(".created")) return "1700000000000";
+      if (path.endsWith(".provider.json")) return JSON.stringify({ name: "anthropic", model: "claude-3" });
+      if (path.endsWith(".md")) return "# Session context";
+      return "";
+    });
+
+    (readdirSync as Mock).mockReturnValue([
+      "my-session.created",
+      "my-session.provider.json",
+      "my-session.conversation.jsonl",
+      "my-session.md",
+    ]);
+
+    const lines = [
+      JSON.stringify({ ts: 1700000001000, from: "user1", content: "hello", type: "message" }),
+      JSON.stringify({ ts: 1700000002000, from: "WOPR", content: "hi back", type: "response" }),
+    ];
+    (createInterface as Mock).mockReturnValue(
+      (async function* () {
+        for (const line of lines) yield line;
+      })(),
+    );
+    (createReadStream as Mock).mockReturnValue({});
+
+    await migrateSessionsToSQL();
+
+    expect(sessionsRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "sess-id-1",
+        name: "my-session",
+        providerId: "anthropic",
+        status: "active",
+        createdAt: 1700000000000,
+        context: "# Session context",
+      }),
+    );
+
+    expect(messagesRepo.insertMany).toHaveBeenCalledTimes(1);
+    const msgs = messagesRepo.insertMany.mock.calls[0][0];
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].role).toBe("user");
+    expect(msgs[0].content).toBe("hello");
+    expect(msgs[1].role).toBe("assistant");
+    expect(msgs[1].content).toBe("hi back");
+    expect(msgs[0].sequence).toBe(0);
+    expect(msgs[1].sequence).toBe(1);
+
+    expect(renameSync).toHaveBeenCalledWith("/fake/sessions.json", "/fake/sessions.json.backup");
+  });
+
+  it("handles missing .created file — falls back to Date.now()", async () => {
+    (existsSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return true;
+      if (path === "/fake/sessions") return false;
+      return false;
+    });
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return JSON.stringify({ "bare-session": "bare-id" });
+      return "";
+    });
+    (readdirSync as Mock).mockReturnValue([]);
+
+    const before = Date.now();
+    await migrateSessionsToSQL();
+
+    const call = sessionsRepo.insert.mock.calls[0][0];
+    expect(call.id).toBe("bare-id");
+    expect(call.createdAt).toBeGreaterThanOrEqual(before);
+    expect(call.providerId).toBeUndefined();
+    expect(call.context).toBeUndefined();
+  });
+
+  it("handles NaN in .created file — falls back to Date.now()", async () => {
+    (existsSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return true;
+      if (path === "/fake/sessions") return false;
+      if (path.endsWith(".created")) return true;
+      return false;
+    });
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return JSON.stringify({ s1: "id1" });
+      if (path.endsWith(".created")) return "not-a-number";
+      return "";
+    });
+    (readdirSync as Mock).mockReturnValue([]);
+
+    const before = Date.now();
+    await migrateSessionsToSQL();
+    expect(sessionsRepo.insert.mock.calls[0][0].createdAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("skips malformed JSONL lines without crashing", async () => {
+    (existsSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return true;
+      if (path === "/fake/sessions") return false;
+      if (path.endsWith(".conversation.jsonl")) return true;
+      return false;
+    });
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return JSON.stringify({ s1: "id1" });
+      return "";
+    });
+
+    const lines = [
+      "NOT JSON",
+      "",
+      "   ",
+      JSON.stringify({ ts: 100, from: "user1", content: "valid", type: "message" }),
+    ];
+    (createInterface as Mock).mockReturnValue(
+      (async function* () {
+        for (const line of lines) yield line;
+      })(),
+    );
+    (createReadStream as Mock).mockReturnValue({});
+    (readdirSync as Mock).mockReturnValue([]);
+
+    await migrateSessionsToSQL();
+
+    expect(messagesRepo.insertMany).toHaveBeenCalledTimes(1);
+    expect(messagesRepo.insertMany.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  it("continues migrating other sessions when one fails", async () => {
+    (existsSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return true;
+      if (path === "/fake/sessions") return false;
+      return false;
+    });
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return JSON.stringify({ s1: "id1", s2: "id2" });
+      return "";
+    });
+    (readdirSync as Mock).mockReturnValue([]);
+
+    sessionsRepo.insert
+      .mockRejectedValueOnce(new Error("DB error"))
+      .mockResolvedValueOnce({});
+
+    await migrateSessionsToSQL();
+    expect(sessionsRepo.insert).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps 'WOPR' sender to assistant role and others to user", async () => {
+    (existsSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return true;
+      if (path === "/fake/sessions") return false;
+      if (path.endsWith(".conversation.jsonl")) return true;
+      return false;
+    });
+    (readFileSync as Mock).mockImplementation((path: string) => {
+      if (path === "/fake/sessions.json") return JSON.stringify({ s1: "id1" });
+      return "";
+    });
+    (readdirSync as Mock).mockReturnValue([]);
+
+    const lines = [
+      JSON.stringify({ ts: 1, from: "system", content: "sys msg", type: "system" }),
+      JSON.stringify({ ts: 2, from: "WOPR", content: "assistant msg", type: "response" }),
+      JSON.stringify({ ts: 3, from: "someuser", content: "user msg", type: "message" }),
+    ];
+    (createInterface as Mock).mockReturnValue(
+      (async function* () {
+        for (const line of lines) yield line;
+      })(),
+    );
+    (createReadStream as Mock).mockReturnValue({});
+
+    await migrateSessionsToSQL();
+
+    const msgs = messagesRepo.insertMany.mock.calls[0][0];
+    expect(msgs[0].role).toBe("system");
+    expect(msgs[1].role).toBe("assistant");
+    expect(msgs[2].role).toBe("user");
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1367

- Add `tests/unit/core/session-migration.test.ts` — 8 tests covering `migrateSessionsToSQL`: early return when no sessions.json, corrupt JSON handling, full forward migration (session + messages), missing/NaN `.created` fallback to Date.now(), malformed JSONL skipping, per-session error isolation, role mapping (WOPR→assistant, system→system, other→user)
- Add `tests/unit/auth/auth-migrate.test.ts` — 9 tests covering `migrateAuthJson` (skip, plaintext, encrypted, corrupt) and `migrateAuthSqlite` (skip, no table, single row with null timestamps, non-null timestamps, multiple rows)
- All mocks via `vi.mock` — no real filesystem, DB, or storage touched

## Test plan
- [x] `npx vitest run tests/unit/core/session-migration.test.ts tests/unit/auth/auth-migrate.test.ts` — 17/17 pass
- [x] `npm run check` passes (lint + tsc --noEmit)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Vitest coverage for `auth-migrate.migrateAuthJson`, `auth-migrate.migrateAuthSqlite`, and `session-migration.migrateSessionsToSQL` to validate session and auth migration behaviors (WOP-1367)
> Add unit tests exercising JSON/plaintext and encrypted auth migration paths, SQLite auth table migration and file renaming, and sessions JSON/JSONL migration with role mapping, error tolerance, and backup handling, centered in [tests/unit/auth/auth-migrate.test.ts](https://github.com/wopr-network/wopr/pull/1642/files#diff-11529fde41e6546d5005d9d7cb57cbfde217074d36bf40a46306a94038b3a76b) and [tests/unit/core/session-migration.test.ts](https://github.com/wopr-network/wopr/pull/1642/files#diff-512159dfcfacd0b525027ffb1d7e220d4bd26d736c6d1c0f3a4dd0546e6854bc).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1367](ticket:jira/WOP-1367) by adding targeted unit tests that cover session and auth migration workflows.
>
> #### 📍Where to Start
> Start with the `migrateAuthJson` and `migrateAuthSqlite` suites in [tests/unit/auth/auth-migrate.test.ts](https://github.com/wopr-network/wopr/pull/1642/files#diff-11529fde41e6546d5005d9d7cb57cbfde217074d36bf40a46306a94038b3a76b), then review the `migrateSessionsToSQL` suite in [tests/unit/core/session-migration.test.ts](https://github.com/wopr-network/wopr/pull/1642/files#diff-512159dfcfacd0b525027ffb1d7e220d4bd26d736c6d1c0f3a4dd0546e6854bc).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d9f802.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->