### PR TITLE
fix: validate OpenAI message content types, reject non-string silently coerced (WOP-1425)

### DIFF
--- a/src/daemon/routes/openai.ts
+++ b/src/daemon/routes/openai.ts
@@ -17,19 +17,103 @@ import type { ProviderConfig } from "../../types/provider.js";
 
 export const openaiRouter = new Hono();
 
+/** Valid roles for OpenAI chat messages */
+const VALID_ROLES = new Set(["system", "user", "assistant", "tool"]);
+
 /**
- * OpenAI Chat Completion request body
+ * OpenAI Chat Completion request body (pre-validation).
+ * `content` is `unknown` until validated — callers send arbitrary JSON.
  */
 interface ChatCompletionRequest {
   model: string;
   messages: Array<{
-    role: "system" | "user" | "assistant";
-    content: string;
+    role?: unknown;
+    content?: unknown;
   }>;
   temperature?: number;
   top_p?: number;
   max_tokens?: number;
   stream?: boolean;
+}
+
+/** Post-validation message with guaranteed string content */
+interface ValidatedMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+}
+
+/**
+ * Validate and normalize OpenAI-style messages.
+ *
+ * Returns normalized messages with string content, or an error string
+ * describing the first invalid message.
+ */
+function validateMessages(
+  messages: ChatCompletionRequest["messages"],
+): { ok: true; messages: ValidatedMessage[] } | { ok: false; error: string } {
+  const validated: ValidatedMessage[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    // Validate role
+    if (typeof msg.role !== "string" || !VALID_ROLES.has(msg.role)) {
+      return {
+        ok: false,
+        error: `messages[${i}].role must be one of: system, user, assistant, tool — got ${JSON.stringify(msg.role)}`,
+      };
+    }
+    const role = msg.role as ValidatedMessage["role"];
+
+    // Validate and normalize content
+    const content = msg.content;
+
+    // null/undefined content: allowed for assistant/tool, rejected for user/system
+    if (content === null || content === undefined) {
+      if (role === "user" || role === "system") {
+        return {
+          ok: false,
+          error: `messages[${i}].content is required for role "${role}"`,
+        };
+      }
+      validated.push({ role, content: "" });
+      continue;
+    }
+
+    // String content: pass through
+    if (typeof content === "string") {
+      validated.push({ role, content });
+      continue;
+    }
+
+    // Array content: extract text parts (OpenAI multimodal format)
+    if (Array.isArray(content)) {
+      const textParts: string[] = [];
+      for (const part of content) {
+        if (
+          typeof part === "object" &&
+          part !== null &&
+          "type" in part &&
+          (part as Record<string, unknown>).type === "text" &&
+          "text" in part &&
+          typeof (part as Record<string, unknown>).text === "string"
+        ) {
+          textParts.push((part as Record<string, unknown>).text as string);
+        }
+        // Skip non-text parts (image_url, etc.) silently
+      }
+      validated.push({ role, content: textParts.join("\n") });
+      continue;
+    }
+
+    // Anything else (number, boolean, non-array object): reject
+    return {
+      ok: false,
+      error: `messages[${i}].content must be a string or content array — got ${typeof content}`,
+    };
+  }
+
+  return { ok: true, messages: validated };
 }
 
 /**
@@ -66,9 +150,9 @@ function resolveProviderConfig(model: string): ProviderConfig | null {
 }
 
 /**
- * Build the prompt and system prompt from OpenAI-style messages array.
+ * Build the prompt and system prompt from validated messages.
  */
