### PR TITLE
fix: remove optional markers from registerA2AServer/unregisterA2AServer (WOP-1468)

### DIFF
--- a/src/plugin-types/context.ts
+++ b/src/plugin-types/context.ts
@@ -226,8 +226,8 @@ export interface WOPRPluginContext {
   getChannelProviders(): ChannelProvider[];
 
   // A2A tools
-  registerA2AServer?(config: A2AServerConfig): void;
-  unregisterA2AServer?(config: A2AServerConfig): void;
+  registerA2AServer(config: A2AServerConfig): void;
+  unregisterA2AServer(config: A2AServerConfig): void;
   /** Get a resolved A2A tool declared in toolDependencies. Returns undefined if optional and not found. */
   getA2ATool(toolName: string): ((args: Record<string, unknown>) => Promise<A2AToolResult>) | undefined;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -897,8 +897,8 @@ export interface WOPRPluginContext {
 
   // A2A (Agent-to-Agent) tools - plugins register MCP tools
   // Example: P2P plugin registers p2p_join_topic, p2p_send_message, etc.
-  registerA2AServer?(config: A2AServerConfig): void;
-  unregisterA2AServer?(config: A2AServerConfig): void;
+  registerA2AServer(config: A2AServerConfig): void;
+  unregisterA2AServer(config: A2AServerConfig): void;
   /** Get a resolved A2A tool declared in toolDependencies. Returns undefined if optional and not found. */
   getA2ATool(toolName: string): ((args: Record<string, unknown>) => Promise<A2AToolResult>) | undefined;
 


### PR DESCRIPTION
## Summary
Closes WOP-1468

- Removed `?` optional markers from `registerA2AServer` and `unregisterA2AServer` in `src/plugin-types/context.ts` and `src/types.ts`
- Context factory always provides both methods unconditionally, so the optional markers were incorrect and required unnecessary defensive null-checks in plugin code
- Type-only change, no runtime impact

## Test plan
- [x] `npm run check` passes (lint + tsc --noEmit)
- [x] No call-sites use optional chaining (`?.`) on these methods

Generated with Claude Code

## Summary by Sourcery

Enhancements:
- Treat registerA2AServer and unregisterA2AServer as required methods on WOPRPluginContext rather than optional type members.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `WOPRPluginContext.registerA2AServer` and `WOPRPluginContext.unregisterA2AServer` required in [context.ts](https://github.com/wopr-network/wopr/pull/1828/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6) and [types.ts](https://github.com/wopr-network/wopr/pull/1828/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) to remove optional markers (WOP-1468)
> Update the `WOPRPluginContext` type to require `registerA2AServer` and `unregisterA2AServer`, removing `?` from both methods in the interface.
>
> #### 📍Where to Start
> Start with the `WOPRPluginContext` interface changes in [context.ts](https://github.com/wopr-network/wopr/pull/1828/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6), then review the corresponding type in [types.ts](https://github.com/wopr-network/wopr/pull/1828/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37fb1c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->