### PR TITLE
feat: emit provider:added/removed/status events from ProviderRegistry (WOP-1508)

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -153,6 +153,25 @@ export interface CapabilityProviderHealthChangeEvent {
   error?: string;
 }
 
+// Provider registry events
+export interface ProviderAddedEvent {
+  providerId: string;
+  providerName: string;
+}
+
+export interface ProviderRemovedEvent {
+  providerId: string;
+  providerName: string;
+}
+
+export interface ProviderStatusEvent {
+  providerId: string;
+  providerName: string;
+  previousAvailable: boolean;
+  currentAvailable: boolean;
+  error?: string;
+}
+
 // ============================================================================
 // Event Map - defines all core events and their payloads
 // ============================================================================
@@ -191,6 +210,11 @@ export interface WOPREventMap {
 
   // Capability health events
   "capability:providerHealthChange": CapabilityProviderHealthChangeEvent;
+
+  // Provider registry events
+  "provider:added": ProviderAddedEvent;
+  "provider:removed": ProviderRemovedEvent;
+  "provider:status": ProviderStatusEvent;
 
   // Wildcard - catch all
   "*": WOPREvent;
@@ -577,6 +601,28 @@ export async function emitPluginActivated(plugin: string, version: string): Prom
 
 export async function emitPluginDeactivated(plugin: string, version: string, drained: boolean): Promise<void> {
   await eventBus.emit("plugin:deactivated", { plugin, version, drained }, "core");
+}
+
+export async function emitProviderAdded(providerId: string, providerName: string): Promise<void> {
+  await eventBus.emit("provider:added", { providerId, providerName }, "core");
+}
+
+export async function emitProviderRemoved(providerId: string, providerName: string): Promise<void> {
+  await eventBus.emit("provider:removed", { providerId, providerName }, "core");
+}
+
+export async function emitProviderStatus(
+  providerId: string,
+  providerName: string,
+  previousAvailable: boolean,
+  currentAvailable: boolean,
+  error?: string,
+): Promise<void> {
+  await eventBus.emit(
+    "provider:status",
+    { providerId, providerName, previousAvailable, currentAvailable, error },
+    "core",
+  );
 }
 
 // ============================================================================

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -1,4 +1,5 @@
 import { logger } from "../logger.js";
+import { emitProviderAdded, emitProviderRemoved, emitProviderStatus } from "./events.js";
 
 /**
  * Provider Registry & Management System
@@ -44,6 +45,25 @@ export class ProviderRegistry {
       lastChecked: 0,
     });
     logger.info(`[provider-registry]   ✓ ${provider.id} registered. Total: ${this.providers.size}`);
+
+    emitProviderAdded(provider.id, provider.name).catch((err) => {
+      logger.error(`[provider-registry] Failed to emit provider:added for ${provider.id}:`, err);
+    });
+  }
+
+  /**
+   * Unregister a provider
+   */
+  unregister(id: string): void {
+    const reg = this.providers.get(id);
+    if (!reg) return;
+
+    logger.info(`[provider-registry] Unregistering: ${id}`);
+    this.providers.delete(id);
+
+    emitProviderRemoved(id, reg.provider.name).catch((err) => {
+      logger.error(`[provider-registry] Failed to emit provider:removed for ${id}:`, err);
+    });
   }
 
   /**
@@ -150,6 +170,7 @@ export class ProviderRegistry {
   async checkHealth(): Promise<void> {
     logger.info(`[provider-registry] Checking health for ${this.providers.size} providers`);
     const checks = Array.from(this.providers.values()).map(async (reg) => {
+      const previousAvailable = reg.available;
       try {
         logger.info(`[provider-registry] Checking ${reg.provider.id}...`);
         const cred = this.credentials.get(reg.provider.id);
@@ -161,6 +182,9 @@ export class ProviderRegistry {
           reg.available = false;
           reg.error = "No credentials configured";
           logger.info(`[provider-registry] ${reg.provider.id}: skipped - no credentials`);
+          if (previousAvailable !== reg.available) {
+            await emitProviderStatus(reg.provider.id, reg.provider.name, previousAvailable, reg.available, reg.error);
+          }
           return;
         }
 
@@ -177,11 +201,19 @@ export class ProviderRegistry {
         } else {
           reg.error = undefined;
         }
+
+        if (previousAvailable !== reg.available) {
+          await emitProviderStatus(reg.provider.id, reg.provider.name, previousAvailable, reg.available, reg.error);
+        }
       } catch (error) {
         logger.error(`[provider-registry] ${reg.provider.id}: health check error:`, error);
         reg.available = false;
         reg.lastChecked = Date.now();
         reg.error = error instanceof Error ? error.message : "Unknown error";
+
+        if (previousAvailable !== reg.available) {
+          await emitProviderStatus(reg.provider.id, reg.provider.name, previousAvailable, reg.available, reg.error);
+        }
       }
     });
 

--- a/tests/unit/provider-events.test.ts
+++ b/tests/unit/provider-events.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let eventBus: any;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const eventsModule = await import("../../src/core/events.js");
+  eventBus = eventsModule.eventBus;
+});
+
+afterEach(() => {
+  eventBus?.removeAllListeners();
+  vi.restoreAllMocks();
+});
+
+describe("Provider Events — event types", () => {
+  it("should accept provider:added event type", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:added", handler);
+
+    await eventBus.emit("provider:added", { providerId: "test-provider", providerName: "Test Provider" }, "core");
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      { providerId: "test-provider", providerName: "Test Provider" },
+      expect.objectContaining({ type: "provider:added", source: "core" }),
+    );
+  });
+
+  it("should accept provider:removed event type", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:removed", handler);
+
+    await eventBus.emit("provider:removed", { providerId: "test-provider", providerName: "Test Provider" }, "core");
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      { providerId: "test-provider", providerName: "Test Provider" },
+      expect.objectContaining({ type: "provider:removed", source: "core" }),
+    );
+  });
+
+  it("should accept provider:status event type", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:status", handler);
+
+    await eventBus.emit(
+      "provider:status",
+      { providerId: "test-provider", providerName: "Test Provider", previousAvailable: false, currentAvailable: true },
+      "core",
+    );
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: "test-provider", previousAvailable: false, currentAvailable: true }),
+      expect.objectContaining({ type: "provider:status" }),
+    );
+  });
+});
+
+describe("ProviderRegistry emits events", () => {
+  let ProviderRegistry: any;
+
+  beforeEach(async () => {
+    const providersModule = await import("../../src/core/providers.js");
+    ProviderRegistry = providersModule.ProviderRegistry;
+    const eventsModule = await import("../../src/core/events.js");
+    eventBus = eventsModule.eventBus;
+  });
+
+  function makeTestProvider(id: string, name: string) {
+    return {
+      id,
+      name,
+      description: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      validateCredentials: vi.fn().mockResolvedValue(true),
+      createClient: vi.fn().mockResolvedValue({
+        query: vi.fn(),
+        listModels: vi.fn().mockResolvedValue([]),
+        healthCheck: vi.fn().mockResolvedValue(true),
+      }),
+      getCredentialType: vi.fn().mockReturnValue("api-key"),
+    };
+  }
+
+  it("should emit provider:added when register() is called", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:added", handler);
+
+    const registry = new ProviderRegistry();
+    registry.register(makeTestProvider("openai", "OpenAI"));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(
+      { providerId: "openai", providerName: "OpenAI" },
+      expect.objectContaining({ type: "provider:added" }),
+    );
+  });
+
+  it("should emit provider:removed when unregister() is called", async () => {
+    const registry = new ProviderRegistry();
+    registry.register(makeTestProvider("openai", "OpenAI"));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const removedHandler = vi.fn();
+    eventBus.on("provider:removed", removedHandler);
+
+    registry.unregister("openai");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(removedHandler).toHaveBeenCalledOnce();
+    expect(removedHandler).toHaveBeenCalledWith(
+      { providerId: "openai", providerName: "OpenAI" },
+      expect.objectContaining({ type: "provider:removed" }),
+    );
+  });
+
+  it("should NOT emit provider:removed for unknown provider", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:removed", handler);
+
+    const registry = new ProviderRegistry();
+    registry.unregister("nonexistent");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("should emit provider:status when checkHealth() changes availability", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:status", handler);
+
+    const registry = new ProviderRegistry();
+    const provider = makeTestProvider("openai", "OpenAI");
+    registry.register(provider);
+
+    registry["credentials"].set("openai", {
+      providerId: "openai",
+      type: "api-key",
+      credential: "test-key",
+      createdAt: Date.now(),
+    });
+
+    await registry.checkHealth();
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "openai",
+        providerName: "OpenAI",
+        previousAvailable: false,
+        currentAvailable: true,
+      }),
+      expect.objectContaining({ type: "provider:status" }),
+    );
+  });
+
+  it("should NOT emit provider:status when availability unchanged", async () => {
+    const handler = vi.fn();
+    eventBus.on("provider:status", handler);
+
+    const registry = new ProviderRegistry();
+    const provider = makeTestProvider("openai", "OpenAI");
+    provider.createClient.mockResolvedValue({
+      query: vi.fn(),
+      listModels: vi.fn().mockResolvedValue([]),
+      healthCheck: vi.fn().mockResolvedValue(false),
+    });
+    registry.register(provider);
+
+    registry["credentials"].set("openai", {
+      providerId: "openai",
+      type: "api-key",
+      credential: "test-key",
+      createdAt: Date.now(),
+    });
+
+    await registry.checkHealth();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1508

- Add `ProviderAddedEvent`, `ProviderRemovedEvent`, `ProviderStatusEvent` interfaces to `src/core/events.ts`
- Register all three in `WOPREventMap`
- Add `emitProviderAdded`, `emitProviderRemoved`, `emitProviderStatus` convenience functions
- Emit `provider:added` from `ProviderRegistry.register()`
- Add `ProviderRegistry.unregister()` method that emits `provider:removed`
- Emit `provider:status` in `checkHealth()` only when availability changes (no spam on unchanged state)

## Test plan
- [x] `npm run check` passes (1 pre-existing warning, no errors)
- [x] `npx vitest run tests/unit/provider-events.test.ts` — 8 tests pass

Generated with Claude Code

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit provider lifecycle and status events from `ProviderRegistry` to event bus in [providers.ts](https://github.com/wopr-network/wopr/pull/1812/files#diff-c9c1ed7a5cf90f689e6a765f7f1c11833f0d1a7f99ec52847b5976422a505bc6) per WOP-1508
> Add provider event payloads and emit helpers in [events.ts](https://github.com/wopr-network/wopr/pull/1812/files#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8); emit `provider:added` on `providers.ProviderRegistry.register`, `provider:removed` on `providers.ProviderRegistry.unregister`, and `provider:status` on availability changes in `providers.ProviderRegistry.checkHealth`; add unit tests validating emissions.
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1508](ticket:jira/WOP-1508) by emitting `provider:added`, `provider:removed`, and `provider:status` events from `ProviderRegistry`.
>
> #### 📍Where to Start
> Start with `providers.ProviderRegistry.register`, `providers.ProviderRegistry.unregister`, and `providers.ProviderRegistry.checkHealth` in [providers.ts](https://github.com/wopr-network/wopr/pull/1812/files#diff-c9c1ed7a5cf90f689e6a765f7f1c11833f0d1a7f99ec52847b5976422a505bc6), then review the emit helpers in [events.ts](https://github.com/wopr-network/wopr/pull/1812/files#diff-0ae3ab27650283ec0a6f27e0a01dd5ee1655b7dc5d8fa3e569109862ad33d6f8).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fe2bb83. 2 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->