### PR TITLE
fix: make OAuth token URL configurable via WOPR_OAUTH_TOKEN_URL env var (WOP-1403)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@
 # Discord Bot Token (optional - for Discord integration)
 # Get from: https://discord.com/developers/applications
 DISCORD_TOKEN=
+
+# OAuth Token URL (optional - defaults to Anthropic's endpoint)
+# Override to use a different OAuth provider endpoint
+# WOPR_OAUTH_TOKEN_URL=https://console.anthropic.com/v1/oauth/token

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -24,7 +24,7 @@ const CLAUDE_CODE_CREDENTIALS = join(homedir(), ".claude", ".credentials.json");
 // Anthropic OAuth configuration
 const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const OAUTH_AUTH_URL = "https://claude.ai/oauth/authorize";
-const OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
+const OAUTH_TOKEN_URL = process.env.WOPR_OAUTH_TOKEN_URL ?? "https://console.anthropic.com/v1/oauth/token";
 const OAUTH_SCOPES = ["org:create_api_key", "user:profile", "user:inference"];
 
 // Required beta headers for Claude Code


### PR DESCRIPTION
## Summary
Closes WOP-1403

- Replace hardcoded `"https://console.anthropic.com/v1/oauth/token"` in `src/auth.ts:27` with `process.env.WOPR_OAUTH_TOKEN_URL ?? "https://console.anthropic.com/v1/oauth/token"`
- Document `WOPR_OAUTH_TOKEN_URL` in `.env.example`

## Test plan
- [ ] `npm run check` passes (lint + type check)
- [ ] `OAUTH_TOKEN_URL` constant now reads from `WOPR_OAUTH_TOKEN_URL` env var with Anthropic URL as default
- [ ] Both `exchangeCode()` and `refreshAccessToken()` continue to use the constant unchanged

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `src/auth.ts` use `process.env.WOPR_OAUTH_TOKEN_URL` to set the OAuth token endpoint for Anthropic token acquisition
> Update `OAUTH_TOKEN_URL` to read from `process.env.WOPR_OAUTH_TOKEN_URL` with a fallback to `https://console.anthropic.com/v1/oauth/token`, and add an example entry in [.env.example](https://github.com/wopr-network/wopr/pull/1646/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c).
>
> #### 📍Where to Start
> Start in `auth.OAUTH_TOKEN_URL` within [src/auth.ts](https://github.com/wopr-network/wopr/pull/1646/files#diff-84a5d130fb4cccb80f78601d140f1d5397dc0272f94cea672a8470539fcf6dc7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da1b6cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->