### PR TITLE
fix: eliminate TOCTOU race in transaction() with promise-based lock (WOP-1380)

### DIFF
--- a/src/storage/repositories/drizzle-repository.ts
+++ b/src/storage/repositories/drizzle-repository.ts
@@ -208,6 +208,7 @@ export class DrizzleRepository<T extends Record<string, unknown>, PK extends key
   private jsonColumns: Set<string>;
   private booleanColumns: Set<string>;
   private inTransaction = false;
+  private _txLock: Promise<void> = Promise.resolve();
 
   constructor(
     private db: DrizzleDB,
@@ -457,9 +458,21 @@ export class DrizzleRepository<T extends Record<string, unknown>, PK extends key
     if (!this.sqliteRaw) {
       throw new Error("transaction() requires a raw SQLite connection (sqliteRaw was not provided)");
     }
+
     if (this.inTransaction) {
       throw new Error("Nested transactions are not supported; a transaction is already active");
     }
+
+    // Queue behind any in-flight transaction to prevent TOCTOU race.
+    // Each caller waits for the previous _txLock to resolve before proceeding.
+    let releaseLock!: () => void;
+    const prevLock = this._txLock;
+    this._txLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+
+    await prevLock;
+
     const raw = this.sqliteRaw as { exec: (sql: string) => void };
     raw.exec("BEGIN");
     this.inTransaction = true;
@@ -476,6 +489,7 @@ export class DrizzleRepository<T extends Record<string, unknown>, PK extends key
       throw error;
     } finally {
       this.inTransaction = false;
+      releaseLock();
     }
   }
 

--- a/tests/unit/drizzle-repository.test.ts
+++ b/tests/unit/drizzle-repository.test.ts
@@ -574,6 +574,34 @@ describe("DrizzleRepository gap coverage (WOP-954)", () => {
     });
   });
 
+  describe("repository-level transaction: TOCTOU race guard", () => {
+    beforeEach(async () => {
+      await storage.register(pluginSchema);
+    });
+
+    it("should serialize concurrent transaction() calls instead of double-BEGIN", async () => {
+      const repo = storage.getRepository<TestRecord>("drepo", "items");
+      const order: string[] = [];
+
+      const tx1 = repo.transaction(async () => {
+        order.push("tx1-start");
+        // Yield to let tx2 attempt to enter
+        await new Promise((r) => setTimeout(r, 10));
+        order.push("tx1-end");
+      });
+
+      const tx2 = repo.transaction(async () => {
+        order.push("tx2-start");
+        order.push("tx2-end");
+      });
+
+      await Promise.all([tx1, tx2]);
+
+      // tx2 must start AFTER tx1 ends (serialized, not interleaved)
+      expect(order.indexOf("tx1-end")).toBeLessThan(order.indexOf("tx2-start"));
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Task 7: QueryBuilder count and first on empty tables / with where conditions
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes WOP-1380

- Replaced the boolean `inTransaction` flag check/set pattern in `DrizzleRepository.transaction()` with a promise-based mutex that serializes concurrent callers
- Each caller captures the current `_txLock` promise, replaces it with a new pending promise, and awaits the previous one — guaranteeing exclusive access before `BEGIN`
- Nested transaction detection is preserved: `inTransaction` is checked synchronously before acquiring the lock, so recursive calls from within `fn()` still throw immediately
- Added test verifying concurrent `transaction()` calls are serialized (tx2 starts only after tx1 ends)

## Test plan
- [ ] `npm run build` passes
- [ ] `npx vitest run tests/unit/drizzle-repository.test.ts` — all 52 tests pass including new TOCTOU serialization test and existing nested rejection test

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize `DrizzleRepository.transaction()` calls with a promise-based lock to eliminate TOCTOU race in SQLite transactions for WOP-1380
> Add a private `_txLock` promise to `DrizzleRepository` and gate `transaction()` execution on it; queue concurrent calls and release in `finally`. Add a unit test validating ordered execution.
>
> #### 📍Where to Start
> Start with `DrizzleRepository.transaction()` in [drizzle-repository.ts](https://github.com/wopr-network/wopr/pull/1653/files#diff-1d871e8012ebee354de62e94476cd10f5a002787b82310610947a4fe02b189aa) and then review the new test in [drizzle-repository.test.ts](https://github.com/wopr-network/wopr/pull/1653/files#diff-51aa0897ae8333517e6cf344506a58a68a0690523409ef270ca95a9f934b1365).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 22b6277. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->