### PR TITLE
fix: read capability catalog baseUrl from WOPR_API_BASE_URL env var (WOP-1434)

### DIFF
--- a/src/core/capability-catalog.ts
+++ b/src/core/capability-catalog.ts
@@ -37,8 +37,10 @@ export interface CapabilityPluginRef {
  * Uses the bot's platform token from env/config.
  */
 function hostedDefaults(): { baseUrl: string } {
+  const configured = process.env.WOPR_API_BASE_URL?.trim();
+  const baseUrl = configured ? configured.replace(/\/+$/, "") : "https://api.wopr.bot";
   return {
-    baseUrl: process.env.WOPR_API_BASE_URL || "https://api.wopr.bot",
+    baseUrl,
   };
 }
 

--- a/tests/unit/capability-catalog-env.test.ts
+++ b/tests/unit/capability-catalog-env.test.ts
@@ -12,15 +12,19 @@ describe("capability-catalog hostedDefaults baseUrl", () => {
       "../../src/core/capability-catalog.js"
     );
     const voice = CAPABILITY_CATALOG.find((c: any) => c.id === "voice");
-    expect(voice?.plugins[0]?.hostedConfig?.baseUrl).toBe("http://localhost:9999");
+    expect(
+      voice?.plugins.every((p: any) => p?.hostedConfig?.baseUrl === "http://localhost:9999")
+    ).toBe(true);
   });
 
   it("falls back to https://api.wopr.bot when env var absent", async () => {
-    vi.stubEnv("WOPR_API_BASE_URL", "");
+    delete process.env.WOPR_API_BASE_URL;
     const { CAPABILITY_CATALOG } = await import(
       "../../src/core/capability-catalog.js"
     );
     const voice = CAPABILITY_CATALOG.find((c: any) => c.id === "voice");
-    expect(voice?.plugins[0]?.hostedConfig?.baseUrl).toBe("https://api.wopr.bot");
+    expect(
+      voice?.plugins.every((p: any) => p?.hostedConfig?.baseUrl === "https://api.wopr.bot")
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Closes WOP-1434

- Replace hardcoded `"https://api.wopr.bot"` in `hostedDefaults()` with `process.env.WOPR_API_BASE_URL || "https://api.wopr.bot"`
- Add unit test (`tests/unit/capability-catalog-env.test.ts`) verifying env var override and fallback behavior

## Test plan
- [x] `npm run check` passes
- [x] `npx vitest run tests/unit/capability-catalog-env.test.ts` passes (2 tests)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Read CAPABILITY_CATALOG hosted defaults baseUrl from `process.env.WOPR_API_BASE_URL` in `src/core/capability-catalog.ts` to align with WOP-1434
> Update `capability-catalog.hostedDefaults` to derive `baseUrl` from `process.env.WOPR_API_BASE_URL`, trimming and removing trailing slashes, with fallback to `https://api.wopr.bot`; add unit tests covering both paths in [capability-catalog-env.test.ts](https://github.com/wopr-network/wopr/pull/1722/files#diff-8fcad89e8f8f113f2a41e99008abb9061224e7e4aaf1730b38147d70cd612473).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1434](ticket:jira/WOP-1434) by sourcing the CAPABILITY_CATALOG baseUrl from the specified environment variable and validating the behavior with tests.
>
> #### 📍Where to Start
> Start with the `hostedDefaults` logic in [capability-catalog.ts](https://github.com/wopr-network/wopr/pull/1722/files#diff-a3c6f22bdb44312e4ddb99cfb1f7de5d19541677e0657ff0c3869afcf3c55a3d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79d02b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoint base URL is now configurable via the WOPR_API_BASE_URL environment variable (whitespace and trailing slashes are trimmed); falls back to the default https://api.wopr.bot when unset.

* **Tests**
  * Added unit tests validating environment-variable-based endpoint configuration and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->