### PR TITLE
fix: notify running daemon on config set/reset (WOP-1473)

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -4,6 +4,7 @@
 import { config } from "../core/config.js";
 import { logger } from "../logger.js";
 import { help } from "./help.js";
+import { client } from "./shared.js";
 
 export async function configCommand(subcommand: string | undefined, args: string[]): Promise<void> {
   // Config doesn't require daemon - it's local file management
@@ -43,12 +44,28 @@ export async function configCommand(subcommand: string | undefined, args: string
 
       config.setValue(key, value);
       await config.save();
+
+      // Notify running daemon (if any) so it picks up the change immediately
+      try {
+        await client.setConfigValue(key, value);
+      } catch {
+        // Daemon not running or unreachable — proceed silently
+      }
+
       logger.info(`Set ${key} = ${JSON.stringify(value)}`);
       break;
     }
     case "reset": {
       config.reset();
       await config.save();
+
+      // Notify running daemon (if any) to reset its in-memory config
+      try {
+        await client.resetConfig();
+      } catch {
+        // Daemon not running or unreachable — proceed silently
+      }
+
       logger.info("Config reset to defaults");
       break;
     }

--- a/tests/unit/config-command.test.ts
+++ b/tests/unit/config-command.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Config command tests (WOP-1473)
+ *
+ * Verifies that `wopr config set` notifies the running daemon,
+ * and succeeds silently when the daemon is not running.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before importing the module under test
+vi.mock("../../src/core/config.js", () => {
+  const configInstance = {
+    load: vi.fn().mockResolvedValue({}),
+    get: vi.fn().mockReturnValue({}),
+    getValue: vi.fn(),
+    setValue: vi.fn(),
+    save: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn(),
+  };
+  return { config: configInstance };
+});
+
+vi.mock("../../src/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/daemon/auth-token.js", () => ({
+  getToken: vi.fn(() => "test-token"),
+}));
+
+// We need to mock fetch globally to intercept WoprClient calls
+let fetchMock: ReturnType<typeof vi.fn>;
+
+import { config } from "../../src/core/config.js";
+import { configCommand } from "../../src/commands/config.js";
+
+const mockedConfig = vi.mocked(config);
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("configCommand", () => {
+  describe("set subcommand", () => {
+    it("should notify daemon after writing config to disk", async () => {
+      // Daemon is running — fetch succeeds
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ key: "daemon.port", value: 9999 }),
+      });
+
+      await configCommand("set", ["daemon.port", "9999"]);
+
+      // Config was written to disk
+      expect(mockedConfig.setValue).toHaveBeenCalledWith("daemon.port", 9999);
+      expect(mockedConfig.save).toHaveBeenCalled();
+
+      // Daemon was notified via PUT /config/daemon.port
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/config/daemon.port"),
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    it("should succeed silently when daemon is not running", async () => {
+      // Daemon is not running — fetch throws ECONNREFUSED
+      fetchMock.mockRejectedValue(new Error("fetch failed: ECONNREFUSED"));
+
+      // Should NOT throw
+      await configCommand("set", ["plugins.autoLoad", "true"]);
+
+      // Config was still written to disk
+      expect(mockedConfig.setValue).toHaveBeenCalledWith("plugins.autoLoad", true);
+      expect(mockedConfig.save).toHaveBeenCalled();
+    });
+
+    it("should succeed silently when daemon returns an error", async () => {
+      // Daemon returns 500
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: vi.fn().mockResolvedValue({ error: "Internal server error" }),
+      });
+
+      // Should NOT throw
+      await configCommand("set", ["daemon.host", "0.0.0.0"]);
+
+      // Config was still written to disk
+      expect(mockedConfig.setValue).toHaveBeenCalledWith("daemon.host", "0.0.0.0");
+      expect(mockedConfig.save).toHaveBeenCalled();
+    });
+  });
+
+  describe("reset subcommand", () => {
+    it("should notify daemon after resetting config", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({ message: "Config reset to defaults" }),
+      });
+
+      await configCommand("reset", []);
+
+      expect(mockedConfig.reset).toHaveBeenCalled();
+      expect(mockedConfig.save).toHaveBeenCalled();
+
+      // Daemon was notified via DELETE /config
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/config"),
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+
+    it("should succeed silently when daemon is not running on reset", async () => {
+      fetchMock.mockRejectedValue(new Error("fetch failed: ECONNREFUSED"));
+
+      await configCommand("reset", []);
+
+      expect(mockedConfig.reset).toHaveBeenCalled();
+      expect(mockedConfig.save).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1473

- After `wopr config set <key> <value>` writes to disk, the CLI now calls `client.setConfigValue()` to forward the change to the running daemon via `PUT /config/:key`
- After `wopr config reset` writes to disk, the CLI now calls `client.resetConfig()` via `DELETE /config`
- Both calls are wrapped in try/catch — if the daemon is not running (ECONNREFUSED) or returns an error, the error is swallowed silently and the command succeeds as before

## Test plan
- [x] `npm run check` passes (lint + tsc)
- [x] `npx vitest run tests/unit/config-command.test.ts` — 5 tests pass
  - set: notifies daemon when running
  - set: succeeds silently when daemon not running (ECONNREFUSED)
  - set: succeeds silently when daemon returns error (500)
  - reset: notifies daemon when running
  - reset: succeeds silently when daemon not running

Generated with Claude Code

## Summary by Sourcery

Notify the running daemon when configuration is changed via the CLI while preserving previous behavior if the daemon is unavailable.

New Features:
- Propagate `config set` changes from the CLI to the running daemon so it picks up updated values immediately.
- Notify the running daemon on `config reset` so its in-memory configuration is reset alongside the persisted config.

Tests:
- Add unit tests for `configCommand` to cover daemon notification on set/reset and silent success when the daemon is unreachable or returns errors.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Notify the running daemon from the `configCommand` CLI handler on `set` and `reset` in [config.ts](https://github.com/wopr-network/wopr/pull/1821/files#diff-8c467368fd64da9077ad462358fce5589607dfbfe03ac72941c7d74dbfba52aa) to address WOP-1473
> Add daemon notifications in `configCommand`: call `client.setConfigValue(key, value)` after `set` and `client.resetConfig()` after `reset`, both wrapped in try/catch to ignore errors. Introduce unit tests validating PUT/DELETE requests and silent failure behavior.
>
> #### 🖇️ Linked Issues
> Addresses [WOP-1473](ticket:jira/WOP-1473) by adding daemon notifications on config changes from the CLI.
>
> #### 📍Where to Start
> Start with the `configCommand` handler in [config.ts](https://github.com/wopr-network/wopr/pull/1821/files#diff-8c467368fd64da9077ad462358fce5589607dfbfe03ac72941c7d74dbfba52aa), focusing on the `set` and `reset` subcommands and their calls to `client.setConfigValue` and `client.resetConfig`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bb3abda. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/commands/config.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 50](https://github.com/wopr-network/wopr/blob/bb3abda4092f265275639786faf5d3b2fa2e1e7c/src/commands/config.ts#L50): The `configCommand` uses the statically initialized `client` instance from `shared.ts`, which is created with default settings (`new WoprClient()`) and does not respect the user's configuration loaded via `config.load()`. If a user has configured a custom daemon port or host in their config file, `client.setConfigValue` and `client.resetConfig` will attempt to connect to the default URL (likely `http://127.0.0.1:7437`) instead of the configured one. This will cause the connection to fail, and because the error is silently caught, the daemon will not be notified of the configuration change, leaving it out of sync with the file system. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->