-function buildPrompts(messages: ChatCompletionRequest["messages"]): {
+function buildPrompts(messages: ValidatedMessage[]): {
   systemPrompt: string | undefined;
   userPrompt: string;
 } {
@@ -140,6 +224,21 @@ openaiRouter.post(
       );
     }
 
+    // Validate individual messages
+    const validation = validateMessages(body.messages);
+    if (!validation.ok) {
+      return c.json(
+        {
+          error: {
+            message: validation.error,
+            type: "invalid_request_error",
+            code: "invalid_message",
+          },
+        },
+        400,
+      );
+    }
+
     // Resolve provider
     const providerConfig = resolveProviderConfig(body.model);
     if (!providerConfig) {
@@ -156,7 +255,7 @@ openaiRouter.post(
     }
 
     const sessionName = makeSessionName();
-    const { systemPrompt, userPrompt } = buildPrompts(body.messages);
+    const { systemPrompt, userPrompt } = buildPrompts(validation.messages);
     const requestId = `chatcmpl-${randomUUID().replace(/-/g, "").slice(0, 24)}`;
     const created = Math.floor(Date.now() / 1000);
 

--- a/tests/unit/openai-compat.test.ts
+++ b/tests/unit/openai-compat.test.ts
@@ -520,6 +520,156 @@ describe("OpenAI Compatibility Layer", () => {
   });
 
   // ==========================================================================
+  // POST /v1/chat/completions - Message validation
+  // ==========================================================================
+
+  describe("POST /v1/chat/completions (message validation)", () => {
+    it("rejects message with non-string, non-array content (number)", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "user", content: 42 }],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error.type).toBe("invalid_request_error");
+      expect(data.error.code).toBe("invalid_message");
+    });
+
+    it("rejects message with object content (not array)", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "user", content: { foo: "bar" } }],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error.code).toBe("invalid_message");
+    });
+
+    it("rejects message with undefined content for user role", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "user" }],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error.code).toBe("invalid_message");
+    });
+
+    it("rejects message with invalid role", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "banana", content: "hello" }],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error.code).toBe("invalid_message");
+    });
+
+    it("rejects message with missing role", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ content: "hello" }],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error.code).toBe("invalid_message");
+    });
+
+    it("accepts content array and extracts text parts", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "What is in this image?" },
+                { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+              ],
+            },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(inject).toHaveBeenCalledWith(
+        expect.any(String),
+        "What is in this image?",
+        expect.any(Object),
+      );
+    });
+
+    it("accepts null content for assistant messages (treats as empty)", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [
+            { role: "assistant", content: null },
+            { role: "user", content: "Continue" },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("includes message index in error for invalid message", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [
+            { role: "user", content: "valid" },
+            { role: "user", content: 123 },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error.message).toContain("messages[1]");
+    });
+  });
+
+  // ==========================================================================
   // Provider resolution
   // ==========================================================================
 


### PR DESCRIPTION
## Summary
Closes WOP-1425

- Add `validateMessages()` in `src/daemon/routes/openai.ts` to validate each message's `role` and `content` before reaching `buildPrompts()`
- Non-string, non-array content (numbers, plain objects, booleans) now returns 400 with `invalid_message` code instead of silently coercing to `"undefined"` or `"[object Object]"`
- Multimodal content arrays (OpenAI format) extract text parts only; non-text parts (image_url, etc.) are silently skipped
- `null`/`undefined` content is accepted for `assistant`/`tool` roles (function call responses), rejected for `user`/`system`
- Unknown or missing `role` returns 400 with index-aware error message
- `buildPrompts()` updated to accept `ValidatedMessage[]` with guaranteed string content

## Test plan
- [x] `npm run check` passes (biome + tsc --noEmit)
- [x] `npx vitest run tests/unit/openai-compat.test.ts` — all 30 tests pass (22 existing + 8 new)
- [x] Rejects `content: 42` (number) with 400
- [x] Rejects `content: { foo: "bar" }` (plain object) with 400
- [x] Rejects missing `content` for `user` role with 400
- [x] Rejects invalid role (`"banana"`) with 400
- [x] Rejects missing role with 400
- [x] Accepts multimodal content array, extracts text parts
- [x] Accepts `null` content for `assistant` messages
- [x] Error message contains `messages[N]` index for invalid message

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate and normalize chat message roles and content in `/v1/chat/completions` to reject non-string content and silently coerce allowed nulls (WOP-1425)
> Add `VALID_ROLES`, introduce `ValidatedMessage`, implement `validateMessages` to enforce roles and normalize content (including extracting text from arrays), update `buildPrompts` to consume validated messages, and return 400 `invalid_message` on validation failure in [openai.ts](https://github.com/wopr-network/wopr/pull/1718/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09). Extend tests to cover acceptance and rejection cases in [openai-compat.test.ts](https://github.com/wopr-network/wopr/pull/1718/files#diff-4d3efddd189479dd525c227c670f479baa35482fe0d8ae45951869b671a59679).
>
> #### 📍Where to Start
> Start with the `validateMessages` logic and its use in the `/chat/completions` handler in [openai.ts](https://github.com/wopr-network/wopr/pull/1718/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09), then review how `buildPrompts` consumes `ValidatedMessage`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0fd82d2. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/daemon/routes/openai.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 60](https://github.com/wopr-network/wopr/blob/0fd82d2687df8b7e0e0ae3fc7c399a81d3ba854b/src/daemon/routes/openai.ts#L60): Runtime crash in `validateMessages` due to missing null check on message objects. The `ChatCompletionRequest` interface update defines `messages` elements as objects with `unknown` properties, but `c.req.json()` allows `messages` to contain `null` values (e.g., `{"messages": [null]}`). The `validateMessages` function iterates `messages` and accesses `msg.role` without verifying `msg` is non-null, causing a `TypeError` and 500 Internal Server Error instead of a 400 validation error. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message validation for OpenAI chat completions endpoint with standardized error responses for invalid inputs.
  * Improved handling of various content formats including arrays and null values.

* **Tests**
  * Added comprehensive test coverage for message validation, including edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->