### PR TITLE
feat: token-aware context window management (WOP-1477)

### DIFF
--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -114,9 +114,11 @@ export function resolveContextWindowConfig(
   const margin = overrides?.safetyMargin ?? DEFAULT_SAFETY_MARGIN;
   const effectiveLimit = Math.floor(rawLimit * margin);
 
+  const maxHistoryTokens = overrides?.maxHistoryTokens ?? effectiveLimit;
+
   return {
-    maxHistoryTokens: overrides?.maxHistoryTokens ?? effectiveLimit,
-    maxEntryTokens: overrides?.maxEntryTokens ?? Math.floor(effectiveLimit * DEFAULT_ENTRY_TOKEN_RATIO),
+    maxHistoryTokens,
+    maxEntryTokens: overrides?.maxEntryTokens ?? Math.floor(maxHistoryTokens * DEFAULT_ENTRY_TOKEN_RATIO),
     maxEntries: overrides?.maxEntries ?? DEFAULT_MAX_ENTRIES,
   };
 }
@@ -236,6 +238,10 @@ const bootstrapFilesProvider: ContextProvider = {
   },
 };
 
+// Per-invocation config for conversation_history provider (set by assembleContext)
+let _historyProviderModel: string | undefined;
+let _historyProviderWindowOverrides: (Partial<ContextWindowConfig> & { safetyMargin?: number }) | undefined;
+
 /**
  * Conversation history from session log (progressive since last trigger)
  */
@@ -257,11 +263,7 @@ const conversationHistoryProvider: ContextProvider = {
         .filter((e) => !e.content?.startsWith("Conversation since"));
 
       // Resolve token budget from model set by assembleContext
-      const windowConfig = resolveContextWindowConfig(
-        (this as unknown as { _model?: string })._model,
-        (this as unknown as { _contextWindowOverrides?: Partial<ContextWindowConfig> & { safetyMargin?: number } })
-          ._contextWindowOverrides,
-      );
+      const windowConfig = resolveContextWindowConfig(_historyProviderModel, _historyProviderWindowOverrides);
 
       // Hard cap on entry count
       entries = entries.slice(-windowConfig.maxEntries);
@@ -387,12 +389,8 @@ export async function assembleContext(
   const { providers: providerNames, wrapUntrusted = true, untrustedWrapper = defaultUntrustedWrapper } = options;
 
   // Pass model info to conversation_history provider for token-aware windowing
-  const historyProvider = contextProviders.get("conversation_history");
-  if (historyProvider) {
-    (historyProvider as unknown as { _model?: string })._model = options.model;
-    (historyProvider as unknown as { _contextWindowOverrides?: typeof options.contextWindow })._contextWindowOverrides =
-      options.contextWindow;
-  }
+  _historyProviderModel = options.model;
+  _historyProviderWindowOverrides = options.contextWindow;
 
   // Get active providers
   let activeProviders = Array.from(contextProviders.values());

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -431,8 +431,8 @@ async function executeInjectInternal(
     // System context is the assembled system + any session file context as fallback
     const fullContext = assembled.system || context || `You are WOPR session "${name}".`;
 
-    // Load provider config from session or auto-detect available provider
-    let providerConfig = await getSessionProvider(name);
+    // Reuse early provider config (fetched above for context windowing)
+    let providerConfig = earlyProviderConfig;
     if (!providerConfig) {
       // Auto-detect: use first available provider
       const available = providerRegistry.listProviders().filter((p) => p.available);

--- a/tests/core/context-window.test.ts
+++ b/tests/core/context-window.test.ts
@@ -72,6 +72,14 @@ describe("resolveContextWindowConfig", () => {
     expect(cfg.maxEntries).toBe(10);
   });
 
+  it("maxEntryTokens does not exceed maxHistoryTokens when maxHistoryTokens is overridden", () => {
+    // Without the fix, maxEntryTokens would be ~28800 (25% of gpt-4o's 115200) but maxHistoryTokens is 1000
+    const cfg = resolveContextWindowConfig("gpt-4o", { maxHistoryTokens: 1000 });
+    expect(cfg.maxHistoryTokens).toBe(1000);
+    expect(cfg.maxEntryTokens).toBeLessThanOrEqual(cfg.maxHistoryTokens);
+    expect(cfg.maxEntryTokens).toBe(Math.floor(1000 * 0.25));
+  });
+
   it("respects custom safetyMargin", () => {
     const cfg = resolveContextWindowConfig("gpt-4o", { safetyMargin: 0.5 });
     expect(cfg.maxHistoryTokens).toBe(Math.floor(128_000 * 0.5));


### PR DESCRIPTION
## Summary
Closes WOP-1477

- Replaces hardcoded 20-entry / 800-char context cap with token-based windowing
- Adds `estimateTokens()` (4 chars ≈ 1 token, no new dependencies), `getModelContextLimit()`, and `resolveContextWindowConfig()` exported from `context.ts`
- Per-model context limit lookup table covering GPT-4o/mini/turbo, Claude (Sonnet/Haiku/Opus), Gemini 1.5/2.0, DeepSeek, Mistral (defaults to 8,192 for unknown models)
- `conversationHistoryProvider` now drops oldest messages first when over token budget (sliding window), with per-entry truncation guarded by 25% of total budget
- `ContextAssemblyOptions` gains `model` and `contextWindow` override fields for configurable limits
- `sessions.ts` fetches session provider config before `assembleContext` to pass model through

## Test plan
- [x] `npm run check` passes (biome + tsc --noEmit)
- [x] 17 unit tests pass: `npx vitest run tests/core/context-window.test.ts`
- [x] Tests cover `estimateTokens`, `getModelContextLimit`, `resolveContextWindowConfig`, and `ContextAssemblyOptions` types

Generated with Claude Code

## Summary by Sourcery

Introduce token-aware context window management for conversation history and plumb model-aware configuration through context assembly and session execution.

New Features:
- Add token-based context window configuration with per-model limits and configurable overrides for conversation history.
- Expose token estimation and model context limit utilities for use in context assembly.

Enhancements:
- Update conversation history provider to use a sliding, token-budgeted window with per-entry truncation and metadata about token usage.
- Extend context assembly options and session execution to propagate model information into context window management.

Tests:
- Add unit tests covering token estimation, model context limit resolution, and context window configuration behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add token-aware context window management to conversation history and assembleContext to use session provider model for WOP-1477
> Introduce model-specific token limits and token estimation, apply token-budgeted selection and truncation in `context.conversationHistoryProvider.getContext`, and pass the provider `model` through `sessions.executeInjectInternal` into `context.assembleContext` for window resolution; include new config interfaces and minimal tests.
>
> #### 📍Where to Start
> Start with `conversationHistoryProvider.getContext` in [context.ts](https://github.com/wopr-network/wopr/pull/1819/files#diff-c02b4d62dc54667a8a1243f8ddc5ae0a604cc5d7218d94fd69bfda1c8514ce1f), then review how `assembleContext` sets module-scoped overrides and how `sessions.executeInjectInternal` passes the model in [sessions.ts](https://github.com/wopr-network/wopr/pull/1819/files#diff-367d072b442cb63ae6a6e617c4f11539ca690563d6f79e932c36d519cebbe997).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6418874.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model-aware context windowing with adaptive token budgets and safety margins; context trimming now respects the active model to keep relevant history.
  * Publicly available token estimation and context-window configuration options for finer control over assembled context.

* **Tests**
  * Added comprehensive tests for token estimation, model limits, and context-window configuration behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->