### PR TITLE
fix: clean up connectionTimestamps on session:destroy (WOP-1387)

### DIFF
--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -13,6 +13,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import { createServer, connect as netConnect, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { eventBus } from "../core/events.js";
 import { logger } from "../logger.js";
 import { getPluginExtension } from "../plugins/extensions.js";
 import { getContext } from "./context.js";
@@ -808,3 +809,11 @@ async function shutdownCleanup(): Promise<void> {
 
 process.on("SIGTERM", shutdownCleanup);
 process.on("SIGINT", shutdownCleanup);
+
+// Clean up connectionTimestamps when sessions are destroyed to prevent memory leak.
+// The close() handler on McpSocketBridgeHandle already deletes the entry, but sessions
+// can be deleted without their bridge being explicitly closed first.
+eventBus.on("session:destroy", ({ session }) => {
+  connectionTimestamps.delete(session);
+  destroyMcpSocketBridge(session);
+});

--- a/tests/security/sandbox-connection-timestamps.test.ts
+++ b/tests/security/sandbox-connection-timestamps.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock logger
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock child_process.spawn to avoid real Docker execution
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+// Mock the plugin extension system
+vi.mock("../../src/plugins/extensions.js", () => ({
+  getPluginExtension: vi.fn(() => undefined),
+}));
+
+// Mock the security context module
+vi.mock("../../src/security/context.js", () => ({
+  getContext: vi.fn(() => null),
+}));
+
+// We need access to the eventBus to simulate session:destroy
+const { eventBus } = await import("../../src/core/events.js");
+
+// Import the module under test — this registers the session:destroy listener
+await import("../../src/security/sandbox.js");
+
+describe("connectionTimestamps cleanup on session:destroy", () => {
+  it("should register a session:destroy listener on the event bus", () => {
+    // The sandbox module must register at least one session:destroy listener
+    const count = eventBus.listenerCount("session:destroy");
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it("should not throw when session:destroy fires for unknown session", async () => {
+    // Emitting for a session with no bridge and no timestamps entry must be a no-op
+    await expect(
+      eventBus.emit(
+        "session:destroy",
+        {
+          session: "nonexistent-session-xyz",
+          history: [],
+          reason: "test",
+        },
+        "core",
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it("should not throw when session:destroy fires multiple times for the same session", async () => {
+    const payload = {
+      session: "repeated-session",
+      history: [],
+      reason: "test",
+    };
+    await eventBus.emit("session:destroy", payload, "core");
+    await expect(
+      eventBus.emit("session:destroy", payload, "core"),
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1387

- `connectionTimestamps` map entries in `src/security/sandbox.ts` were never removed when sessions ended without their MCP bridge being explicitly closed, causing unbounded map growth in long-running daemons
- Registers a `session:destroy` event listener that calls `connectionTimestamps.delete(session)` and `destroyMcpSocketBridge(session)` — both are no-ops for sessions that were never sandboxed
- The `close()` handler on `McpSocketBridgeHandle` already deletes the entry when a bridge is explicitly closed; this fix covers the leak path where sessions are deleted via `deleteSession()` without the bridge being closed first

## Test plan
- [x] `npm run check` passes (lint + tsc, exit 0)
- [x] `npx vitest run tests/security/sandbox-connection-timestamps.test.ts` — 3 new tests pass
- [x] `npx vitest run tests/security/mcp-socket-bridge.test.ts tests/security/sandbox.test.ts` — 13 existing tests still pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register a `eventBus.on("session:destroy")` listener in `security.sandbox` to delete `connectionTimestamps[session]` and call `destroyMcpSocketBridge(session)` for cleanup (WOP-1387)
> Add a session destroy handler in [sandbox.ts](https://github.com/wopr-network/wopr/pull/1650/files#diff-256f1e73c5fcfb5500107700cce95d55648266f2b0dc210afd86fe128718f354) that removes the session’s `connectionTimestamps` entry and invokes `destroyMcpSocketBridge(session)`; include tests validating listener registration and idempotent handling in [sandbox-connection-timestamps.test.ts](https://github.com/wopr-network/wopr/pull/1650/files#diff-4748e86f198843cf0ef9f95338e544e4e6aafd9af73daaf47cbb6cd532cf59d4).
>
> #### 📍Where to Start
> Start with the `eventBus.on("session:destroy")` handler in [sandbox.ts](https://github.com/wopr-network/wopr/pull/1650/files#diff-256f1e73c5fcfb5500107700cce95d55648266f2b0dc210afd86fe128718f354).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7f59829. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/security/sandbox.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 816](https://github.com/wopr-network/wopr/blob/7f598296c19ab5c94064e5a1fac5613fd380c9e8/src/security/sandbox.ts#L816): A race condition between `createMcpSocketBridge` initialization and the new `session:destroy` handler causes a resource leak. `createMcpSocketBridge` (lines 640-756) performs asynchronous operations—specifically awaiting `server.listen` (line 705) and `execDocker` (line 719)—before registering the resulting handle in `activeBridges` (line 755). If a `session:destroy` event fires during this `await` window, the new handler (line 816) executes `destroyMcpSocketBridge`, which attempts to look up the session in `activeBridges` (line 763). Since the bridge is not yet registered, the lookup fails and cleanup is skipped. Subsequently, `createMcpSocketBridge` resumes and erroneously registers the bridge for the now-destroyed session. This leaves a `net.Server` listening and a Docker bridge active with no automatic mechanism to clean them up until process termination. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->