### PR TITLE
fix: return real token usage from OpenAI-compatible endpoint (WOP-1459)

### DIFF
--- a/src/core/queue/types.ts
+++ b/src/core/queue/types.ts
@@ -27,6 +27,7 @@ export interface InjectOptions {
 export interface InjectResult {
   response: string;
   sessionId: string;
+  usage?: { inputTokens: number; outputTokens: number };
 }
 
 /**

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -247,6 +247,7 @@ async function executeInjectInternal(
   const channel = options?.channel;
   const collected: string[] = [];
   let sessionId = existingSessionId || "";
+  let usageResult: { inputTokens: number; outputTokens: number } | undefined;
 
   // SECURITY: Create security context from source (defaults to CLI/owner)
   const injectionSource = options?.source ?? createInjectionSource("cli");
@@ -357,7 +358,7 @@ async function executeInjectInternal(
         type: "context",
         channel,
       });
-      return { response: "", sessionId };
+      return { response: "", sessionId, usage: usageResult };
     }
 
     const processedMessage = incomingResult.message;
@@ -557,10 +558,20 @@ async function executeInjectInternal(
             break;
           }
           case "result": {
-            const resultMsg = msg as { subtype?: string; errors?: unknown; permission_denials?: unknown };
+            const resultMsg = msg as {
+              subtype?: string;
+              errors?: unknown;
+              permission_denials?: unknown;
+              usage?: { input_tokens?: number; output_tokens?: number };
+            };
             if (resultMsg.subtype === "success") {
               if (!silent) logger.info(`\n[wopr] Complete (${providerUsed}).`);
-              const streamMsg: StreamMessage = { type: "complete", content: "" };
+              const rawUsage = resultMsg.usage;
+              const usageData = rawUsage
+                ? { inputTokens: rawUsage.input_tokens ?? 0, outputTokens: rawUsage.output_tokens ?? 0 }
+                : undefined;
+              usageResult = usageData;
+              const streamMsg: StreamMessage = { type: "complete", content: "", usage: usageData };
               if (onStream) onStream(streamMsg);
             } else {
               if (!silent) logger.error(`[wopr] Error: ${resultMsg.subtype}`);
@@ -645,11 +656,23 @@ async function executeInjectInternal(
               }
               break;
             }
-            case "result":
-              if (msg.subtype === "success") {
+            case "result": {
+              const retryResultMsg = msg as {
+                subtype?: string;
+                usage?: { input_tokens?: number; output_tokens?: number };
+              };
+              if (retryResultMsg.subtype === "success") {
                 if (!silent) logger.info(`[wopr] Complete (retry).`);
+                const rawUsage = retryResultMsg.usage;
+                const usageData = rawUsage
+                  ? { inputTokens: rawUsage.input_tokens ?? 0, outputTokens: rawUsage.output_tokens ?? 0 }
+                  : undefined;
+                usageResult = usageData;
+                const streamMsg: StreamMessage = { type: "complete", content: "", usage: usageData };
+                if (onStream) onStream(streamMsg);
               }
               break;
+            }
           }
         }
       } else {
@@ -675,7 +698,7 @@ async function executeInjectInternal(
         type: "context",
         channel,
       });
-      return { response: "", sessionId };
+      return { response: "", sessionId, usage: usageResult };
     }
 
     response = outgoingResult.response;
@@ -696,7 +719,7 @@ async function executeInjectInternal(
     const { updateLastTriggerTimestamp } = await import("./context.js");
     updateLastTriggerTimestamp(name);
 
-    return { response, sessionId };
+    return { response, sessionId, usage: usageResult };
   } finally {
     // SECURITY: Always clear context when request completes
     clearContext(name);

--- a/src/daemon/routes/openai.ts
+++ b/src/daemon/routes/openai.ts
@@ -44,6 +44,7 @@ interface ChatCompletionRequest {
   top_p?: number;
   max_tokens?: number;
   stream?: boolean;
+  stream_options?: { include_usage?: boolean };
 }
 
 /** Post-validation message with guaranteed string content */
@@ -304,6 +305,8 @@ openaiRouter.post(
         });
 
         try {
+          let streamUsage: { inputTokens: number; outputTokens: number } | undefined;
+
           await inject(sessionName, userPrompt, {
             silent: true,
             from: "openai-api",
@@ -327,12 +330,14 @@ openaiRouter.post(
                   ],
                 };
                 s.write(`data: ${JSON.stringify(chunk)}\n\n`);
+              } else if (msg.type === "complete" && msg.usage) {
+                streamUsage = msg.usage;
               }
             },
           });
 
           // Final chunk with finish_reason
-          const finalChunk = {
+          const finalChunk: Record<string, unknown> = {
             id: requestId,
             object: "chat.completion.chunk",
             created,
@@ -345,6 +350,13 @@ openaiRouter.post(
               },
             ],
           };
