### PR TITLE
fix: gate stack traces on shouldLogStack() in production (WOP-1433)

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -9,7 +9,7 @@
  */
 
 import { EventEmitter } from "node:events";
-import { logger } from "../logger.js";
+import { logger, shouldLogStack } from "../logger.js";
 
 // ============================================================================
 // Core Event Types
@@ -304,7 +304,7 @@ class WOPREventBusImpl implements WOPREventBus {
         const errMsg = err instanceof Error ? err.message : String(err);
         const stack = err instanceof Error ? err.stack : undefined;
         logger.error(`[events] Handler error for '${String(event)}' (source: ${meta?.source || "unknown"}): ${errMsg}`);
-        if (stack) logger.error(`[events] Stack: ${stack}`);
+        if (stack && shouldLogStack()) logger.error(`[events] Stack: ${stack}`);
       }
     };
 
@@ -338,7 +338,7 @@ class WOPREventBusImpl implements WOPREventBus {
         const errMsg = err instanceof Error ? err.message : String(err);
         const stack = err instanceof Error ? err.stack : undefined;
         logger.error(`[events] Handler error for '${String(event)}' (source: ${meta?.source || "unknown"}): ${errMsg}`);
-        if (stack) logger.error(`[events] Stack: ${stack}`);
+        if (stack && shouldLogStack()) logger.error(`[events] Stack: ${stack}`);
       }
     };
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -21,7 +21,7 @@ import { config as centralConfig } from "../core/config.js";
 // Provider registry imports
 import { providerRegistry } from "../core/providers.js";
 import { inject } from "../core/sessions.js";
-import { logger as winstonLogger } from "../logger.js";
+import { shouldLogStack, logger as winstonLogger } from "../logger.js";
 import { LOG_FILE, PID_FILE } from "../paths.js";
 import { bootstrapEnvPlugins } from "../plugins/bootstrap.js";
 import { pluginManifests } from "../plugins/state.js";
@@ -71,7 +71,7 @@ const DEFAULT_HOST = process.env.WOPR_DAEMON_HOST || "127.0.0.1";
 // After an uncaught exception Node's state is undefined; continuing risks silent corruption.
 export function handleUncaughtException(error: Error): void {
   winstonLogger.error(`[daemon] Uncaught exception: ${error.message}`);
-  winstonLogger.error(`[daemon] Stack: ${error.stack}`);
+  if (shouldLogStack()) winstonLogger.error(`[daemon] Stack: ${error.stack}`);
   process.exit(1);
 }
 
@@ -79,7 +79,7 @@ export function handleUnhandledRejection(reason: unknown, _promise: Promise<unkn
   const msg = reason instanceof Error ? reason.message : String(reason);
   const stack = reason instanceof Error ? reason.stack : undefined;
   winstonLogger.error(`[daemon] Unhandled rejection: ${msg}`);
-  if (stack) winstonLogger.error(`[daemon] Stack: ${stack}`);
+  if (stack && shouldLogStack()) winstonLogger.error(`[daemon] Stack: ${stack}`);
   process.exit(1);
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,3 +7,13 @@ export const logger = winston.createLogger({
 });
 
 export default logger;
+
+/**
+ * Returns true when full stack traces should be included in log output.
+ * Stacks are logged when NODE_ENV is not "production" OR LOG_LEVEL is "debug".
+ */
+export function shouldLogStack(): boolean {
+  const env = process.env.NODE_ENV;
+  const level = process.env.LOG_LEVEL;
+  return env !== "production" || level === "debug";
+}

--- a/src/plugins/loading.ts
+++ b/src/plugins/loading.ts
@@ -11,7 +11,7 @@ import { getCapabilityDependencyGraph } from "../core/capability-deps.js";
 import { getCapabilityHealthProber } from "../core/capability-health.js";
 import { getCapabilityRegistry } from "../core/capability-registry.js";
 import { emitPluginActivated, emitPluginDeactivated, emitPluginDrained, emitPluginDraining } from "../core/events.js";
-import { logger } from "../logger.js";
+import { logger, shouldLogStack } from "../logger.js";
 import type { InstallMethod, PluginManifest, PluginRequirements } from "../plugin-types/manifest.js";
 import {
   checkNodeRequirement,
@@ -578,7 +578,7 @@ export async function loadAllPlugins(
     } catch (err: unknown) {
       const error = err as Error;
       logger.error(`[plugins]   Failed to load ${plugin.name}:`, error.message);
-      if (error.stack) {
+      if (error.stack && shouldLogStack()) {
         logger.error(`[plugins]     Stack:`, error.stack.substring(0, 200));
       }
       failed.push({ name: plugin.name, error: error.message });

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("shouldLogStack", () => {
+  let origNodeEnv: string | undefined;
+  let origLogLevel: string | undefined;
+
+  beforeEach(() => {
+    origNodeEnv = process.env.NODE_ENV;
+    origLogLevel = process.env.LOG_LEVEL;
+  });
+
+  afterEach(() => {
+    if (origNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = origNodeEnv;
+    if (origLogLevel === undefined) delete process.env.LOG_LEVEL;
+    else process.env.LOG_LEVEL = origLogLevel;
+  });
+
+  it("returns true when NODE_ENV is not production", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.LOG_LEVEL;
+    const { shouldLogStack } = await import("../../src/logger.js");
+    expect(shouldLogStack()).toBe(true);
+  });
+
+  it("returns false when NODE_ENV is production and LOG_LEVEL is not debug", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.LOG_LEVEL = "info";
+    const { shouldLogStack } = await import("../../src/logger.js");
+    expect(shouldLogStack()).toBe(false);
+  });
+
+  it("returns true when NODE_ENV is production but LOG_LEVEL is debug", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.LOG_LEVEL = "debug";
+    const { shouldLogStack } = await import("../../src/logger.js");
+    expect(shouldLogStack()).toBe(true);
+  });
+
+  it("returns true when NODE_ENV is undefined", async () => {
+    delete process.env.NODE_ENV;
+    delete process.env.LOG_LEVEL;
+    const { shouldLogStack } = await import("../../src/logger.js");
+    expect(shouldLogStack()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1433

- Add `shouldLogStack()` helper to `src/logger.ts` — returns true when `NODE_ENV !== 'production'` or `LOG_LEVEL === 'debug'`
- Gate stack trace logging in `src/daemon/index.ts` (uncaught exception + unhandled rejection handlers)
- Gate stack trace logging in `src/plugins/loading.ts` (plugin load failure handler)
- Gate stack trace logging in `src/core/events.ts` (event bus error handler, both occurrences)
- Add `tests/unit/logger.test.ts` with 4 tests covering all `shouldLogStack()` branches

## Test plan
- [x] `npm run check` passes
- [x] `npx vitest run tests/unit/logger.test.ts` — 4/4 pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate error stack logging behind `logger.shouldLogStack()` across event handlers, daemon error handlers, and plugin loader to reduce stack traces in production (WOP-1433)
> Introduce `logger.shouldLogStack()` and update error handling paths to log stacks only when it returns true, adjusting `WOPREventBusImpl.on`, `WOPREventBusImpl.once`, daemon exception/rejection handlers, and plugin loading.
>
> #### 📍Where to Start
> Start with `shouldLogStack()` in [logger.ts](https://github.com/wopr-network/wopr/pull/1723/files#diff-7bc1140e724e284ae22084e1172568baa8d151063d02c75ed1d8805fa7796aca), then review its use in event handler wrappers in [events.ts](https://github.com/wopr-network/wopr/pull/1723/files#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8) and error handlers in [index.ts](https://github.com/wopr-network/wopr/pull/1723/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 547b9c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->