### PR TITLE
security: guard _setTokenVerifier and _resetForTesting behind NODE_ENV=test (WOP-1389)

### DIFF
--- a/src/daemon/ws.ts
+++ b/src/daemon/ws.ts
@@ -43,6 +43,9 @@ function verifyToken(provided: string): boolean {
 let tokenVerifierOverride: ((token: string) => boolean) | null = null;
 
 export function _setTokenVerifier(fn: ((token: string) => boolean) | null): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("_setTokenVerifier is test-only");
+  }
   tokenVerifierOverride = fn;
 }
 
@@ -442,6 +445,9 @@ export function getSubscriptionStats(): { clients: number; totalSubscriptions: n
  * Reset all state (for testing).
  */
 export function _resetForTesting(): void {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("_resetForTesting is test-only");
+  }
   clients.clear();
   tokenVerifierOverride = null;
 }

--- a/tests/unit/ws.test.ts
+++ b/tests/unit/ws.test.ts
@@ -677,6 +677,28 @@ describe("Subscription stats", () => {
   });
 });
 
+describe("Test-only guards", () => {
+  it("_setTokenVerifier throws outside test environment", () => {
+    const origEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "production";
+      expect(() => _setTokenVerifier(() => true)).toThrow("_setTokenVerifier is test-only");
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+
+  it("_resetForTesting throws outside test environment", () => {
+    const origEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = "production";
+      expect(() => _resetForTesting()).toThrow("_resetForTesting is test-only");
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+});
+
 describe("Multiple clients", () => {
   it("should deliver to all matching clients independently", () => {
     const ws1 = createMockWs();


### PR DESCRIPTION
## Summary
Closes WOP-1389

- Guards `_setTokenVerifier` behind `NODE_ENV !== "test"` check — throws in production, preventing plugins from overriding WebSocket auth globally
- Guards `_resetForTesting` the same way for consistency (it also mutates `tokenVerifierOverride`)
- Both functions remain exported so existing test imports work unchanged
- Added two new test cases verifying both guards throw when `NODE_ENV` is set to `"production"`

## Test plan
- [ ] `npm run build` passes
- [ ] Targeted tests pass (`npx vitest run tests/unit/ws.test.ts`) — all 48 tests pass
- [ ] Guard tests confirm functions throw with message when `NODE_ENV !== "test"`
- [ ] Existing tests confirm functions work normally under Vitest (which sets `NODE_ENV=test`)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `ws._setTokenVerifier` and `ws._resetForTesting` to throw unless `process.env.NODE_ENV === "test"` to enforce test-only usage in [ws.ts](https://github.com/wopr-network/wopr/pull/1644/files#diff-e665b94f790667d6f6d6dce3cca8b8e346313dde40345ed0afc0e97de1f9b520)
> Add `NODE_ENV === "test"` checks to `ws._setTokenVerifier` and `ws._resetForTesting`, throwing specific errors when called otherwise, and add unit tests for these guards in [ws.test.ts](https://github.com/wopr-network/wopr/pull/1644/files#diff-264c316760ceed8a0f5dfdcacab4e2ae6c69f726a0f70333c47bba9337f169ee)
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1389](ticket:jira/WOP-1389) by restricting test-only utilities to the test environment.
>
> #### 📍Where to Start
> Start with the guard logic in `ws._setTokenVerifier` and `ws._resetForTesting` in [ws.ts](https://github.com/wopr-network/wopr/pull/1644/files#diff-e665b94f790667d6f6d6dce3cca8b8e346313dde40345ed0afc0e97de1f9b520).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34e4dff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->