### PR TITLE
test: document spoofable x-forwarded-for behavior in rate limiter (WOP-1404)

### DIFF
--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -202,4 +202,99 @@ describe("Rate Limiting Middleware", () => {
     });
     expect(res2.status).toBe(200);
   });
+
+  // -----------------------------------------------------------------
+  // WOP-1404: Document spoofable X-Forwarded-For behavior
+  // SECURITY NOTE: When keyByIp is true, the rate limiter trusts
+  // X-Forwarded-For and X-Real-IP headers sent by the client.
+  // These are trivially spoofable unless a trusted reverse proxy
+  // strips and resets them upstream. This is a known limitation.
+  // -----------------------------------------------------------------
+
+  it("should use X-Forwarded-For for key derivation when keyByIp is true (WOP-1404)", async () => {
+    const app = new Hono();
+    app.use("*", rateLimit({ windowMs: 60_000, limit: 1, keyByIp: true }));
+    app.get("/api/test", (c) => c.json({ ok: true }));
+
+    // First request from "1.2.3.4" — allowed
+    const res1 = await app.request("/api/test", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+    expect(res1.status).toBe(200);
+
+    // Second request from same "IP" — rate limited
+    const res2 = await app.request("/api/test", {
+      headers: { "X-Forwarded-For": "1.2.3.4" },
+    });
+    expect(res2.status).toBe(429);
+  });
+
+  it("should allow bypass by rotating X-Forwarded-For value (WOP-1404 — documents spoofable behavior)", async () => {
+    const app = new Hono();
+    app.use("*", rateLimit({ windowMs: 60_000, limit: 1, keyByIp: true }));
+    app.get("/api/test", (c) => c.json({ ok: true }));
+
+    // Each "different IP" gets its own bucket — an attacker can rotate to bypass
+    const res1 = await app.request("/api/test", {
+      headers: { "X-Forwarded-For": "10.0.0.1" },
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/api/test", {
+      headers: { "X-Forwarded-For": "10.0.0.2" },
+    });
+    expect(res2.status).toBe(200);
+
+    const res3 = await app.request("/api/test", {
+      headers: { "X-Forwarded-For": "10.0.0.3" },
+    });
+    expect(res3.status).toBe(200);
+
+    // Meanwhile the "real" IP (10.0.0.1) bucket is exhausted
+    const res4 = await app.request("/api/test", {
+      headers: { "X-Forwarded-For": "10.0.0.1" },
+    });
+    expect(res4.status).toBe(429);
+  });
+
+  it("should fall back to 'anonymous' bucket when no X-Forwarded-For header is present (WOP-1404)", async () => {
+    const app = new Hono();
+    app.use("*", rateLimit({ windowMs: 60_000, limit: 2, keyByIp: true }));
+    app.get("/api/test", (c) => c.json({ ok: true }));
+
+    // Request without X-Forwarded-For or X-Real-IP — falls back to "anonymous"
+    const res1 = await app.request("/api/test");
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request("/api/test");
+    expect(res2.status).toBe(200);
+
+    // Third request hits the "anonymous" bucket limit
+    const res3 = await app.request("/api/test");
+    expect(res3.status).toBe(429);
+  });
+
+  it("should share the 'anonymous' bucket across multiple clients without X-Forwarded-For (WOP-1404)", async () => {
+    const app = new Hono();
+    app.use("*", rateLimit({ windowMs: 60_000, limit: 2, keyByIp: true }));
+    app.get("/api/test", (c) => c.json({ ok: true }));
+
+    // "Client A" — no identifying headers
+    const resA = await app.request("/api/test", {
+      headers: { Authorization: "Bearer client-a" },
+    });
+    expect(resA.status).toBe(200);
+
+    // "Client B" — different auth but still no IP header, shares anonymous bucket
+    const resB = await app.request("/api/test", {
+      headers: { Authorization: "Bearer client-b" },
+    });
+    expect(resB.status).toBe(200);
+
+    // "Client C" — bucket exhausted even though this is a "new" client
+    const resC = await app.request("/api/test", {
+      headers: { Authorization: "Bearer client-c" },
+    });
+    expect(resC.status).toBe(429);
+  });
 });


### PR DESCRIPTION
## Summary
Closes WOP-1404

- Adds 4 new tests to `tests/unit/rate-limit.test.ts` documenting known security limitations of the `keyByIp` rate limiter mode
- Documents that `X-Forwarded-For` header is used for key derivation and is trivially spoofable by clients
- Documents that rotating `X-Forwarded-For` values allows an attacker to bypass per-IP rate limiting
- Documents that requests without any IP header fall back to a shared `"anonymous"` bucket, causing unrelated clients to compete for the same quota

## Test plan
- [ ] `npx vitest run tests/unit/rate-limit.test.ts` passes (15/15 tests)
- [ ] `npm run check` passes (existing warning in a2a-mcp.ts is pre-existing, not introduced here)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests in `tests/unit/rate-limit.test.ts` to document spoofable `X-Forwarded-For` behavior and anonymous bucket fallback in rate limiting with `keyByIp: true` and `limit` 1–2 over a 60,000 ms window
> Add four tests in [rate-limit.test.ts](https://github.com/wopr-network/wopr/pull/1643/files#diff-63b98887039a7550be2fb75c63e489a6ca1406b87b5ba842eebeda464e6b11cf) covering key derivation from `X-Forwarded-For`, bypass by rotating forwarded IPs, and fallback to a shared `anonymous` bucket when no IP header is present.
>
> #### 📍Where to Start
> Start with the new test cases in [rate-limit.test.ts](https://github.com/wopr-network/wopr/pull/1643/files#diff-63b98887039a7550be2fb75c63e489a6ca1406b87b5ba842eebeda464e6b11cf), focusing on the scenarios named for `X-Forwarded-For` handling and the `anonymous` bucket behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e3ed1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->