### PR TITLE
security: replace Math.random() with crypto.randomBytes for request IDs (WOP-1420)

### DIFF
--- a/src/security/context.ts
+++ b/src/security/context.ts
@@ -6,6 +6,7 @@
  * permissions and tracking security events.
  */
 
+import { randomBytes } from "node:crypto";
 import { logger } from "../logger.js";
 import {
   checkCapability,
@@ -365,7 +366,7 @@ export function createApiContext(
  */
 function generateRequestId(): string {
   const timestamp = Date.now().toString(36);
-  const random = Math.random().toString(36).substring(2, 8);
+  const random = randomBytes(6).toString("hex");
   return `sec-${timestamp}-${random}`;
 }
 

--- a/src/security/forward.ts
+++ b/src/security/forward.ts
@@ -5,6 +5,7 @@
  * to privileged sessions, with full policy enforcement.
  */
 
+import { randomBytes } from "node:crypto";
 import { logger } from "../logger.js";
 import { clearContext, createSecurityContext, type SecurityContext, storeContext } from "./context.js";
 import {
@@ -49,7 +50,7 @@ export interface ForwardResult {
 
 function generateTrackingId(): string {
   const timestamp = Date.now().toString(36);
-  const random = Math.random().toString(36).substring(2, 8);
+  const random = randomBytes(6).toString("hex");
   return `fwd-${timestamp}-${random}`;
 }
 

--- a/src/security/gateway.ts
+++ b/src/security/gateway.ts
@@ -11,6 +11,7 @@
  * They must go through a gateway.
  */
 
+import { randomBytes } from "node:crypto";
 import { logger } from "../logger.js";
 import { createSecurityContext, type SecurityContext } from "./context.js";
 import { canGatewayForward, getGatewayRules, getSecurityConfig, isGatewaySession } from "./policy.js";
@@ -359,7 +360,7 @@ export function requiresGateway(source: InjectionSource, targetSession: string):
 
 function generateRequestId(): string {
   const timestamp = Date.now().toString(36);
-  const random = Math.random().toString(36).substring(2, 8);
+  const random = randomBytes(6).toString("hex");
   return `fwd-${timestamp}-${random}`;
 }
 


### PR DESCRIPTION
## Summary
Closes WOP-1420

- Replace `Math.random().toString(36).substring(2, 8)` with `randomBytes(6).toString("hex")` in three security files
- `src/security/gateway.ts` — `generateRequestId()` (line 362)
- `src/security/forward.ts` — `generateTrackingId()` (line 52)
- `src/security/context.ts` — `generateRequestId()` (line 368)
- Increases entropy from ~31 bits (Math.random) to 48 bits (crypto.randomBytes), preventing ID prediction/brute-force

## Test plan
- [ ] `npm run check` passes (lint + tsc)
- [ ] ID format preserved: `fwd-<timestamp>-<hex>` and `sec-<timestamp>-<hex>`
- [ ] No existing tests broken (functions are private, not exported)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace random ID generation in `security/context.generateRequestId`, `security/forward.generateTrackingId`, and `security/gateway.generateRequestId` with `crypto.randomBytes(6)` to meet security intent in WOP-1420
> Switch random ID segments to 12-character hex from 6 bytes using `node:crypto` across security ID utilities, keeping existing ID formats.
>
> #### 📍Where to Start
> Start with `generateRequestId` in [context.ts](https://github.com/wopr-network/wopr/pull/1804/files#diff-ad6cf786730b7e2532597b0df7101fc3d5f948d2ed6fb822400f27f82a671dc9), then review similar changes in [forward.ts](https://github.com/wopr-network/wopr/pull/1804/files#diff-a563d0e684e118020a75fdbdf6010144d7d1f9a5b395398a971c35bd40ad707d) and [gateway.ts](https://github.com/wopr-network/wopr/pull/1804/files#diff-02bfd281174fdd5b92a838ce683864688eac2bc697fa870d0190f8a0c8482bd4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6627a33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->