### PR TITLE
fix: log selfdoc dynamic import errors instead of swallowing (WOP-1390)

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -418,8 +418,8 @@ export async function initContextSystem(): Promise<void> {
         registerContextProvider(mod.selfDocContextProvider);
       }
     })
-    .catch(() => {
-      // Self-doc provider is optional
+    .catch((err) => {
+      logger.debug("[context] selfdoc provider unavailable:", err);
     });
 
   // Ensure workspace exists with bootstrap files


### PR DESCRIPTION
## Summary
Closes WOP-1390

- Replace silent `catch(() => {})` on the selfdoc dynamic import with a debug-level log
- Errors are now visible via `logger.debug` instead of being swallowed entirely
- Follows the same pattern as the workspace error handler at line 434

## Test plan
- [ ] `npm run check` passes (lint + tsc)
- [ ] No behavioral change — selfdoc provider remains optional, only logging added

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log self-documentation provider dynamic import errors in `src/core/context.ts:initContextSystem` to aid troubleshooting (WOP-1390)
> Replace the empty catch for the selfdoc provider import with `logger.debug` that records the error in [context.ts](https://github.com/wopr-network/wopr/pull/1647/files#diff-c02b4d62dc54667a8a1243f8ddc5ae0a604cc5d7218d94fd69bfda1c8514ce1f).
>
> #### 🖇️ Linked Issues
> This pull request references [WOP-1390](ticket:jira/WOP-1390) by adding debug logging when the selfdoc dynamic import fails.
>
> #### 📍Where to Start
> Start in `initContextSystem` within [context.ts](https://github.com/wopr-network/wopr/pull/1647/files#diff-c02b4d62dc54667a8a1243f8ddc5ae0a604cc5d7218d94fd69bfda1c8514ce1f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8a0d47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->