### PR TITLE
security: pass --ignore-scripts to npm install in plugin installation (WOP-1388)

### DIFF
--- a/src/plugins/installation.ts
+++ b/src/plugins/installation.ts
@@ -102,12 +102,15 @@ export async function installPlugin(source: string): Promise<InstalledPlugin> {
     const pkgPath = join(pluginDir, "package.json");
     if (existsSync(pkgPath)) {
       logger.info(`[plugins] Installing dependencies for ${repo}...`);
-      execFileSync("npm", ["install"], { cwd: pluginDir, stdio: "inherit" });
+      execFileSync("npm", ["install", "--ignore-scripts"], { cwd: pluginDir, stdio: "inherit" });
 
-      // Build TypeScript plugins if tsconfig.json exists
+      // Security: build scripts are NOT run automatically — npm lifecycle
+      // scripts can execute arbitrary code (OWASP A08). Users must review
+      // plugin source and run `npm run build` manually for TypeScript plugins.
       if (existsSync(join(pluginDir, "tsconfig.json"))) {
-        logger.info(`[plugins] Building TypeScript plugin...`);
-        execFileSync("npm", ["run", "build"], { cwd: pluginDir, stdio: "inherit" });
+        logger.info(
+          `[plugins] TypeScript plugin detected. Run 'npm run build' manually in ${pluginDir} after reviewing the source.`,
+        );
       }
     }
 
@@ -145,12 +148,12 @@ export async function installPlugin(source: string): Promise<InstalledPlugin> {
     const pkgPath = join(pluginDir, "package.json");
     if (existsSync(pkgPath)) {
       logger.info(`[plugins] Installing dependencies for local plugin...`);
-      execFileSync("npm", ["install"], { cwd: pluginDir, stdio: "inherit" });
+      execFileSync("npm", ["install", "--ignore-scripts"], { cwd: pluginDir, stdio: "inherit" });
 
-      // Build TypeScript plugins if tsconfig.json exists
       if (existsSync(join(pluginDir, "tsconfig.json"))) {
-        logger.info(`[plugins] Building TypeScript plugin...`);
-        execFileSync("npm", ["run", "build"], { cwd: pluginDir, stdio: "inherit" });
+        logger.info(
+          `[plugins] TypeScript plugin detected. Run 'npm run build' manually in ${pluginDir} after reviewing the source.`,
+        );
       }
     }
 
@@ -181,7 +184,7 @@ export async function installPlugin(source: string): Promise<InstalledPlugin> {
     mkdirSync(pluginDir, { recursive: true });
 
     // Use npm to install
-    execFileSync("npm", ["install", npmPackage], { cwd: pluginDir, stdio: "inherit" });
+    execFileSync("npm", ["install", "--ignore-scripts", npmPackage], { cwd: pluginDir, stdio: "inherit" });
 
     // Read installed package metadata (scoped packages are nested: node_modules/@scope/name)
     const pkgPath = join(pluginDir, "node_modules", "@wopr-network", `plugin-${shortName}`, "package.json");

--- a/tests/unit/plugin-installation.test.ts
+++ b/tests/unit/plugin-installation.test.ts
@@ -260,3 +260,92 @@ describe("installPlugin — valid local plugin directory", () => {
     expect(result.name).toBe("existing-plugin");
   });
 });
+
+// ============================================================================
+// npm --ignore-scripts flag (WOP-1388)
+// ============================================================================
+
+describe("installPlugin — npm install uses --ignore-scripts", () => {
+  it("passes --ignore-scripts for github source", async () => {
+    const cp = await import("node:child_process");
+    const execFileSyncMock = vi.mocked(cp.execFileSync);
+
+    const pluginSrc = join(testExternalDir, "gh-plugin");
+    mkdirSync(pluginSrc, { recursive: true });
+
+    await installPlugin("github:test-org/gh-plugin");
+
+    // Find the npm install call (not the git clone/pull call)
+    const calls = execFileSyncMock.mock.calls;
+    const npmInstallCall = calls.find(
+      (c) => c[0] === "npm" && Array.isArray(c[1]) && c[1][0] === "install",
+    );
+    expect(npmInstallCall).toBeDefined();
+    expect(npmInstallCall![1]).toContain("--ignore-scripts");
+  });
+
+  it("passes --ignore-scripts for local source", async () => {
+    const cp = await import("node:child_process");
+    const execFileSyncMock = vi.mocked(cp.execFileSync);
+
+    const pluginSrc = join(testExternalDir, "local-safe");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({ name: "local-safe", version: "1.0.0" }),
+    );
+
+    await installPlugin(pluginSrc);
+
+    const calls = execFileSyncMock.mock.calls;
+    const npmInstallCall = calls.find(
+      (c) => c[0] === "npm" && Array.isArray(c[1]) && c[1][0] === "install",
+    );
+    expect(npmInstallCall).toBeDefined();
+    expect(npmInstallCall![1]).toContain("--ignore-scripts");
+  });
+
+  it("passes --ignore-scripts for npm package source", async () => {
+    const cp = await import("node:child_process");
+    const execFileSyncMock = vi.mocked(cp.execFileSync);
+
+    await installPlugin("discord");
+
+    const calls = execFileSyncMock.mock.calls;
+    // Find the call that installs the scoped package (npm path)
+    const npmInstallCall = calls.find(
+      (c) =>
+        c[0] === "npm" &&
+        Array.isArray(c[1]) &&
+        (c[1] as string[]).some((arg) => arg.includes("@wopr-network")),
+    );
+    expect(npmInstallCall).toBeDefined();
+    expect(npmInstallCall![1]).toContain("--ignore-scripts");
+    expect(npmInstallCall![1]).toContain("@wopr-network/plugin-discord");
+  });
+
+  it("does not call npm run build automatically", async () => {
+    const cp = await import("node:child_process");
+    const execFileSyncMock = vi.mocked(cp.execFileSync);
+
+    const pluginSrc = join(testExternalDir, "ts-plugin");
+    mkdirSync(pluginSrc, { recursive: true });
+    writeFileSync(
+      join(pluginSrc, "package.json"),
+      JSON.stringify({ name: "ts-plugin", version: "1.0.0" }),
+    );
+    writeFileSync(join(pluginSrc, "tsconfig.json"), JSON.stringify({}));
+
+    await installPlugin(pluginSrc);
+
+    const calls = execFileSyncMock.mock.calls;
+    const buildCall = calls.find(
+      (c) =>
+        c[0] === "npm" &&
+        Array.isArray(c[1]) &&
+        c[1][0] === "run" &&
+        c[1][1] === "build",
+    );
+    expect(buildCall).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1388

- Added `--ignore-scripts` to all three `npm install` calls in `installPlugin()` (github, local, and npm package paths)
- Removed automatic `npm run build` for TypeScript plugins — users must review source and build manually
- Added logger.info message directing users to run `npm run build` manually when a tsconfig.json is detected
- Added 4 new tests verifying `--ignore-scripts` is passed for all source types and that `npm run build` is never called automatically

## Test plan
- [x] `npm run check` passes (lint + type check)
- [x] Targeted tests pass: `npx vitest run tests/unit/plugin-installation.test.ts` — 13/13 pass
- [x] All three install paths (github, local, npm) now use `--ignore-scripts`
- [x] Auto-build removed; manual build instruction logged for TypeScript plugins

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass --ignore-scripts to npm install and remove automatic TypeScript build in `plugins.installPlugin` for GitHub, local, and npm plugin installation flows
> Update plugin installation to call `npm install --ignore-scripts` across all source types and stop invoking `npm run build`; add log guidance for TypeScript plugins. Primary changes are in [installation.ts](https://github.com/wopr-network/wopr/pull/1645/files#diff-8f474832604c95d5c7a989a4b77a154c9df7c3e18198352544b3bae2c6873091). Add tests validating `--ignore-scripts` usage and absence of auto-build in [plugin-installation.test.ts](https://github.com/wopr-network/wopr/pull/1645/files#diff-61531fb7379b087b36af6115b0f423dd5699d211c611b46b7af381c2cff2b243).
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1388](ticket:jira/WOP-1388) by enforcing `--ignore-scripts` during plugin installation and removing automatic TypeScript builds.
>
> #### 📍Where to Start
> Start with `plugins.installPlugin` in [installation.ts](https://github.com/wopr-network/wopr/pull/1645/files#diff-8f474832604c95d5c7a989a4b77a154c9df7c3e18198352544b3bae2c6873091) to review the new `npm install --ignore-scripts` call and removed auto-build logic, then check test assertions in [plugin-installation.test.ts](https://github.com/wopr-network/wopr/pull/1645/files#diff-61531fb7379b087b36af6115b0f423dd5699d211c611b46b7af381c2cff2b243).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bb3c34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->