+          if (body.stream_options?.include_usage && streamUsage) {
+            finalChunk.usage = {
+              prompt_tokens: streamUsage.inputTokens,
+              completion_tokens: streamUsage.outputTokens,
+              total_tokens: streamUsage.inputTokens + streamUsage.outputTokens,
+            };
+          }
           s.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
           s.write("data: [DONE]\n\n");
         } catch (err) {
@@ -390,9 +402,9 @@ openaiRouter.post(
           },
         ],
         usage: {
-          prompt_tokens: 0,
-          completion_tokens: 0,
-          total_tokens: 0,
+          prompt_tokens: result.usage?.inputTokens ?? 0,
+          completion_tokens: result.usage?.outputTokens ?? 0,
+          total_tokens: (result.usage?.inputTokens ?? 0) + (result.usage?.outputTokens ?? 0),
         },
       });
     } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,6 +369,7 @@ export interface StreamMessage {
   toolName?: string;
   subtype?: string; // For system messages: "init", "compact_boundary", "status", etc.
   metadata?: Record<string, unknown>; // For system message metadata (e.g., compact_metadata)
+  usage?: { inputTokens: number; outputTokens: number };
 }
 
 export type StreamCallback = (msg: StreamMessage) => void;

--- a/tests/unit/openai-compat.test.ts
+++ b/tests/unit/openai-compat.test.ts
@@ -237,6 +237,101 @@ describe("OpenAI Compatibility Layer", () => {
   });
 
   // ==========================================================================
+  // Token usage tests
+  // ==========================================================================
+
+  describe("token usage", () => {
+    it("returns token usage from inject result", async () => {
+      vi.mocked(inject).mockResolvedValueOnce({
+        response: "Hello world",
+        sessionId: "test-session-id",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      });
+
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.usage).toEqual({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+    });
+
+    it("returns zero usage when provider does not report tokens", async () => {
+      vi.mocked(inject).mockResolvedValueOnce({ response: "Hello", sessionId: "test-session-id" });
+
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "anthropic", messages: [{ role: "user", content: "Hello" }] }),
+      });
+
+      const data = await res.json();
+      expect(data.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+    });
+
+    it("includes usage in final SSE chunk when stream_options.include_usage is true", async () => {
+      vi.mocked(inject).mockImplementation(async (_name: string, _message: string, options?: any) => {
+        if (options?.onStream) {
+          options.onStream({ type: "text", content: "Hello" });
+          options.onStream({ type: "complete", content: "", usage: { inputTokens: 10, outputTokens: 5 } });
+        }
+        return { response: "Hello", sessionId: "test-session-id", usage: { inputTokens: 10, outputTokens: 5 } };
+      });
+
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "user", content: "Hello" }],
+          stream: true,
+          stream_options: { include_usage: true },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      const events = text
+        .split("\n\n")
+        .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+        .map((line) => JSON.parse(line.replace("data: ", "")));
+
+      const finalChunk = events.find((e: any) => e.choices?.[0]?.finish_reason === "stop");
+      expect(finalChunk).toBeDefined();
+      expect(finalChunk.usage).toEqual({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+    });
+
+    it("does NOT include usage in final SSE chunk when stream_options is absent", async () => {
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "anthropic", messages: [{ role: "user", content: "Hello" }], stream: true }),
+      });
+
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      const events = text
+        .split("\n\n")
+        .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+        .map((line) => JSON.parse(line.replace("data: ", "")));
+
+      const finalChunk = events.find((e: any) => e.choices?.[0]?.finish_reason === "stop");
+      expect(finalChunk).toBeDefined();
+      expect(finalChunk.usage).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
   // POST /v1/chat/completions - Validation
   // ==========================================================================
 


### PR DESCRIPTION
## Summary
Closes WOP-1459

- Extracts token usage from SDK result messages in sessions.ts
- Propagates usage through InjectResult to the OpenAI route
- Non-streaming responses return real prompt_tokens/completion_tokens
- Streaming responses include usage in final SSE chunk (when stream_options.include_usage=true)
- Falls back to zeros when provider doesn't report usage

## Test plan
- [x] `npm run check` passes
- [x] `npx vitest run tests/unit/openai-compat.test.ts` — 34 tests pass (4 new usage tests)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return accurate token usage in `/v1/chat/completions` and include usage in SSE final chunk when `stream_options.include_usage` is true via updates in `src/daemon/routes/openai.ts` and `src/core/sessions.ts`
> Add usage propagation through `executeInjectInternal` and stream messages, and surface usage in OpenAI-compatible responses and SSE final chunks; extend types to carry `{ inputTokens, outputTokens }`. See [openai.ts](https://github.com/wopr-network/wopr/pull/1807/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09) and [sessions.ts](https://github.com/wopr-network/wopr/pull/1807/files#diff-367d072b442cb63ae6a6e617c4f11539ca690563d6f79e932c36d519cebbe997).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1459](ticket:jira/WOP-1459) by returning real token usage from the OpenAI-compatible endpoint.
>
> #### 📍Where to Start
> Start with the streaming and non-streaming response handling in `post('/chat/completions')` in [openai.ts](https://github.com/wopr-network/wopr/pull/1807/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09), then follow usage propagation from `executeInjectInternal` in [sessions.ts](https://github.com/wopr-network/wopr/pull/1807/files#diff-367d072b442cb63ae6a6e617c4f11539ca690563d6f79e932c36d519cebbe997).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b24eaa5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->