### PR TITLE
feat: add session TTL expiry, periodic cleanup, and LRU eviction (WOP-1505)

### DIFF
--- a/src/core/session-cleaner.ts
+++ b/src/core/session-cleaner.ts
@@ -1,0 +1,114 @@
+import { logger } from "../logger.js";
+import { countActiveSessionsAsync, findExpiredSessionsAsync, findLruSessionsAsync } from "./session-repository.js";
+import { deleteSession, hasPendingInject } from "./sessions.js";
+
+export interface SessionCleanerConfig {
+  ttlMs: number;
+  maxCount: number;
+  cleanupIntervalMs: number;
+}
+
+export interface SessionCleanerStats {
+  expiredRemoved: number;
+  lruEvicted: number;
+  lastCleanupAt: number;
+  isRunning: boolean;
+}
+
+export class SessionCleaner {
+  private config: SessionCleanerConfig;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private stats: SessionCleanerStats = {
+    expiredRemoved: 0,
+    lruEvicted: 0,
+    lastCleanupAt: 0,
+    isRunning: false,
+  };
+
+  constructor(config: SessionCleanerConfig) {
+    this.config = config;
+  }
+
+  start(): void {
+    if (this.interval) return;
+    this.stats.isRunning = true;
+    this.interval = setInterval(() => {
+      this.cleanup().catch((err) => {
+        logger.error(`[session-cleaner] cleanup error: ${err}`);
+      });
+    }, this.config.cleanupIntervalMs);
+    // Run first cleanup async, don't block startup
+    this.cleanup().catch((err) => {
+      logger.error(`[session-cleaner] initial cleanup error: ${err}`);
+    });
+    logger.info(
+      `[session-cleaner] started (TTL=${this.config.ttlMs}ms, max=${this.config.maxCount}, interval=${this.config.cleanupIntervalMs}ms)`,
+    );
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.stats.isRunning = false;
+    logger.info("[session-cleaner] stopped");
+  }
+
+  async cleanup(): Promise<SessionCleanerStats> {
+    const runStats = {
+      expiredRemoved: 0,
+      lruEvicted: 0,
+      lastCleanupAt: Date.now(),
+      isRunning: this.stats.isRunning,
+    };
+
+    // Phase 1: Remove expired sessions (TTL)
+    const expired = await findExpiredSessionsAsync(this.config.ttlMs);
+    for (const session of expired) {
+      if (hasPendingInject(session.name)) {
+        logger.debug(`[session-cleaner] skipping "${session.name}" — has pending inject`);
+        continue;
+      }
+      try {
+        await deleteSession(session.name, "ttl-expired");
+        runStats.expiredRemoved++;
+      } catch (err) {
+        logger.error(`[session-cleaner] failed to delete expired session "${session.name}": ${err}`);
+      }
+    }
+
+    // Phase 2: LRU eviction if over maxCount
+    const activeCount = await countActiveSessionsAsync();
+    if (activeCount > this.config.maxCount) {
+      const excess = activeCount - this.config.maxCount;
+      const lruCandidates = await findLruSessionsAsync(excess);
+      for (const session of lruCandidates) {
+        if (hasPendingInject(session.name)) {
+          continue;
+        }
+        try {
+          await deleteSession(session.name, "lru-evicted");
+          runStats.lruEvicted++;
+        } catch (err) {
+          logger.error(`[session-cleaner] failed to evict session "${session.name}": ${err}`);
+        }
+      }
+    }
+
+    // Update cumulative stats
+    this.stats.expiredRemoved += runStats.expiredRemoved;
+    this.stats.lruEvicted += runStats.lruEvicted;
+    this.stats.lastCleanupAt = runStats.lastCleanupAt;
+
+    if (runStats.expiredRemoved > 0 || runStats.lruEvicted > 0) {
+      logger.info(`[session-cleaner] removed ${runStats.expiredRemoved} expired, evicted ${runStats.lruEvicted} LRU`);
+    }
+
+    return runStats;
+  }
+
+  getStats(): SessionCleanerStats {
+    return { ...this.stats };
+  }
+}

