### PR TITLE
feat(security): scope-aware injection trust (WOP-1422)

### DIFF
--- a/src/daemon/routes/openai.ts
+++ b/src/daemon/routes/openai.ts
@@ -15,7 +15,17 @@ import { deleteSession, inject, setSessionContext, setSessionProvider } from "..
 import { createInjectionSource } from "../../security/index.js";
 import type { ProviderConfig } from "../../types/provider.js";
 
-export const openaiRouter = new Hono();
+type AuthEnv = {
+  Variables: {
+    user: { id: string } | undefined;
+    role: string;
+    session: unknown;
+    authMethod: string;
+    apiKeyScope: string;
+  };
+};
+
+export const openaiRouter = new Hono<AuthEnv>();
 
 /** Valid roles for OpenAI chat messages */
 const VALID_ROLES = new Set(["system", "user", "assistant", "tool"]);
@@ -265,6 +275,22 @@ openaiRouter.post(
     }
     await setSessionProvider(sessionName, providerConfig);
 
+    // WOP-1422: Enforce API key scope — read-only keys cannot inject
+    const apiKeyScope = c.get("apiKeyScope") as string | undefined;
+    if (apiKeyScope === "read-only") {
+      await deleteSession(sessionName, "scope-rejected").catch(() => {});
+      return c.json(
+        {
+          error: {
+            message: "Forbidden: insufficient scope for inject",
+            type: "invalid_request_error",
+            code: "insufficient_scope",
+          },
+        },
+        403,
+      );
+    }
+
     if (body.stream) {
       // ---- Streaming response (SSE) ----
       c.header("Content-Type", "text/event-stream");
@@ -281,7 +307,10 @@ openaiRouter.post(
           await inject(sessionName, userPrompt, {
             silent: true,
             from: "openai-api",
-            source: createInjectionSource("daemon"),
+            source:
+              apiKeyScope === "full"
+                ? createInjectionSource("daemon", { trustLevel: "owner" })
+                : createInjectionSource("daemon"),
             onStream: (msg) => {
               if (msg.type === "text" && msg.content) {
                 const chunk = {
@@ -339,7 +368,10 @@ openaiRouter.post(
       const result = await inject(sessionName, userPrompt, {
         silent: true,
         from: "openai-api",
-        source: createInjectionSource("daemon"),
+        source:
+          apiKeyScope === "full"
+            ? createInjectionSource("daemon", { trustLevel: "owner" })
+            : createInjectionSource("daemon"),
       });
 
       return c.json({

--- a/src/daemon/routes/sessions.ts
+++ b/src/daemon/routes/sessions.ts
@@ -19,7 +19,17 @@ import { createInjectionSource } from "../../security/index.js";
 import { validateSessionName } from "../validation.js";
 import { broadcastInjection, broadcastStream } from "../ws.js";
 
-export const sessionsRouter = new Hono();
+type AuthEnv = {
+  Variables: {
+    user: { id: string } | undefined;
+    role: string;
+    session: unknown;
+    authMethod: string;
+    apiKeyScope: string;
+  };
+};
+
+export const sessionsRouter = new Hono<AuthEnv>();
 
 // List all sessions
 sessionsRouter.get(
@@ -199,6 +209,13 @@ sessionsRouter.post(
   async (c) => {
     const name = c.req.param("name");
     validateSessionName(name);
+
+    // WOP-1422: Enforce API key scope — read-only keys cannot inject
+    const apiKeyScope = c.get("apiKeyScope") as string | undefined;
+    if (apiKeyScope === "read-only") {
+      return c.json({ error: "Forbidden: insufficient scope for inject" }, 403);
+    }
+
     const body = await c.req.json();
     const { message, from = "api" } = body;
 
@@ -221,7 +238,10 @@ sessionsRouter.post(
           from,
           // SECURITY: API requests come from daemon with owner trust level
           // (daemon is local, authenticated implicitly)
-          source: createInjectionSource("daemon"),
+          source:
+            apiKeyScope === "full"
+              ? createInjectionSource("daemon", { trustLevel: "owner" })
+              : createInjectionSource("daemon"),
           onStream: (msg) => {
             // Send SSE event
             const data = JSON.stringify({
@@ -253,7 +273,10 @@ sessionsRouter.post(
         silent: true,
         from,
         // SECURITY: API requests come from daemon with owner trust level
-        source: createInjectionSource("daemon"),
+        source:
+          apiKeyScope === "full"
+            ? createInjectionSource("daemon", { trustLevel: "owner" })
+            : createInjectionSource("daemon"),
         onStream: (msg) => {
           broadcastStream(name, from, msg);
         },

--- a/tests/unit/inject-scope.test.ts
+++ b/tests/unit/inject-scope.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { sessionsRouter } from "../../src/daemon/routes/sessions.js";
+
+// Mock dependencies
+vi.mock("../../src/core/sessions.js", () => ({
+  listSessions: vi.fn().mockResolvedValue({}),
+  getSessions: vi.fn().mockResolvedValue({ test: "session-id" }),
+  getSessionContext: vi.fn().mockResolvedValue("context"),
+  setSessionContext: vi.fn().mockResolvedValue(undefined),
+  deleteSession: vi.fn().mockResolvedValue(undefined),
+  inject: vi.fn().mockResolvedValue({ sessionId: "sid", response: "ok" }),
+  logMessage: vi.fn().mockResolvedValue(undefined),
+  readConversationLog: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../src/security/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/security/index.js")>();
+  return {
+    ...original,
+    createInjectionSource: vi.fn(original.createInjectionSource),
+  };
+});
+
+vi.mock("../../src/daemon/ws.js", () => ({
+  broadcastInjection: vi.fn(),
+  broadcastStream: vi.fn(),
+}));
+
+describe("inject endpoint scope enforcement", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    // Simulate middleware setting apiKeyScope on context
+    app.use("*", async (c, next) => {
+      const scope = c.req.header("X-Test-Scope");
+      if (scope) {
+        c.set("apiKeyScope", scope);
+      }
+      // If no scope header, apiKeyScope stays undefined (daemon bearer token path)
+      await next();
+    });
+    app.route("/sessions", sessionsRouter);
+  });
+
+  it("returns 403 for read-only API key scope", async () => {
+    const res = await app.request("/sessions/test/inject", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Test-Scope": "read-only",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/forbidden|insufficient.*scope/i);
+  });
+
+  it("allows full scope API key to inject", async () => {
+    const res = await app.request("/sessions/test/inject", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Test-Scope": "full",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows daemon bearer token (no apiKeyScope) to inject", async () => {
+    const res = await app.request("/sessions/test/inject", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("uses owner trust for full scope", async () => {
+    const { createInjectionSource } = await import("../../src/security/index.js");
+    await app.request("/sessions/test/inject", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Test-Scope": "full",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(createInjectionSource).toHaveBeenCalledWith("daemon", expect.objectContaining({ trustLevel: "owner" }));
+  });
+
+  it("uses owner trust for daemon bearer (undefined scope)", async () => {
+    const { createInjectionSource } = await import("../../src/security/index.js");
+    await app.request("/sessions/test/inject", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hello" }),
+    });
+    expect(createInjectionSource).toHaveBeenCalledWith("daemon");
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1422

- Add scope guard to `/sessions/:name/inject` — `read-only` API keys get 403
- Add same scope guard to `/v1/chat/completions` (OpenAI-compat route)
- Map `full` scope API keys to `owner` trust; daemon bearer token (undefined scope) keeps existing `owner` trust via bare `createInjectionSource("daemon")`
- Add `AuthEnv` types to both routers so `c.get("apiKeyScope")` is properly typed
- Add 5 unit tests covering all access paths

## Test plan
- [x] `npm run check` passes (lint + tsc)
- [x] `npx vitest run tests/unit/inject-scope.test.ts` — 5/5 pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce scope-aware injection trust by rejecting `POST /v1/chat/completions` and `POST /sessions/:name/inject` with `apiKeyScope` "read-only" and setting `createInjectionSource("daemon")` trustLevel to "owner" when scope is "full" in [openai.ts](https://github.com/wopr-network/wopr/pull/1721/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09) and [sessions.ts](https://github.com/wopr-network/wopr/pull/1721/files#diff-13f1a51824d9c75301614ce6637753bf777975a3460dd2bc3073b38a0bbb584b)
> Add `AuthEnv` with `apiKeyScope`, gate handlers to return 403 for "read-only" scope, and set `createInjectionSource("daemon", { trustLevel: "owner" })` when scope is "full"; include unit tests in [inject-scope.test.ts](https://github.com/wopr-network/wopr/pull/1721/files#diff-4b023a632e277db4b45cee1e55224b89da59d7cb46e838bbd6505adccfbea872).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1422](https://linear.app/wopr/issue/WOP-1422) by implementing scope-aware trust and rejection logic for injection-related endpoints.
>
> #### 📍Where to Start
> Start with the `openaiRouter.post` chat completions handler in [openai.ts](https://github.com/wopr-network/wopr/pull/1721/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09), then review the `sessionsRouter.post` inject handler in [sessions.ts](https://github.com/wopr-network/wopr/pull/1721/files#diff-13f1a51824d9c75301614ce6637753bf777975a3460dd2bc3073b38a0bbb584b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a98aee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->