### PR TITLE
test: add comprehensive unit tests for daemon plugin routes (WOP-1414)

### DIFF
--- a/tests/unit/routes/plugins.test.ts
+++ b/tests/unit/routes/plugins.test.ts
@@ -308,6 +308,15 @@ describe("POST /uninstall — uninstall plugin", () => {
     const json = await res.json();
     expect(json.error).toBe("Plugin uninstall failed");
   });
+
+  it("returns 400 when removePlugin throws after unload succeeds", async () => {
+    mockUnloadPlugin.mockResolvedValue(undefined);
+    mockRemovePlugin.mockRejectedValue(new Error("remove failed"));
+    const res = await req("POST", "/uninstall", { name: "test-plugin" });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Plugin uninstall failed");
+  });
 });
 
 describe("DELETE /:name — remove plugin (legacy)", () => {
@@ -337,6 +346,12 @@ describe("DELETE /:name — remove plugin (legacy)", () => {
 
   it("returns 400 for invalid name", async () => {
     const res = await req("DELETE", "/..bad");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when unloadPlugin throws", async () => {
+    mockUnloadPlugin.mockRejectedValue(new Error("unload failed"));
+    const res = await req("DELETE", "/test-plugin");
     expect(res.status).toBe(400);
   });
 
@@ -648,6 +663,18 @@ describe("GET /available", () => {
     expect(json.results).toHaveLength(1);
   });
 
+  it("passes query string to searchPlugins", async () => {
+    mockSearchPlugins.mockResolvedValue([]);
+    await req("GET", "/available?q=voice");
+    expect(mockSearchPlugins).toHaveBeenCalledWith("voice");
+  });
+
+  it("passes empty string to searchPlugins when q is omitted", async () => {
+    mockSearchPlugins.mockResolvedValue([]);
+    await req("GET", "/available");
+    expect(mockSearchPlugins).toHaveBeenCalledWith("");
+  });
+
   it("respects limit query param (capped at 100)", async () => {
     const manyResults = Array.from({ length: 150 }, (_, i) => ({ name: `p${i}` }));
     mockSearchPlugins.mockResolvedValue(manyResults);
@@ -748,6 +775,11 @@ describe("registries", () => {
     const json = await res.json();
     expect(json.removed).toBe(true);
     expect(mockRemoveRegistry).toHaveBeenCalledWith("custom");
+  });
+
+  it("POST /registries returns 400 when url is missing", async () => {
+    const res = await req("POST", "/registries", { url: "https://example.com" });
+    expect(res.status).toBe(400);
   });
 });
 


### PR DESCRIPTION
## Summary
Closes WOP-1414

- Adds `tests/unit/routes/plugins.test.ts` with 75 tests covering all 20 route handlers in `src/daemon/routes/plugins.ts` (901 lines, previously zero coverage)
- Tests all HTTP methods: GET, POST, PUT, DELETE across list, install, uninstall, enable, disable, reload, config, state, health, search, registries, and discord claim routes
- Covers validation errors (missing params, invalid plugin names, path traversal, shell metacharacters), 404s, schema validation failures, and drain options passthrough
- Mocks all external dependencies (plugins.js, config, providers, sessions, logger, hono-openapi, hono-rate-limiter) for isolated unit testing

## Test plan
- [x] `npm run check` passes (lint + tsc --noEmit)
- [x] `npx vitest run tests/unit/routes/plugins.test.ts` passes — 75 tests in 41ms

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for daemon plugins router to verify install, uninstall, enable/disable, config, health, search, UI extensions, registry, and Discord claim routes in [plugins.test.ts](https://github.com/wopr-network/wopr/pull/1800/files#diff-a514124518be41418382a21f579b2f4097140b8f4de7142ce2f2945d47cc0b69)
> Add a Vitest suite that mocks plugin and middleware dependencies and exercises route behaviors for install/uninstall variants, state toggles and reload, config read/update with schema checks, health and manifest resolution, available search with query/limits, UI extensions/components, generic search validation, registry list/add/remove, and Discord ownership claim via extension.
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1414](ticket:jira/WOP-1414) by adding coverage for daemon plugin routes.
>
> #### 📍Where to Start
> Start with the test setup and helper request function in [plugins.test.ts](https://github.com/wopr-network/wopr/pull/1800/files#diff-a514124518be41418382a21f579b2f4097140b8f4de7142ce2f2945d47cc0b69) to see mocked modules and router wiring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c06ed70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for plugin management operations, including installation, configuration, enabling/disabling, and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->