### PR TITLE
test: add auth-schema and selfdoc-context unit tests (WOP-1392)

### DIFF
--- a/tests/unit/auth-schema.test.ts
+++ b/tests/unit/auth-schema.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { authApiKeySchema, authCredentialSchema, authPluginSchema } from "../../src/auth/auth-schema.js";
+
+describe("authCredentialSchema", () => {
+  it("accepts a valid credential record", () => {
+    const valid = {
+      id: "anthropic-key-1",
+      provider: "anthropic",
+      encryptedValue: "encrypted-data-here",
+      encryptionMethod: "aes-256-gcm",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    expect(authCredentialSchema.parse(valid)).toEqual(valid);
+  });
+
+  it("accepts a credential without optional encryptionMethod", () => {
+    const valid = {
+      id: "openai-key-1",
+      provider: "openai",
+      encryptedValue: "plaintext-key",
+      createdAt: 1000,
+      updatedAt: 2000,
+    };
+    const result = authCredentialSchema.parse(valid);
+    expect(result.id).toBe("openai-key-1");
+    expect(result.encryptionMethod).toBeUndefined();
+  });
+
+  it("rejects a credential missing required id", () => {
+    const invalid = {
+      provider: "anthropic",
+      encryptedValue: "data",
+      createdAt: 1000,
+      updatedAt: 2000,
+    };
+    expect(() => authCredentialSchema.parse(invalid)).toThrow();
+  });
+
+  it("rejects a credential missing required provider", () => {
+    const invalid = {
+      id: "key-1",
+      encryptedValue: "data",
+      createdAt: 1000,
+      updatedAt: 2000,
+    };
+    expect(() => authCredentialSchema.parse(invalid)).toThrow();
+  });
+
+  it("rejects a credential with wrong type for createdAt", () => {
+    const invalid = {
+      id: "key-1",
+      provider: "anthropic",
+      encryptedValue: "data",
+      createdAt: "not-a-number",
+      updatedAt: 2000,
+    };
+    expect(() => authCredentialSchema.parse(invalid)).toThrow();
+  });
+
+  it("rejects a completely empty object", () => {
+    expect(() => authCredentialSchema.parse({})).toThrow();
+  });
+
+  it("rejects null and undefined", () => {
+    expect(() => authCredentialSchema.parse(null)).toThrow();
+    expect(() => authCredentialSchema.parse(undefined)).toThrow();
+  });
+});
+
+describe("authApiKeySchema", () => {
+  it("accepts a fully populated API key record", () => {
+    const valid = {
+      id: "uuid-1234",
+      userId: "user-1",
+      name: "My API Key",
+      keyHash: "scrypt-hash-here",
+      keyPrefix: "wopr_abc123",
+      scope: "full",
+      lastUsedAt: Date.now(),
+      createdAt: Date.now(),
+      expiresAt: Date.now() + 86400000,
+    };
+    expect(authApiKeySchema.parse(valid)).toEqual(valid);
+  });
+
+  it("accepts an API key with only required fields", () => {
+    const minimal = {
+      id: "uuid-5678",
+      name: "Minimal Key",
+      keyHash: "hash",
+      keyPrefix: "wopr_xyz789",
+      createdAt: Date.now(),
+    };
+    const result = authApiKeySchema.parse(minimal);
+    expect(result.userId).toBeUndefined();
+    expect(result.scope).toBeUndefined();
+    expect(result.lastUsedAt).toBeUndefined();
+    expect(result.expiresAt).toBeUndefined();
+  });
+
+  it("rejects an API key missing required name", () => {
+    const invalid = {
+      id: "uuid-1",
+      keyHash: "hash",
+      keyPrefix: "wopr_abc",
+      createdAt: 1000,
+    };
+    expect(() => authApiKeySchema.parse(invalid)).toThrow();
+  });
+
+  it("rejects an API key missing required keyHash", () => {
+    const invalid = {
+      id: "uuid-1",
+      name: "Key",
+      keyPrefix: "wopr_abc",
+      createdAt: 1000,
+    };
+    expect(() => authApiKeySchema.parse(invalid)).toThrow();
+  });
+
+  it("rejects an API key with wrong type for expiresAt", () => {
+    const invalid = {
+      id: "uuid-1",
+      name: "Key",
+      keyHash: "hash",
+      keyPrefix: "wopr_abc",
+      createdAt: 1000,
+      expiresAt: "tomorrow",
+    };
+    expect(() => authApiKeySchema.parse(invalid)).toThrow();
+  });
+});
+
+describe("authPluginSchema", () => {
+  it("has namespace 'auth'", () => {
+    expect(authPluginSchema.namespace).toBe("auth");
+  });
+
+  it("has version 1", () => {
+    expect(authPluginSchema.version).toBe(1);
+  });
+
+  it("defines auth_credentials table with correct primaryKey", () => {
+    expect(authPluginSchema.tables.auth_credentials).toBeDefined();
+    expect(authPluginSchema.tables.auth_credentials.primaryKey).toBe("id");
+  });
+
+  it("defines auth_api_keys table with correct primaryKey", () => {
+    expect(authPluginSchema.tables.auth_api_keys).toBeDefined();
+    expect(authPluginSchema.tables.auth_api_keys.primaryKey).toBe("id");
+  });
+
+  it("has provider and updatedAt indexes on auth_credentials", () => {
+    const indexes = authPluginSchema.tables.auth_credentials.indexes;
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fields: ["provider"] }),
+        expect.objectContaining({ fields: ["updatedAt"] }),
+      ]),
+    );
+  });
+
+  it("has keyPrefix, userId, createdAt, expiresAt indexes on auth_api_keys", () => {
+    const indexes = authPluginSchema.tables.auth_api_keys.indexes;
+    expect(indexes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fields: ["keyPrefix"] }),
+        expect.objectContaining({ fields: ["userId"] }),
+        expect.objectContaining({ fields: ["createdAt"] }),
+        expect.objectContaining({ fields: ["expiresAt"] }),
+      ]),
+    );
+  });
+});

