### PR TITLE
feat: warn at startup when plugin sandboxing is disabled (WOP-1510)

### DIFF
--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -107,6 +107,7 @@ export {
   isSessionSandboxed,
   listSandboxes,
   type SandboxContext,
+  warnSandboxDisabled,
 } from "./sandbox.js";
 // Export all types
 export {

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -7,6 +7,7 @@
 
 import { logger } from "../logger.js";
 import { getStorage } from "../storage/index.js";
+import { warnSandboxDisabled } from "./sandbox.js";
 import type { SecurityConfigRow, SecurityPluginRuleRow } from "./schema.js";
 import { securityConfigSchema, securityPluginRuleSchema } from "./schema.js";
 import type { SecurityPluginRule } from "./store.js";
@@ -66,6 +67,10 @@ export async function initSecurity(woprDir: string): Promise<void> {
   await securityStore.init();
 
   logger.info("[security] Security system initialized");
+
+  // Warn if sandboxing is disabled (WOP-1510)
+  const secConfig = getSecurityConfig();
+  warnSandboxDisabled(secConfig);
 }
 
 /**

--- a/src/security/sandbox.ts
+++ b/src/security/sandbox.ts
@@ -17,7 +17,7 @@ import { eventBus } from "../core/events.js";
 import { logger } from "../logger.js";
 import { getPluginExtension } from "../plugins/extensions.js";
 import { getContext } from "./context.js";
-import type { SandboxConfig as LegacySandboxConfig } from "./types.js";
+import type { SandboxConfig as LegacySandboxConfig, SecurityConfig } from "./types.js";
 
 // ============================================================================
 // Sandbox Extension Interface (provided by wopr-plugin-sandbox)
@@ -61,6 +61,28 @@ interface SandboxExtension {
  */
 function getSandboxExtension(): SandboxExtension | undefined {
   return getPluginExtension<SandboxExtension>("sandbox");
+}
+
+/**
+ * Log a warning at startup if plugin sandboxing is disabled.
+ * Called from initSecurity() after the security config is loaded.
+ */
+export function warnSandboxDisabled(config: SecurityConfig): void {
+  // Check if warning is suppressed
+  if (config.warnOnDisabledSandbox === false) {
+    return;
+  }
+
+  // Check if sandbox is enabled in the default policy
+  if (config.defaults?.sandbox?.enabled) {
+    return;
+  }
+
+  logger.warn(
+    "[SECURITY] Plugin sandboxing is disabled — plugins run with full process access. " +
+      "Set sandbox.mode to 'non-main' or 'all' in config, or install wopr-plugin-sandbox. " +
+      "To suppress this warning, set security.warnOnDisabledSandbox to false.",
+  );
 }
 
 // ============================================================================

--- a/src/security/types.ts
+++ b/src/security/types.ts
@@ -503,6 +503,9 @@ export interface SecurityConfig {
     /** Audit log path */
     logPath?: string;
   };
+
+  /** Whether to log a warning at startup when sandboxing is disabled (default: true) */
+  warnOnDisabledSandbox?: boolean;
 }
 
 /**
@@ -554,6 +557,7 @@ export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
     logSuccess: false,
     logDenied: true,
   },
+  warnOnDisabledSandbox: true,
 };
 
 // ============================================================================

--- a/tests/security/sandbox-disabled-warning.test.ts
+++ b/tests/security/sandbox-disabled-warning.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for sandbox-disabled startup warning (WOP-1510)
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the logger
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock the plugin extension system — sandbox plugin NOT installed
+vi.mock("../../src/plugins/extensions.js", () => ({
+  getPluginExtension: vi.fn().mockReturnValue(undefined),
+}));
+
+const { logger } = await import("../../src/logger.js");
+const { warnSandboxDisabled } = await import("../../src/security/sandbox.js");
+const { DEFAULT_SECURITY_CONFIG } = await import("../../src/security/types.js");
+
+describe("warnSandboxDisabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should log a warning when sandboxing is disabled and warnOnDisabledSandbox is true", () => {
+    const config = { ...DEFAULT_SECURITY_CONFIG, warnOnDisabledSandbox: true };
+    warnSandboxDisabled(config);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[SECURITY] Plugin sandboxing is disabled — plugins run with full process access. " +
+        "Set sandbox.mode to 'non-main' or 'all' in config, or install wopr-plugin-sandbox. " +
+        "To suppress this warning, set security.warnOnDisabledSandbox to false.",
+    );
+  });
+
+  it("should NOT log a warning when warnOnDisabledSandbox is false", () => {
+    const config = { ...DEFAULT_SECURITY_CONFIG, warnOnDisabledSandbox: false };
+    warnSandboxDisabled(config);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("should NOT log a warning when sandbox is enabled in config", () => {
+    const config = {
+      ...DEFAULT_SECURITY_CONFIG,
+      warnOnDisabledSandbox: true,
+      defaults: {
+        ...DEFAULT_SECURITY_CONFIG.defaults,
+        sandbox: { enabled: true, network: "bridge" as const },
+      },
+    };
+    warnSandboxDisabled(config);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("should default to warning when warnOnDisabledSandbox is undefined", () => {
+    const config = { ...DEFAULT_SECURITY_CONFIG };
+    delete (config as Record<string, unknown>).warnOnDisabledSandbox;
+    warnSandboxDisabled(config);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("[SECURITY] Plugin sandboxing is disabled"));
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1510

- Add `warnOnDisabledSandbox?: boolean` to `SecurityConfig` interface (default `true` in `DEFAULT_SECURITY_CONFIG`)
- Add exported `warnSandboxDisabled(config)` to `src/security/sandbox.ts` — logs a warning when `defaults.sandbox.enabled` is false and the warning is not suppressed
- Call `warnSandboxDisabled()` at end of `initSecurity()` in `src/security/policy.ts`
- Re-export `warnSandboxDisabled` from `src/security/index.ts`

## Test plan
- [x] `npm run check` passes (lint + typecheck)
- [x] Targeted tests pass: `npx vitest run tests/security/sandbox-disabled-warning.test.ts` (4/4)
- [x] 4 test cases: warn fires when disabled, suppressed by `warnOnDisabledSandbox: false`, not fired when sandbox enabled, fires when field undefined (defaults to warning)

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn at startup in `security.initSecurity` when plugin sandboxing is disabled to address WOP-1510
> Add `warnSandboxDisabled` and invoke it during `security.initSecurity`; expose the util via `src/security/index`; extend `SecurityConfig` with `warnOnDisabledSandbox` defaulting to `true`; add tests for warning behavior.
>
> #### 📍Where to Start
> Start with the call to `warnSandboxDisabled` in `initSecurity` in [policy.ts](https://github.com/wopr-network/wopr/pull/1809/files#diff-56c1c6f185139c42d133c1c9d4f1b0152c002355efd4b11778ffe5d03de35a36).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b724ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A startup warning now alerts users when plugin sandboxing is disabled. A new configuration option allows users to suppress this warning, which is enabled by default.

* **Tests**
  * Added tests validating the sandbox warning behavior across various configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->