### PR TITLE
fix: daemon exits on uncaught exception (WOP-1411)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -65,20 +65,24 @@ import {
 const DEFAULT_PORT = parseInt(process.env.WOPR_DAEMON_PORT || "7437", 10);
 const DEFAULT_HOST = process.env.WOPR_DAEMON_HOST || "127.0.0.1";
 
-// Global error handlers - prevent crash on unhandled errors
-process.on("uncaughtException", (error) => {
+// Global error handlers — crash so the supervisor (systemd/Docker) can restart cleanly.
+// After an uncaught exception Node's state is undefined; continuing risks silent corruption.
+export function handleUncaughtException(error: Error): void {
   winstonLogger.error(`[daemon] Uncaught exception: ${error.message}`);
   winstonLogger.error(`[daemon] Stack: ${error.stack}`);
-  // Don't exit - log and continue
-});
+  process.exit(1);
+}
 
-process.on("unhandledRejection", (reason, _promise) => {
+export function handleUnhandledRejection(reason: unknown, _promise: Promise<unknown>): void {
   const msg = reason instanceof Error ? reason.message : String(reason);
   const stack = reason instanceof Error ? reason.stack : undefined;
   winstonLogger.error(`[daemon] Unhandled rejection: ${msg}`);
   if (stack) winstonLogger.error(`[daemon] Stack: ${stack}`);
-  // Don't exit - log and continue
-});
+  process.exit(1);
+}
+
+process.on("uncaughtException", handleUncaughtException);
+process.on("unhandledRejection", handleUnhandledRejection);
 
 export interface DaemonConfig {
   port?: number;

--- a/tests/unit/daemon-crash-handlers.test.ts
+++ b/tests/unit/daemon-crash-handlers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the logger before importing handlers
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { handleUncaughtException, handleUnhandledRejection } from "../../src/daemon/index.js";
+
+describe("daemon crash handlers", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  describe("handleUncaughtException", () => {
+    it("logs the error and exits with code 1", () => {
+      const err = new Error("test uncaught");
+      handleUncaughtException(err);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("handleUnhandledRejection", () => {
+    it("logs an Error reason and exits with code 1", () => {
+      const err = new Error("test rejection");
+      handleUnhandledRejection(err, Promise.resolve());
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("logs a string reason and exits with code 1", () => {
+      handleUnhandledRejection("string reason", Promise.resolve());
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1411

- Replaced the two \"swallow and continue\" handlers (`uncaughtException`, `unhandledRejection`) with named exported functions that log then call `process.exit(1)`
- After an uncaught exception Node's heap state is undefined; continuing risks silent data corruption — crashing lets the supervisor (systemd/Docker) restart cleanly
- SIGTERM/SIGINT graceful shutdown path is untouched

## Test plan
- [x] `npm run build` / `npm run check` passes (lint + tsc)
- [x] Targeted tests pass: `npx vitest run tests/unit/daemon-crash-handlers.test.ts` (3 tests)
- [x] `handleUncaughtException` calls `process.exit(1)` after logging
- [x] `handleUnhandledRejection` calls `process.exit(1)` for both Error and string reasons

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exit the daemon with code 1 on uncaught exceptions and unhandled rejections using `src/daemon/index.ts::handleUncaughtException` and `src/daemon/index.ts::handleUnhandledRejection` to address WOP-1411
> Add named handlers that log via `winstonLogger` and call `process.exit(1)`, and register them for `uncaughtException` and `unhandledRejection` in [index.ts](https://github.com/wopr-network/wopr/pull/1714/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078). Include unit tests in [daemon-crash-handlers.test.ts](https://github.com/wopr-network/wopr/pull/1714/files#diff-d391b6ed013c409696f1f3781ac5981436a426eaa93dbdd71c4a8077f0a2ff9f).
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1411](https://linear.app/wopr/issue/WOP-1411) by making the daemon exit on uncaught exceptions and unhandled rejections.
>
> #### 📍Where to Start
> Start with the exported `handleUncaughtException` and `handleUnhandledRejection` in [index.ts](https://github.com/wopr-network/wopr/pull/1714/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 621dae5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application now cleanly exits when encountering uncaught exceptions or unhandled promise rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->