### PR TITLE
test: add unit tests for schema-converter, accessors, migrate-json (WOP-1391)

### DIFF
--- a/tests/unit/accessors.test.ts
+++ b/tests/unit/accessors.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  ChannelAdapter,
+  ChannelRef,
+  ContextProvider,
+  UiComponentExtension,
+  WebUiExtension,
+} from "../../src/types.js";
+import {
+  getChannel,
+  getChannels,
+  getChannelsForSession,
+  getContextProvider,
+  getUiComponents,
+  getWebUiExtensions,
+} from "../../src/plugins/accessors.js";
+import {
+  channelAdapters,
+  channelKey,
+  contextProviders,
+  uiComponents,
+  webUiExtensions,
+} from "../../src/plugins/state.js";
+
+afterEach(() => {
+  contextProviders.clear();
+  channelAdapters.clear();
+  webUiExtensions.clear();
+  uiComponents.clear();
+});
+
+describe("getContextProvider", () => {
+  it("returns undefined for unknown session", () => {
+    expect(getContextProvider("unknown")).toBeUndefined();
+  });
+
+  it("returns the provider for a known session", () => {
+    const provider = {
+      name: "test",
+      priority: 1,
+      getContext: async () => null,
+    } as ContextProvider;
+    contextProviders.set("sess-1", provider);
+    expect(getContextProvider("sess-1")).toBe(provider);
+  });
+});
+
+describe("getChannel", () => {
+  const ref: ChannelRef = { type: "discord", id: "ch-1" };
+  const adapter: ChannelAdapter = {
+    channel: ref,
+    session: "sess-1",
+    getContext: async () => "",
+    send: async () => {},
+  };
+
+  it("returns undefined for unknown channel", () => {
+    expect(getChannel({ type: "discord", id: "nope" })).toBeUndefined();
+  });
+
+  it("returns the adapter for a known channel", () => {
+    channelAdapters.set(channelKey(ref), adapter);
+    expect(getChannel(ref)).toBe(adapter);
+  });
+});
+
+describe("getChannels", () => {
+  it("returns empty array when no channels", () => {
+    expect(getChannels()).toEqual([]);
+  });
+
+  it("returns all registered channels", () => {
+    const a1: ChannelAdapter = {
+      channel: { type: "discord", id: "1" },
+      session: "s1",
+      getContext: async () => "",
+      send: async () => {},
+    };
+    const a2: ChannelAdapter = {
+      channel: { type: "p2p", id: "2" },
+      session: "s2",
+      getContext: async () => "",
+      send: async () => {},
+    };
+    channelAdapters.set("discord:1", a1);
+    channelAdapters.set("p2p:2", a2);
+    expect(getChannels()).toEqual([a1, a2]);
+  });
+});
+
+describe("getChannelsForSession", () => {
+  it("returns only channels matching the session", () => {
+    const a1: ChannelAdapter = {
+      channel: { type: "discord", id: "1" },
+      session: "sess-A",
+      getContext: async () => "",
+      send: async () => {},
+    };
+    const a2: ChannelAdapter = {
+      channel: { type: "discord", id: "2" },
+      session: "sess-B",
+      getContext: async () => "",
+      send: async () => {},
+    };
+    channelAdapters.set("discord:1", a1);
+    channelAdapters.set("discord:2", a2);
+    expect(getChannelsForSession("sess-A")).toEqual([a1]);
+    expect(getChannelsForSession("sess-B")).toEqual([a2]);
+    expect(getChannelsForSession("sess-C")).toEqual([]);
+  });
+});
+
+describe("getWebUiExtensions", () => {
+  it("returns empty array when none registered", () => {
+    expect(getWebUiExtensions()).toEqual([]);
+  });
+
+  it("returns all registered extensions", () => {
+    const ext: WebUiExtension = { id: "ext-1", title: "Test", url: "/test" };
+    webUiExtensions.set("ext-1", ext);
+    expect(getWebUiExtensions()).toEqual([ext]);
+  });
+});
+
+describe("getUiComponents", () => {
+  it("returns empty array when none registered", () => {
+    expect(getUiComponents()).toEqual([]);
+  });
+
+  it("returns all registered components", () => {
+    const comp: UiComponentExtension = {
+      id: "comp-1",
+      title: "Test",
+      moduleUrl: "/comp.js",
+      slot: "sidebar",
+    };
+    uiComponents.set("comp-1", comp);
+    expect(getUiComponents()).toEqual([comp]);
+  });
+});