--- a/tests/unit/selfdoc-context.test.ts
+++ b/tests/unit/selfdoc-context.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the session-context-repository module BEFORE importing selfdoc-context
+vi.mock("../../src/core/session-context-repository.js", () => ({
+  initSessionContextStorage: vi.fn().mockResolvedValue(undefined),
+  resetSessionContextStorageInit: vi.fn(),
+  getSessionContext: vi.fn().mockResolvedValue(null),
+  setSessionContext: vi.fn().mockResolvedValue(undefined),
+  listSessionContextFiles: vi.fn().mockResolvedValue([]),
+}));
+
+// Mock logger to suppress output
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  getSessionContext,
+  initSessionContextStorage,
+  listSessionContextFiles,
+  setSessionContext,
+} from "../../src/core/session-context-repository.js";
+import { createDefaultSelfDoc, selfDocContextProvider } from "../../src/core/selfdoc-context.js";
+
+const mockGetSessionContext = vi.mocked(getSessionContext);
+const mockSetSessionContext = vi.mocked(setSessionContext);
+const mockListFiles = vi.mocked(listSessionContextFiles);
+const mockInitStorage = vi.mocked(initSessionContextStorage);
+
+describe("selfDocContextProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionContext.mockResolvedValue(null);
+    mockListFiles.mockResolvedValue([]);
+    mockInitStorage.mockResolvedValue(undefined);
+  });
+
+  it("has name 'selfdoc' and priority 15", () => {
+    expect(selfDocContextProvider.name).toBe("selfdoc");
+    expect(selfDocContextProvider.priority).toBe(15);
+    expect(selfDocContextProvider.enabled).toBe(true);
+  });
+
+  it("returns null when no files are stored", async () => {
+    const result = await selfDocContextProvider.getContext("test-session");
+    expect(result).toBeNull();
+    expect(mockInitStorage).toHaveBeenCalled();
+  });
+
+  it("returns context with IDENTITY.md content when present", async () => {
+    mockGetSessionContext.mockImplementation(async (session: string, filename: string) => {
+      if (session === "my-session" && filename === "IDENTITY.md") {
+        return "I am WOPR";
+      }
+      return null;
+    });
+
+    const result = await selfDocContextProvider.getContext("my-session");
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("## IDENTITY");
+    expect(result!.content).toContain("I am WOPR");
+    expect(result!.role).toBe("context");
+    expect(result!.metadata?.source).toBe("selfdoc");
+    expect(result!.metadata?.priority).toBe(15);
+  });
+
+  it("loads multiple selfdoc files in order", async () => {
+    mockGetSessionContext.mockImplementation(async (session: string, filename: string) => {
+      if (filename === "IDENTITY.md") return "identity content";
+      if (filename === "AGENTS.md") return "agents content";
+      if (filename === "USER.md") return "user content";
+      return null;
+    });
+
+    const result = await selfDocContextProvider.getContext("my-session");
+    expect(result).not.toBeNull();
+    const content = result!.content;
+    // IDENTITY should appear before AGENTS, AGENTS before USER
+    const identityIdx = content.indexOf("identity content");
+    const agentsIdx = content.indexOf("agents content");
+    const userIdx = content.indexOf("user content");
+    expect(identityIdx).toBeLessThan(agentsIdx);
+    expect(agentsIdx).toBeLessThan(userIdx);
+    expect(result!.metadata?.loadedFiles).toEqual(["IDENTITY.md", "AGENTS.md", "USER.md"]);
+  });
+
+  it("falls back to __global__ when session-specific file is missing", async () => {
+    // readSelfDocFile checks session first, then __global__
+    mockGetSessionContext.mockImplementation(async (session: string, filename: string) => {
+      if (session === "__global__" && filename === "AGENTS.md") {
+        return "global agents";
+      }
+      return null;
+    });
+
+    const result = await selfDocContextProvider.getContext("my-session");
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("global agents");
+  });
+
+  it("loads SELF.md from global identity", async () => {
+    mockGetSessionContext.mockImplementation(async (session: string, filename: string) => {
+      if (session === "__global__" && filename === "memory/SELF.md") {
+        return "I remember everything";
+      }
+      return null;
+    });
+
+    const result = await selfDocContextProvider.getContext("my-session");
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("SELF (Long-term Memory)");
+    expect(result!.content).toContain("I remember everything");
+    expect(result!.metadata?.loadedFiles).toContain("memory/SELF.md");
+  });
+
+  it("loads recent memory files and limits to last 7 days", async () => {
+    const dates = [
+      "2026-02-20",
+      "2026-02-21",
+      "2026-02-22",
+      "2026-02-23",
+      "2026-02-24",
+      "2026-02-25",
+      "2026-02-26",
+      "2026-02-27",
+      "2026-02-28",
+    ];
+    const filenames = dates.map((d) => `memory/${d}.md`);
+
+    mockListFiles.mockResolvedValue(filenames);
+    mockGetSessionContext.mockImplementation(async (_session: string, filename: string) => {
+      if (filename.startsWith("memory/") && filename.match(/\d{4}-\d{2}-\d{2}\.md$/)) {
+        return `Notes for ${filename}`;
+      }
+      return null;
+    });
+
+    const result = await selfDocContextProvider.getContext("my-session");
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("Recent Memory (last 7 days)");
+    // Should only have 7, not 9
+    expect(result!.content).not.toContain("2026-02-20");
+    expect(result!.content).not.toContain("2026-02-21");
+    expect(result!.content).toContain("2026-02-22");
+    expect(result!.content).toContain("2026-02-28");
+  });
+
+  it("handles error in listSessionContextFiles gracefully", async () => {
+    mockListFiles.mockRejectedValue(new Error("storage unavailable"));
+    mockGetSessionContext.mockImplementation(async (session: string, filename: string) => {
+      if (filename === "IDENTITY.md") return "still works";
+      return null;
+    });
+
+    // Should not throw — readRecentMemoryFiles catches errors
+    const result = await selfDocContextProvider.getContext("my-session");
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain("still works");
+  });
+});
+
+describe("createDefaultSelfDoc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionContext.mockResolvedValue(null);
+    mockSetSessionContext.mockResolvedValue(undefined);
+    mockInitStorage.mockResolvedValue(undefined);
+  });
+
+  it("creates IDENTITY.md, AGENTS.md, and USER.md when missing", async () => {
+    await createDefaultSelfDoc("new-session", { agentName: "TestBot", userName: "Alice" });
+
+    // Should have called setSessionContext for each of the 3 files
+    expect(mockSetSessionContext).toHaveBeenCalledTimes(3);
+
+    const calls = mockSetSessionContext.mock.calls;
+    const filenames = calls.map((c) => c[1]);
+    expect(filenames).toContain("IDENTITY.md");
+    expect(filenames).toContain("AGENTS.md");
+    expect(filenames).toContain("USER.md");
+
+    // Check IDENTITY.md content includes agent name
+    const identityCall = calls.find((c) => c[1] === "IDENTITY.md");
+    expect(identityCall![2]).toContain("TestBot");
+
+    // Check USER.md content includes user name
+    const userCall = calls.find((c) => c[1] === "USER.md");
+    expect(userCall![2]).toContain("Alice");
+  });
+
+  it("uses defaults when no options provided", async () => {
+    await createDefaultSelfDoc("new-session");
+
+    const identityCall = mockSetSessionContext.mock.calls.find((c) => c[1] === "IDENTITY.md");
+    expect(identityCall![2]).toContain("WOPR Assistant");
+
+    const userCall = mockSetSessionContext.mock.calls.find((c) => c[1] === "USER.md");
+    expect(userCall![2]).toContain("Unknown");
+  });
+
+  it("does not overwrite existing files", async () => {
+    // Simulate IDENTITY.md already exists
+    mockGetSessionContext.mockImplementation(async (_session: string, filename: string) => {
+      if (filename === "IDENTITY.md") return "existing identity";
+      return null;
+    });
+
+    await createDefaultSelfDoc("existing-session");
+
+    // setSessionContext should NOT be called for IDENTITY.md
+    const filenames = mockSetSessionContext.mock.calls.map((c) => c[1]);
+    expect(filenames).not.toContain("IDENTITY.md");
+    // But should be called for AGENTS.md and USER.md
+    expect(filenames).toContain("AGENTS.md");
+    expect(filenames).toContain("USER.md");
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1392

- Add 18 Zod validation tests for `authCredentialSchema`, `authApiKeySchema`, and `authPluginSchema` in `src/auth/auth-schema.ts`
- Add 11 unit tests for `selfDocContextProvider` and `createDefaultSelfDoc` in `src/core/selfdoc-context.ts`, using `vi.mock` to isolate from storage layer
- Tests cover happy paths, optional field handling, error cases, fallback to `__global__`, 7-day memory file limit, and write-if-missing behavior

## Test plan
- [ ] `npm run check` passes (lint + typecheck)
- [ ] `npx vitest run tests/unit/auth-schema.test.ts` — 18 tests pass
- [ ] `npx vitest run tests/unit/selfdoc-context.test.ts` — 11 tests pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for auth schemas and selfdoc context to validate parsing rules, static metadata, index presence, file ordering, and 7-day memory limits in [tests/unit/auth-schema.test.ts](https://github.com/wopr-network/wopr/pull/1648/files#diff-6b8010fc57cc3e44a6190058ef673d967bb1686466585216d00bfa876cee1b42) and [tests/unit/selfdoc-context.test.ts](https://github.com/wopr-network/wopr/pull/1648/files#diff-8af2293b73311182db097bfb5ad72d38bf78291beee618cd8ac77b6430af3ecd) for WOP-1392
> Introduce Vitest suites that assert `authCredentialSchema`, `authApiKeySchema`, and `authPluginSchema` parsing and indexes, and validate `selfDocContextProvider` and `createDefaultSelfDoc` behavior including file loading order and 7-day recent memory filtering.
>
> #### 🖇️ Linked Issues
> Addresses [WOP-1392](ticket:jira/WOP-1392) by adding targeted unit tests covering auth schema validation and selfdoc context behavior.
>
> #### 📍Where to Start
> Start with the `authCredentialSchema` and `authApiKeySchema` tests in [tests/unit/auth-schema.test.ts](https://github.com/wopr-network/wopr/pull/1648/files#diff-6b8010fc57cc3e44a6190058ef673d967bb1686466585216d00bfa876cee1b42), then review `selfDocContextProvider` cases in [tests/unit/selfdoc-context.test.ts](https://github.com/wopr-network/wopr/pull/1648/files#diff-8af2293b73311182db097bfb5ad72d38bf78291beee618cd8ac77b6430af3ecd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d617fbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->