### PR TITLE
security: add hardcoded shell denylist to hook commands (WOP-1423)

### DIFF
--- a/src/security/hooks.ts
+++ b/src/security/hooks.ts
@@ -46,6 +46,28 @@ const DEFAULT_HOOK_COMMAND_ALLOWLIST: ReadonlySet<string> = new Set([
 const SHELL_METACHAR_PATTERN = /[;|&`$(){}!<>\\]/;
 
 /**
+ * Hardcoded denylist of shell executables that can NEVER be used in hook
+ * commands, even if added to allowedHookCommands via config. Shells allow
+ * arbitrary command execution via -c, bypassing all argument validation.
+ *
+ * This list cannot be overridden by configuration. OWASP A03 Injection.
+ * See: WOP-1423
+ */
+const SHELL_DENYLIST: ReadonlySet<string> = new Set([
+  "bash",
+  "sh",
+  "zsh",
+  "fish",
+  "dash",
+  "ksh",
+  "csh",
+  "tcsh",
+  "cmd",
+  "powershell",
+  "pwsh",
+]);
+
+/**
  * Get the effective allowlist (default + user-configured).
  */
 function getHookCommandAllowlist(): ReadonlySet<string> {
@@ -78,6 +100,13 @@ export function parseHookCommand(command: string): { executable: string; args: s
   // Block absolute/relative paths — only bare executable names allowed
   if (executable.includes("/") || executable.includes("\\") || isAbsolute(executable)) {
     logger.warn(`[hooks] Hook command rejected: paths not allowed in executable (${executable})`);
+    return null;
+  }
+
+  // Block shell executables — hardcoded, cannot be overridden by config.
+  // Shells allow arbitrary execution via -c, bypassing argument validation.
+  if (SHELL_DENYLIST.has(executable.toLowerCase())) {
+    logger.warn(`[hooks] Hook command rejected: '${executable}' is a denied shell executable`);
     return null;
   }
 

--- a/tests/security/hooks.test.ts
+++ b/tests/security/hooks.test.ts
@@ -168,6 +168,61 @@ describe("parseHookCommand", () => {
   });
 });
 
+describe("shell denylist (WOP-1423)", () => {
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `wopr-test-denylist-${randomBytes(8).toString("hex")}`);
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+    resetStorage();
+    getStorage(join(testDir, "test.sqlite"));
+    await initSecurity(testDir);
+  });
+
+  afterEach(() => {
+    resetStorage();
+  });
+
+  it("rejects all shell binaries even when added to allowedHookCommands", async () => {
+    const shells = ["bash", "sh", "zsh", "fish", "dash", "ksh", "csh", "tcsh", "cmd", "powershell", "pwsh"];
+    await setTestSecurityConfig({
+      enforcement: "enforce",
+      defaults: { minTrustLevel: "semi-trusted" },
+      allowedHookCommands: shells,
+    });
+
+    for (const shell of shells) {
+      const result = parseHookCommand(`${shell} -c echo`);
+      expect(result, `expected '${shell}' to be denied by denylist`).toBeNull();
+    }
+  });
+
+  it("rejects shells case-insensitively", async () => {
+    await setTestSecurityConfig({
+      enforcement: "enforce",
+      defaults: { minTrustLevel: "semi-trusted" },
+      allowedHookCommands: ["BASH", "ZSH", "PowerShell"],
+    });
+
+    expect(parseHookCommand("BASH -c echo")).toBeNull();
+    expect(parseHookCommand("ZSH -c echo")).toBeNull();
+    expect(parseHookCommand("PowerShell -c echo")).toBeNull();
+  });
+
+  it("still allows non-shell commands when shells are in config", async () => {
+    await setTestSecurityConfig({
+      enforcement: "enforce",
+      defaults: { minTrustLevel: "semi-trusted" },
+      allowedHookCommands: ["bash", "my-custom-hook"],
+    });
+
+    expect(parseHookCommand("bash -c echo")).toBeNull();
+    const result = parseHookCommand("my-custom-hook run");
+    expect(result).not.toBeNull();
+    expect(result!.executable).toBe("my-custom-hook");
+  });
+});
+
 describe("runPreInjectHooks", () => {
   beforeEach(async () => {
     testDir = join(tmpdir(), `wopr-test-hooks-${randomBytes(8).toString("hex")}`);


### PR DESCRIPTION
## Summary
Closes WOP-1423

- Added `SHELL_DENYLIST` constant (ReadonlySet) covering bash, sh, zsh, fish, dash, ksh, csh, tcsh, cmd, powershell, pwsh
- Denylist check inserted in `parseHookCommand` after path check, before allowlist — ensures shells are rejected even if added to `allowedHookCommands` config
- Check is case-insensitive (`.toLowerCase()`) to catch BASH, ZSH, PowerShell etc.
- Added 3 new test cases in `tests/security/hooks.test.ts` covering: all shells rejected even when in config, case-insensitive rejection, non-shell commands still allowed

## Test plan
- [ ] `npm run check` passes (lint + tsc)
- [ ] `npx vitest run tests/security/hooks.test.ts` — shell injection attack vectors all pass; denylist tests pass; storage-dependent tests fail due to pre-existing SQLite native binding issue unrelated to this change

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block shell executables in hook commands by adding `security.hooks.SHELL_DENYLIST` and enforcing it in `security.hooks.parseHookCommand` in [hooks.ts](https://github.com/wopr-network/wopr/pull/1719/files#diff-92f46c008d12f771b3f554b17ef1da1cbe457d31a8f2ef652a954987efe1a3b7)
> Add a hardcoded `ReadonlySet` denylist of common shells in [hooks.ts](https://github.com/wopr-network/wopr/pull/1719/files#diff-92f46c008d12f771b3f554b17ef1da1cbe457d31a8f2ef652a954987efe1a3b7) and update `security.hooks.parseHookCommand` to return `null` and log a warning when the executable (case-insensitive) is in the denylist, checked before the allowlist. Add tests validating denial and case-insensitivity in [hooks.test.ts](https://github.com/wopr-network/wopr/pull/1719/files#diff-4170b74be0490f117221e9323fa0886d20f1e0839e81f0d66c1a12abf4d12f30).
>
> #### 📍Where to Start
> Start with the denylist check in `security.hooks.parseHookCommand` in [hooks.ts](https://github.com/wopr-network/wopr/pull/1719/files#diff-92f46c008d12f771b3f554b17ef1da1cbe457d31a8f2ef652a954987efe1a3b7), then review the new tests in [hooks.test.ts](https://github.com/wopr-network/wopr/pull/1719/files#diff-4170b74be0490f117221e9323fa0886d20f1e0839e81f0d66c1a12abf4d12f30).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 011b4a3. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->