--- a/tests/unit/migrate-json.test.ts
+++ b/tests/unit/migrate-json.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock node:fs before importing the module under test
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  renameSync: vi.fn(),
+}));
+
+// Mock plugin-storage
+const mockPluginRepo = {
+  findById: vi.fn(),
+  insert: vi.fn(),
+};
+const mockRegistryRepo = {
+  findById: vi.fn(),
+  insert: vi.fn(),
+};
+vi.mock("../../src/plugins/plugin-storage.js", () => ({
+  ensurePluginSchema: vi.fn(async () => {}),
+  getPluginRepo: () => mockPluginRepo,
+  getRegistryRepo: () => mockRegistryRepo,
+}));
+
+// Mock logger to silence output
+vi.mock("../../src/logger.js", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { existsSync, readFileSync, renameSync } from "node:fs";
+import { migratePluginJsonToSql } from "../../src/plugins/migrate-json.js";
+import { PLUGINS_FILE, REGISTRIES_FILE } from "../../src/plugins/state.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("migratePluginJsonToSql", () => {
+  it("returns zeros when no JSON files exist", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    const result = await migratePluginJsonToSql();
+    expect(result).toEqual({ plugins: 0, registries: 0 });
+    expect(renameSync).not.toHaveBeenCalled();
+  });
+
+  it("migrates plugins.json and renames to .backup", async () => {
+    const plugins = [
+      {
+        name: "test-plugin",
+        version: "1.0.0",
+        source: "npm",
+        path: "/x",
+        enabled: true,
+        installedAt: 1,
+      },
+    ];
+    vi.mocked(existsSync).mockImplementation((p) => p === PLUGINS_FILE);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(plugins));
+    mockPluginRepo.findById.mockResolvedValue(null);
+    mockPluginRepo.insert.mockResolvedValue(undefined);
+
+    const result = await migratePluginJsonToSql();
+    expect(result.plugins).toBe(1);
+    expect(mockPluginRepo.insert).toHaveBeenCalledOnce();
+    expect(renameSync).toHaveBeenCalledWith(
+      PLUGINS_FILE,
+      `${PLUGINS_FILE}.backup`,
+    );
+  });
+
+  it("skips already-migrated plugins (idempotent)", async () => {
+    const plugins = [
+      {
+        name: "existing",
+        version: "1.0.0",
+        source: "npm",
+        path: "/x",
+        enabled: true,
+        installedAt: 1,
+      },
+    ];
+    vi.mocked(existsSync).mockImplementation((p) => p === PLUGINS_FILE);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(plugins));
+    mockPluginRepo.findById.mockResolvedValue({ name: "existing" }); // already exists
+
+    const result = await migratePluginJsonToSql();
+    expect(result.plugins).toBe(0);
+    expect(mockPluginRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it("migrates plugin-registries.json and renames to .backup", async () => {
+    const registries = [
+      {
+        name: "official",
+        url: "https://registry.wopr.dev",
+        enabled: true,
+        lastSync: 1,
+      },
+    ];
+    vi.mocked(existsSync).mockImplementation((p) => p === REGISTRIES_FILE);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(registries));
+    mockRegistryRepo.findById.mockResolvedValue(null);
+    mockRegistryRepo.insert.mockResolvedValue(undefined);
+
+    const result = await migratePluginJsonToSql();
+    expect(result.registries).toBe(1);
+    expect(mockRegistryRepo.insert).toHaveBeenCalledOnce();
+    expect(renameSync).toHaveBeenCalledWith(
+      REGISTRIES_FILE,
+      `${REGISTRIES_FILE}.backup`,
+    );
+  });
+
+  it("handles both files at once", async () => {
+    const plugins = [
+      {
+        name: "p1",
+        version: "1.0.0",
+        source: "npm",
+        path: "/x",
+        enabled: true,
+        installedAt: 1,
+      },
+    ];
+    const registries = [
+      { name: "r1", url: "https://r1.dev", enabled: true, lastSync: 1 },
+    ];
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p) === PLUGINS_FILE) return JSON.stringify(plugins);
+      return JSON.stringify(registries);
+    });
+    mockPluginRepo.findById.mockResolvedValue(null);
+    mockPluginRepo.insert.mockResolvedValue(undefined);
+    mockRegistryRepo.findById.mockResolvedValue(null);
+    mockRegistryRepo.insert.mockResolvedValue(undefined);
+
+    const result = await migratePluginJsonToSql();
+    expect(result).toEqual({ plugins: 1, registries: 1 });
+    expect(renameSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles malformed JSON gracefully (no throw)", async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue("NOT VALID JSON");
+
+    const result = await migratePluginJsonToSql();
+    // Should not throw — errors are caught and logged
+    expect(result.plugins).toBe(0);
+    expect(result.registries).toBe(0);
+  });
+});

