### PR TITLE
fix: emit zero usage in streaming final chunk when provider omits usage (WOP-1478)

### DIFF
--- a/src/daemon/routes/openai.ts
+++ b/src/daemon/routes/openai.ts
@@ -350,11 +350,11 @@ openaiRouter.post(
               },
             ],
           };
-          if (body.stream_options?.include_usage && streamUsage) {
+          if (body.stream_options?.include_usage) {
             finalChunk.usage = {
-              prompt_tokens: streamUsage.inputTokens,
-              completion_tokens: streamUsage.outputTokens,
-              total_tokens: streamUsage.inputTokens + streamUsage.outputTokens,
+              prompt_tokens: streamUsage?.inputTokens ?? 0,
+              completion_tokens: streamUsage?.outputTokens ?? 0,
+              total_tokens: (streamUsage?.inputTokens ?? 0) + (streamUsage?.outputTokens ?? 0),
             };
           }
           s.write(`data: ${JSON.stringify(finalChunk)}\n\n`);

--- a/tests/unit/openai-compat.test.ts
+++ b/tests/unit/openai-compat.test.ts
@@ -310,6 +310,39 @@ describe("OpenAI Compatibility Layer", () => {
       expect(finalChunk.usage).toEqual({ prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
     });
 
+    it("returns zero usage in final SSE chunk when include_usage is true but provider reports no usage", async () => {
+      vi.mocked(inject).mockImplementation(async (_name: string, _message: string, options?: any) => {
+        if (options?.onStream) {
+          options.onStream({ type: "text", content: "Hello" });
+          options.onStream({ type: "complete", content: "" }); // no usage field
+        }
+        return { response: "Hello", sessionId: "test-session-id" }; // no usage field
+      });
+
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "anthropic",
+          messages: [{ role: "user", content: "Hello" }],
+          stream: true,
+          stream_options: { include_usage: true },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      const events = text
+        .split("\n\n")
+        .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+        .map((line) => JSON.parse(line.replace("data: ", "")));
+
+      const finalChunk = events.find((e: any) => e.choices?.[0]?.finish_reason === "stop");
+      expect(finalChunk).toBeDefined();
+      expect(finalChunk.usage).toEqual({ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+    });
+
     it("does NOT include usage in final SSE chunk when stream_options is absent", async () => {
       const app = createTestApp();
       const res = await app.request("/v1/chat/completions", {


### PR DESCRIPTION
## Summary
Closes WOP-1478

- When `stream_options.include_usage=true` but the upstream provider does not report token counts, the streaming path previously omitted the `usage` field from the final SSE chunk entirely
- Non-streaming already fell back to `{ prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }` — this PR aligns the streaming path to do the same
- Adds a regression test covering the zero-fallback case in `tests/unit/openai-compat.test.ts`

**Root cause**: `src/daemon/routes/openai.ts` line 353 guarded the usage emission with `&& streamUsage`, so when the provider omitted usage in the `complete` message, no `usage` field was emitted despite the client opting in with `include_usage: true`.

## Test plan
- [x] `npm run check` passes (lint + type check)
- [x] `npx vitest run tests/unit/openai-compat.test.ts` — 35 tests pass
- [x] Existing `include_usage: true` with real usage still works (test at line 280)
- [x] New test: `include_usage: true` with no provider usage → returns zeros
- [x] `include_usage` absent → `usage` field still absent from final chunk

Generated with Claude Code

## Summary by Sourcery

Align streaming OpenAI-compatible responses with non-streaming behavior when usage data is missing from the provider.

Bug Fixes:
- Ensure the final streaming SSE chunk includes a usage object with zeroed token counts when include_usage is requested but the provider omits usage data.

Tests:
- Add a regression test verifying that streaming responses emit zeroed usage when include_usage is true and the provider does not report usage.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Emit zeroed `usage` in the final SSE chunk for `openaiRouter.post` "/chat/completions" when `stream_options.include_usage` is true to satisfy WOP-1478
> Update the final chunk logic to always include `usage` when `stream_options.include_usage` is true, defaulting `prompt_tokens` and `completion_tokens` to 0 via nullish coalescing in [openai.ts](https://github.com/wopr-network/wopr/pull/1815/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09); add a unit test asserting zeroed usage in the final SSE chunk in [openai-compat.test.ts](https://github.com/wopr-network/wopr/pull/1815/files#diff-4d3efddd189479dd525c227c670f479baa35482fe0d8ae45951869b671a59679).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1478](https://linear.app/wopr/issue/WOP-1478) by enforcing zeroed usage emission when providers omit usage in streaming responses.
>
> #### 📍Where to Start
> Start at the `openaiRouter.post` "/chat/completions" handler in [openai.ts](https://github.com/wopr-network/wopr/pull/1815/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09) to review the final SSE chunk `usage` construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 500dcea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->