--- a/src/core/session-repository.ts
+++ b/src/core/session-repository.ts
@@ -278,3 +278,30 @@ export async function getConversationSessionId(sessionName: string): Promise<str
   const session = await repo.findFirst({ name: sessionName });
   return session?.id ?? null;
 }
+
+/** Find active sessions whose lastActivityAt is older than ttlMs ago */
+export async function findExpiredSessionsAsync(ttlMs: number): Promise<SessionRecord[]> {
+  await initSessionStorage();
+  const cutoff = Date.now() - ttlMs;
+  const rows = await sessionsRepo().findMany({ status: "active" });
+  return rows.filter((s) => s.lastActivityAt < cutoff);
+}
+
+/** Count active sessions */
+export async function countActiveSessionsAsync(): Promise<number> {
+  await initSessionStorage();
+  const rows = await sessionsRepo().findMany({ status: "active" });
+  return rows.length;
+}
+
+/** Find N oldest active sessions by lastActivityAt (LRU candidates) */
+export async function findLruSessionsAsync(count: number): Promise<SessionRecord[]> {
+  await initSessionStorage();
+  const rows = await sessionsRepo()
+    .query()
+    .where("status", "active")
+    .orderBy("lastActivityAt", "asc")
+    .limit(count)
+    .execute();
+  return rows;
+}

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -70,9 +70,33 @@ if (!existsSync(SESSIONS_DIR)) {
 // ============================================================================
 
 import { type InjectOptions, type InjectResult, type MultimodalMessage, queueManager } from "./queue/index.js";
+import { SessionCleaner, type SessionCleanerStats } from "./session-cleaner.js";
 
 // Flag to track if queue executor has been initialized
 let queueInitialized = false;
+
+// Session cleaner singleton
+let sessionCleaner: SessionCleaner | null = null;
+
+export function startSessionCleaner(config?: { ttlMs?: number; maxCount?: number; cleanupIntervalMs?: number }): void {
+  if (sessionCleaner) return;
+  sessionCleaner = new SessionCleaner({
+    ttlMs: config?.ttlMs ?? (Number(process.env.WOPR_SESSION_TTL_MS) || 24 * 60 * 60 * 1000),
+    maxCount: config?.maxCount ?? (Number(process.env.WOPR_SESSION_MAX_COUNT) || 1000),
+    cleanupIntervalMs:
+      config?.cleanupIntervalMs ?? (Number(process.env.WOPR_SESSION_CLEANUP_INTERVAL_MS) || 5 * 60 * 1000),
+  });
+  sessionCleaner.start();
+}
+
+export function stopSessionCleaner(): void {
+  sessionCleaner?.stop();
+  sessionCleaner = null;
+}
+
+export function getSessionCleanerStats(): SessionCleanerStats | null {
+  return sessionCleaner?.getStats() ?? null;
+}
 
 /**
  * Initialize the queue system with the inject executor
@@ -105,6 +129,9 @@ function initQueue(): void {
   });
 
   logger.info("[sessions] Queue system initialized");
+
+  // Start session cleanup
+  startSessionCleaner();
 }
 
 /**

--- a/tests/unit/session-cleaner.test.ts
+++ b/tests/unit/session-cleaner.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Session Cleaner Tests (WOP-1505)
+ *
+ * Tests for:
+ * - findExpiredSessionsAsync / countActiveSessionsAsync / findLruSessionsAsync (session-repository.ts)
+ * - SessionCleaner class (session-cleaner.ts): TTL expiry, LRU eviction, pending-inject guard
+ * - startSessionCleaner / stopSessionCleaner / getSessionCleanerStats (sessions.ts)
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any dynamic imports
+// ---------------------------------------------------------------------------
+
+const TEST_WOPR_HOME = mkdtempSync(join(tmpdir(), "wopr-session-cleaner-test-"));
+const TEST_SESSIONS_DIR = join(TEST_WOPR_HOME, "sessions");
+const TEST_SESSIONS_FILE = join(TEST_WOPR_HOME, "sessions.json");
+
+vi.mock("../../src/paths.js", () => ({
+  WOPR_HOME: TEST_WOPR_HOME,
+  SESSIONS_DIR: TEST_SESSIONS_DIR,
+  SESSIONS_FILE: TEST_SESSIONS_FILE,
+}));
+
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/security/index.js", () => ({
+  checkSessionAccess: vi.fn(() => ({ allowed: true })),
+  clearContext: vi.fn(),
+  createInjectionSource: vi.fn(() => ({ type: "cli", origin: "test" })),
+  createSecurityContext: vi.fn(() => ({
+    requestId: "test-req",
+    recordEvent: vi.fn(),
+  })),
+  isEnforcementEnabled: vi.fn(() => false),
+  storeContext: vi.fn(),
+}));
+
+vi.mock("../../src/core/events.js", () => ({
+  emitMutableIncoming: vi.fn(async () => ({ prevented: false, message: "" })),
+  emitMutableOutgoing: vi.fn(async () => ({ prevented: false, response: "" })),
+  emitSessionCreate: vi.fn(async () => {}),
+  emitSessionDestroy: vi.fn(async () => {}),
+  emitSessionResponseChunk: vi.fn(async () => {}),
+}));
+
+vi.mock("../../src/core/context.js", () => ({
+  assembleContext: vi.fn(async () => ({
+    context: "",
+    system: "",
+    sources: [],
+    warnings: [],
+  })),
+  initContextSystem: vi.fn(),
+  updateLastTriggerTimestamp: vi.fn(),
+}));
+
+vi.mock("../../src/core/providers.js", () => ({
+  providerRegistry: {
+    listProviders: vi.fn(() => []),
+    resolveProvider: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/core/a2a-mcp.js", () => ({
+  getA2AMcpServer: vi.fn(() => null),
+  isA2AEnabled: vi.fn(() => false),
+  setSessionFunctions: vi.fn(),
+  listA2ATools: vi.fn(() => []),
+  registerA2ATool: vi.fn(),
+  unregisterA2ATool: vi.fn(),
+}));
+
+const mockQueueManager = {
+  inject: vi.fn(),
+  cancelActive: vi.fn(() => false),
+  hasPending: vi.fn(() => false),
+  getStats: vi.fn(() => ({ active: 0, queued: 0 })),
+  getAllStats: vi.fn(() => ({})),
+  setExecutor: vi.fn(),
+  on: vi.fn(),
+};
+
+vi.mock("../../src/core/queue/index.js", () => ({
+  queueManager: mockQueueManager,
+}));
+
+// ---------------------------------------------------------------------------
+// Import modules under test
+// ---------------------------------------------------------------------------
+let sessions: typeof import("../../src/core/sessions.js");
+let sessionRepository: typeof import("../../src/core/session-repository.js");
+let storage: typeof import("../../src/storage/index.js");
+
+beforeEach(async () => {
+  vi.resetModules();
+
+  mockQueueManager.inject.mockReset();
+  mockQueueManager.cancelActive.mockReset().mockReturnValue(false);
+  mockQueueManager.hasPending.mockReset().mockReturnValue(false);
+  mockQueueManager.getStats.mockReset().mockReturnValue({ active: 0, queued: 0 });
+  mockQueueManager.getAllStats.mockReset().mockReturnValue({});
+  mockQueueManager.setExecutor.mockReset();
+  mockQueueManager.on.mockReset();
+
+  storage = await import("../../src/storage/index.js");
+  sessionRepository = await import("../../src/core/session-repository.js");
+  sessions = await import("../../src/core/sessions.js");
+
+  await sessionRepository.initSessionStorage();
+});
+
+afterEach(async () => {
+  storage.resetStorage();
+  sessionRepository.resetSessionStorageInit();
+
+  const dbPath = join(TEST_WOPR_HOME, "wopr.sqlite");
+  if (existsSync(dbPath)) unlinkSync(dbPath);
+  const walPath = `${dbPath}-wal`;
+  const shmPath = `${dbPath}-shm`;
+  if (existsSync(walPath)) unlinkSync(walPath);
+  if (existsSync(shmPath)) unlinkSync(shmPath);
+
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  rmSync(TEST_WOPR_HOME, { recursive: true, force: true });
+});
+
+// Helper: backdate a session's lastActivityAt
+async function backdateSession(name: string, ageMs: number): Promise<void> {
+  const storageMod = await import("../../src/storage/index.js");
+  const repo = storageMod.getStorage().getRepository("sessions", "sessions");
+  const record = await repo.findFirst({ name });
+  if (record) {
+    await repo.update(record.id, { lastActivityAt: Date.now() - ageMs });
+  }
+}
+
+// ===========================================================================
+// findExpiredSessionsAsync
+// ===========================================================================
+describe("findExpiredSessionsAsync", () => {
+  it("should return sessions with lastActivityAt older than cutoff", async () => {
+    await sessions.saveSessionId("old-session", "id-old");
+    await backdateSession("old-session", 48 * 60 * 60 * 1000); // 48h ago
+
+    const expired = await sessionRepository.findExpiredSessionsAsync(24 * 60 * 60 * 1000);
+    expect(expired).toHaveLength(1);
+    expect(expired[0].name).toBe("old-session");
+  });
+
+  it("should not return sessions within TTL", async () => {
+    await sessions.saveSessionId("fresh-session", "id-fresh");
+
+    const expired = await sessionRepository.findExpiredSessionsAsync(24 * 60 * 60 * 1000);
+    expect(expired).toHaveLength(0);
+  });
+
+  it("should return multiple expired sessions", async () => {
+    await sessions.saveSessionId("s1", "id-1");
+    await sessions.saveSessionId("s2", "id-2");
+    await backdateSession("s1", 48 * 60 * 60 * 1000);
+    await backdateSession("s2", 48 * 60 * 60 * 1000);
+
+    const expired = await sessionRepository.findExpiredSessionsAsync(24 * 60 * 60 * 1000);
+    expect(expired).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// countActiveSessionsAsync
+// ===========================================================================
+describe("countActiveSessionsAsync", () => {
+  it("should return 0 with no sessions", async () => {
+    const count = await sessionRepository.countActiveSessionsAsync();
+    expect(count).toBe(0);
+  });
+
+  it("should return count of active sessions", async () => {
+    await sessions.saveSessionId("s1", "id-1");
+    await sessions.saveSessionId("s2", "id-2");
+    const count = await sessionRepository.countActiveSessionsAsync();
+    expect(count).toBe(2);
+  });
+});
+
+// ===========================================================================
+// findLruSessionsAsync
+// ===========================================================================
+describe("findLruSessionsAsync", () => {
+  it("should return oldest sessions by lastActivityAt", async () => {
+    await sessions.saveSessionId("s1", "id-1");
+    await backdateSession("s1", 10000); // oldest
+    await sessions.saveSessionId("s2", "id-2");
+
+    const lru = await sessionRepository.findLruSessionsAsync(1);
+    expect(lru).toHaveLength(1);
+    expect(lru[0].name).toBe("s1");
+  });
+
+  it("should return up to N candidates", async () => {
+    await sessions.saveSessionId("a", "id-a");
+    await backdateSession("a", 3000);
+    await sessions.saveSessionId("b", "id-b");
+    await backdateSession("b", 2000);
+    await sessions.saveSessionId("c", "id-c");
+
+    const lru = await sessionRepository.findLruSessionsAsync(2);
+    expect(lru).toHaveLength(2);
+    expect(lru[0].name).toBe("a");
+    expect(lru[1].name).toBe("b");
+  });
+});
+
+// ===========================================================================
+// SessionCleaner
+// ===========================================================================
+describe("SessionCleaner", () => {
+  it("should remove expired sessions on cleanup()", async () => {
+    await sessions.saveSessionId("expired", "id-exp");
+    await backdateSession("expired", 48 * 60 * 60 * 1000);
+
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 24 * 60 * 60 * 1000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    const stats = await cleaner.cleanup();
+
+    expect(stats.expiredRemoved).toBe(1);
+    const remaining = await sessions.getSessions();
+    expect(remaining.expired).toBeUndefined();
+  });
+
+  it("should not remove fresh sessions", async () => {
+    await sessions.saveSessionId("fresh", "id-fresh");
+
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 24 * 60 * 60 * 1000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    const stats = await cleaner.cleanup();
+
+    expect(stats.expiredRemoved).toBe(0);
+    const remaining = await sessions.getSessions();
+    expect(remaining.fresh).toBeDefined();
+  });
+
+  it("should evict LRU sessions when over maxCount", async () => {
+    for (let i = 0; i < 3; i++) {
+      await sessions.saveSessionId(`s${i}`, `id-${i}`);
+    }
+    // Backdate s0 to be oldest
+    await backdateSession("s0", 3000);
+    await backdateSession("s1", 2000);
+
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 24 * 60 * 60 * 1000, maxCount: 2, cleanupIntervalMs: 60000 });
+    const stats = await cleaner.cleanup();
+
+    expect(stats.lruEvicted).toBe(1);
+    const remaining = await sessions.getSessions();
+    expect(remaining.s0).toBeUndefined();
+  });
+
+  it("should not delete sessions with pending injects", async () => {
+    await sessions.saveSessionId("busy", "id-busy");
+    await backdateSession("busy", 48 * 60 * 60 * 1000);
+
+    // Mock hasPending to return true for "busy"
+    mockQueueManager.hasPending.mockImplementation((name: string) => name === "busy");
+
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 24 * 60 * 60 * 1000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    const stats = await cleaner.cleanup();
+
+    expect(stats.expiredRemoved).toBe(0);
+    const remaining = await sessions.getSessions();
+    expect(remaining.busy).toBeDefined();
+  });
+
+  it("should start and stop the interval", async () => {
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 86400000, maxCount: 1000, cleanupIntervalMs: 60000 });
+
+    cleaner.start();
+    expect(cleaner.getStats().isRunning).toBe(true);
+
+    cleaner.stop();
+    expect(cleaner.getStats().isRunning).toBe(false);
+  });
+
+  it("should not start a second interval if already running", async () => {
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 86400000, maxCount: 1000, cleanupIntervalMs: 60000 });
+
+    cleaner.start();
+    const statsBefore = cleaner.getStats();
+    cleaner.start(); // second call should be a no-op
+    const statsAfter = cleaner.getStats();
+
+    expect(statsBefore.isRunning).toBe(statsAfter.isRunning);
+    cleaner.stop();
+  });
+
+  it("should accumulate expiredRemoved in getStats() across multiple cleanups", async () => {
+    await sessions.saveSessionId("a", "id-a");
+    await backdateSession("a", 48 * 60 * 60 * 1000);
+
+    const { SessionCleaner } = await import("../../src/core/session-cleaner.js");
+    const cleaner = new SessionCleaner({ ttlMs: 24 * 60 * 60 * 1000, maxCount: 1000, cleanupIntervalMs: 60000 });
+
+    await cleaner.cleanup();
+    // Create another expired session
+    await sessions.saveSessionId("b", "id-b");
+    await backdateSession("b", 48 * 60 * 60 * 1000);
+    await cleaner.cleanup();
+
+    expect(cleaner.getStats().expiredRemoved).toBe(2);
+  });
+});
+
+// ===========================================================================
+// sessions.ts facade: startSessionCleaner / stopSessionCleaner / getSessionCleanerStats
+// ===========================================================================
+describe("session cleaner facade", () => {
+  it("should export startSessionCleaner, stopSessionCleaner, getSessionCleanerStats", () => {
+    expect(typeof sessions.startSessionCleaner).toBe("function");
+    expect(typeof sessions.stopSessionCleaner).toBe("function");
+    expect(typeof sessions.getSessionCleanerStats).toBe("function");
+  });
+
+  it("should return null stats before cleaner is started", () => {
+    expect(sessions.getSessionCleanerStats()).toBeNull();
+  });
+
+  it("should return stats after starting", () => {
+    sessions.startSessionCleaner({ ttlMs: 86400000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    const stats = sessions.getSessionCleanerStats();
+    expect(stats).not.toBeNull();
+    expect(stats?.isRunning).toBe(true);
+    sessions.stopSessionCleaner();
+  });
+
+  it("should return null after stopping", () => {
+    sessions.startSessionCleaner({ ttlMs: 86400000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    sessions.stopSessionCleaner();
+    expect(sessions.getSessionCleanerStats()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1505

- Add `findExpiredSessionsAsync`, `countActiveSessionsAsync`, `findLruSessionsAsync` to `src/core/session-repository.ts`
- Add `SessionCleaner` class (`src/core/session-cleaner.ts`) with `start()`/`stop()`/`cleanup()`/`getStats()`
- Wire `startSessionCleaner()` into `initQueue()` in `sessions.ts` — auto-starts on first inject
- Default TTL: 24h, max session count: 1000, cleanup interval: 5min (all configurable via env vars)
- Sessions with pending injects are skipped during cleanup to avoid interrupting active work
- Exports `startSessionCleaner`, `stopSessionCleaner`, `getSessionCleanerStats` for external control/monitoring

## Test plan
- [x] `npm run check` passes (lint + typecheck)
- [x] 18 targeted tests pass: `npx vitest run tests/unit/session-cleaner.test.ts`
- [x] Tests cover: expired session removal, fresh session preservation, LRU eviction, pending-inject guard, start/stop lifecycle, cumulative stats

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add periodic session TTL expiry and LRU eviction with `sessions.startSessionCleaner` auto-starting at 24h TTL, 1000 max sessions, and 5m interval in `sessions.initQueue`
> Introduce `SessionCleaner` for TTL-based deletion and LRU eviction; add repository helpers for expired lookup, active count, and LRU candidates; expose `sessions.startSessionCleaner`, `sessions.stopSessionCleaner`, and `sessions.getSessionCleanerStats`; auto-start cleaner during queue init. Core logic lives in [src/core/session-cleaner.ts](https://github.com/wopr-network/wopr/pull/1808/files#diff-9a09771aa2cbb74f877f03c7c7504ff59a0fb6d3239c6afd83d9837ba1a0dfde).
>
> #### 🖇️ Linked Issues
> This pull request implements the session cleanup work for [WOP-1505](ticket:jira/WOP-1505).
>
> #### 📍Where to Start
> Start with `SessionCleaner.cleanup()` and its `start()`/`stop()` flow in [src/core/session-cleaner.ts](https://github.com/wopr-network/wopr/pull/1808/files#diff-9a09771aa2cbb74f877f03c7c7504ff59a0fb6d3239c6afd83d9837ba1a0dfde), then see integration in `sessions.initQueue` in [src/core/sessions.ts](https://github.com/wopr-network/wopr/pull/1808/files#diff-367d072b442cb63ae6a6e617c4f11539ca690563d6f79e932c36d519cebbe997).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c0b9f89. 3 files reviewed, 7 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/core/session-cleaner.ts — 1 comment posted, 3 evaluated, 1 filtered</summary>
>
> - [line 35](https://github.com/wopr-network/wopr/blob/c0b9f89aa5e68b46699a95d4cb775192c17c6513/src/core/session-cleaner.ts#L35): The `cleanup` method is executed on an interval without checking if the previous cleanup has finished, potentially leading to overlapping executions. If `findExpiredSessionsAsync` or `deleteSession` take longer than `cleanupIntervalMs`, multiple cleanup runs will pile up, causing race conditions in session deletion, redundant database load, and potential memory exhaustion. <b>[ Skipped comment generation ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->