--- a/tests/unit/schema-converter.test.ts
+++ b/tests/unit/schema-converter.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { jsonSchemaToZod } from "../../src/plugins/schema-converter.js";
+
+describe("jsonSchemaToZod", () => {
+  it("returns z.unknown() for null/undefined input", () => {
+    const schema = jsonSchemaToZod(null as never);
+    expect(schema.safeParse("anything").success).toBe(true);
+    expect(schema.safeParse(123).success).toBe(true);
+  });
+
+  it("returns z.unknown() for non-object input", () => {
+    const schema = jsonSchemaToZod("not an object" as never);
+    expect(schema.safeParse(42).success).toBe(true);
+  });
+
+  it("converts string type", () => {
+    const schema = jsonSchemaToZod({ type: "string" });
+    expect(schema.safeParse("hello").success).toBe(true);
+    expect(schema.safeParse(123).success).toBe(false);
+  });
+
+  it("converts number type", () => {
+    const schema = jsonSchemaToZod({ type: "number" });
+    expect(schema.safeParse(42).success).toBe(true);
+    expect(schema.safeParse("nope").success).toBe(false);
+  });
+
+  it("converts integer type to z.number()", () => {
+    const schema = jsonSchemaToZod({ type: "integer" });
+    expect(schema.safeParse(7).success).toBe(true);
+    expect(schema.safeParse("nope").success).toBe(false);
+  });
+
+  it("converts boolean type", () => {
+    const schema = jsonSchemaToZod({ type: "boolean" });
+    expect(schema.safeParse(true).success).toBe(true);
+    expect(schema.safeParse("yes").success).toBe(false);
+  });
+
+  it("converts array type with items", () => {
+    const schema = jsonSchemaToZod({
+      type: "array",
+      items: { type: "string" },
+    });
+    expect(schema.safeParse(["a", "b"]).success).toBe(true);
+    expect(schema.safeParse([1, 2]).success).toBe(false);
+  });
+
+  it("converts array type without items to z.array(z.unknown())", () => {
+    const schema = jsonSchemaToZod({ type: "array" });
+    expect(schema.safeParse([1, "mixed", true]).success).toBe(true);
+  });
+
+  it("converts object type with properties and required", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+      },
+      required: ["name"],
+    });
+    // name required, age optional
+    expect(schema.safeParse({ name: "Alice" }).success).toBe(true);
+    expect(schema.safeParse({ name: "Alice", age: 30 }).success).toBe(true);
+    expect(schema.safeParse({ age: 30 }).success).toBe(false);
+  });
+
+  it("converts object type without properties to z.record()", () => {
+    const schema = jsonSchemaToZod({ type: "object" });
+    expect(schema.safeParse({ any: "value" }).success).toBe(true);
+  });
+
+  it("adds description to top-level schema", () => {
+    const schema = jsonSchemaToZod({
+      type: "string",
+      description: "A name field",
+    });
+    expect(schema.description).toBe("A name field");
+  });
+
+  it("adds description to nested object properties", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        email: { type: "string", description: "User email" },
+      },
+      required: ["email"],
+    }) as z.ZodObject<{ email: z.ZodString }>;
+    expect(schema.shape.email.description).toBe("User email");
+  });
+
+  it("returns z.unknown() for unrecognized type", () => {
+    const schema = jsonSchemaToZod({ type: "foobar" });
+    expect(schema.safeParse("anything").success).toBe(true);
+  });
+
+  it("handles nested objects recursively", () => {
+    const schema = jsonSchemaToZod({
+      type: "object",
+      properties: {
+        address: {
+          type: "object",
+          properties: {
+            street: { type: "string" },
+          },
+          required: ["street"],
+        },
+      },
+      required: ["address"],
+    });
+    expect(
+      schema.safeParse({ address: { street: "123 Main" } }).success,
+    ).toBe(true);
+    expect(schema.safeParse({ address: {} }).success).toBe(false);
+  });
+
+  it("handles array of objects", () => {
+    const schema = jsonSchemaToZod({
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: { type: "number" } },
+        required: ["id"],
+      },
+    });
+    expect(schema.safeParse([{ id: 1 }, { id: 2 }]).success).toBe(true);
+    expect(schema.safeParse([{}]).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1391

- Add 15 unit tests for `jsonSchemaToZod` in `schema-converter.ts` covering all type branches (string, number, integer, boolean, array, object), recursion, optional properties, descriptions, and edge cases
- Add 11 unit tests for all 6 accessor functions in `accessors.ts` by directly mutating the shared state Maps and asserting correct reads
- Add 6 unit tests for `migratePluginJsonToSql` in `migrate-json.ts` using `vi.mock` for `node:fs`, `plugin-storage`, and `logger`; covers both-files migration, idempotency, and malformed JSON error recovery

## Test plan
- [x] `npm run build` passes
- [x] Targeted tests pass: `npx vitest run tests/unit/schema-converter.test.ts tests/unit/accessors.test.ts tests/unit/migrate-json.test.ts`
- [x] 32 tests, all passing

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for plugin accessors, `migratePluginJsonToSql`, and `jsonSchemaToZod` to validate behavior for sessions, registries, and schema conversion (WOP-1391)
> Add tests covering plugin accessor lookups and session filtering, JSON-to-SQL migration flows with file mocks and idempotency, and JSON Schema to Zod conversion for primitives, arrays, objects, and unknown types.
>
> #### 📍Where to Start
> Start with the accessor tests in [accessors.test.ts](https://github.com/wopr-network/wopr/pull/1649/files#diff-0234c8acbefc99b31b657f24c02b71d03cf21c5f37411374511a706a518d45bc), then review migration logic coverage in [migrate-json.test.ts](https://github.com/wopr-network/wopr/pull/1649/files#diff-26ab5282e61a87813688ff88bda122cb0019dfa14bc86b554813b884a58b1578), and finish with schema conversion cases in [schema-converter.test.ts](https://github.com/wopr-network/wopr/pull/1649/files#diff-bc7893d6dce63d5ff86a35f41f4a796aad2855969feae4ef3fae2896e140789c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 443c3cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suites covering core accessor functionality, JSON-to-SQL migration behavior, and schema conversion logic with multiple scenarios including edge cases and error handling.

* **Chores**
  * Extended test hook timeout configuration to improve test stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->