### PR TITLE
feat: implement pluggable inference routing strategies (WOP-1476)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -18,6 +18,8 @@ export interface ProviderDefaults {
   topP?: number;
   reasoningEffort?: string; // For Codex: minimal/low/medium/high/xhigh
   options?: Record<string, unknown>;
+  costPerToken?: number;
+  preferred?: boolean;
 }
 
 export interface WoprConfig {
@@ -60,6 +62,8 @@ export interface WoprConfig {
    *       providers.anthropic.model = "claude-opus-4-5-20251101"
    */
   providers?: Record<string, ProviderDefaults>;
+  /** Default inference routing strategy */
+  routingStrategy?: "first" | "cheapest" | "capable" | "preferred";
   /** Memory system configuration (chunking, sync, etc.) */
   memory?: Partial<import("../memory/types.js").MemoryConfig>;
   /** SOUL_EVIL personality override configuration */
@@ -98,6 +102,8 @@ const ProviderDefaultsSchema = z.object({
   topP: z.number().optional(),
   reasoningEffort: z.string().optional(),
   options: z.record(z.string(), z.unknown()).optional(),
+  costPerToken: z.number().optional(),
+  preferred: z.boolean().optional(),
 });
 
 const WoprConfigSchema = z.object({
@@ -136,6 +142,7 @@ const WoprConfigSchema = z.object({
     })
     .optional(),
   providers: z.record(z.string(), ProviderDefaultsSchema).optional(),
+  routingStrategy: z.enum(["first", "cheapest", "capable", "preferred"]).optional(),
   memory: z.record(z.string(), z.unknown()).optional(),
   soulEvil: z
     .object({

--- a/src/daemon/routes/openai-routing.ts
+++ b/src/daemon/routes/openai-routing.ts
@@ -1,0 +1,65 @@
+/**
+ * Inference routing strategies for OpenAI-compatible API.
+ *
+ * Pure functions that select a provider from the available set
+ * based on the chosen strategy.
+ */
+
+export type RoutingStrategy = "first" | "cheapest" | "capable" | "preferred";
+
+export interface RoutableProvider {
+  id: string;
+  name: string;
+  available: boolean;
+  supportedModels: string[];
+}
+
+interface ProviderCostConfig {
+  costPerToken?: number;
+  preferred?: boolean;
+}
+
+/**
+ * Select a provider based on the given strategy.
+ *
+ * @param providers - All registered providers with availability and model info
+ * @param model - The requested model string
+ * @param strategy - Which routing strategy to use
+ * @param providerConfigs - Per-provider config (costs, preferred flag)
+ * @returns The selected provider, or null if none available
+ */
+export function selectProvider(
+  providers: RoutableProvider[],
+  model: string,
+  strategy: RoutingStrategy,
+  providerConfigs: Record<string, ProviderCostConfig>,
+): RoutableProvider | null {
+  const available = providers.filter((p) => p.available);
+  if (available.length === 0) return null;
+
+  // Direct match on provider ID always wins (existing behavior)
+  const directMatch = available.find((p) => p.id === model);
+  if (directMatch) return directMatch;
+
+  switch (strategy) {
+    case "capable": {
+      const capable = available.filter((p) => p.supportedModels.includes(model));
+      return capable.length > 0 ? capable[0] : available[0];
+    }
+
+    case "cheapest": {
+      const withCosts = available
+        .map((p) => ({ provider: p, cost: providerConfigs[p.id]?.costPerToken ?? Number.POSITIVE_INFINITY }))
+        .sort((a, b) => a.cost - b.cost);
+      return withCosts[0].provider;
+    }
+
+    case "preferred": {
+      const preferred = available.find((p) => providerConfigs[p.id]?.preferred === true);
+      return preferred ?? available[0];
+    }
+
+    default:
+      return available[0];
+  }
+}

--- a/src/daemon/routes/openai.ts
+++ b/src/daemon/routes/openai.ts
@@ -10,10 +10,12 @@ import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
 import { describeRoute } from "hono-openapi";
+import { config as centralConfig } from "../../core/config.js";
 import { providerRegistry } from "../../core/providers.js";
 import { deleteSession, inject, setSessionContext, setSessionProvider } from "../../core/sessions.js";
 import { createInjectionSource } from "../../security/index.js";
 import type { ProviderConfig } from "../../types/provider.js";
+import { type RoutableProvider, type RoutingStrategy, selectProvider } from "./openai-routing.js";
 
 type AuthEnv = {
   Variables: {
@@ -136,28 +138,48 @@ function makeSessionName(): string {
   return `openai-${randomUUID().slice(0, 12)}`;
 }
 
+const VALID_STRATEGIES = new Set<RoutingStrategy>(["first", "cheapest", "capable", "preferred"]);
+
 /**
  * Resolve which WOPR provider to use for a given OpenAI model string.
  *
- * Strategy:
- * 1. If the model string matches a registered provider ID, use that provider.
- * 2. If a provider's supportedModels includes the model, use that provider.
- * 3. Otherwise fall back to the first available provider.
+ * Routing strategy precedence: per-request header > config default > "first"
  */
-function resolveProviderConfig(model: string): ProviderConfig | null {
+function resolveProviderConfig(model: string, strategyOverride?: string): ProviderConfig | null {
   const providers = providerRegistry.listProviders();
   const available = providers.filter((p) => p.available);
 
   if (available.length === 0) return null;
 
-  // Direct match on provider ID (e.g. model="anthropic")
-  const directMatch = available.find((p) => p.id === model);
-  if (directMatch) {
-    return { name: directMatch.id };
-  }
+  // Build RoutableProvider list with supportedModels from registry
+  const routable: RoutableProvider[] = available.map((p) => {
+    const reg = providerRegistry.getProvider(p.id);
+    return {
+      id: p.id,
+      name: p.name,
+      available: p.available,
+      supportedModels: reg?.provider.supportedModels ?? [],
+    };
+  });
 
-  // Use first available provider, pass the model string through
-  return { name: available[0].id, model };
+  // Determine strategy: header override > config > default "first"
+  const configStrategy = centralConfig.get().routingStrategy;
+  const rawStrategy = strategyOverride ?? configStrategy ?? "first";
+  const strategy: RoutingStrategy = VALID_STRATEGIES.has(rawStrategy as RoutingStrategy)
+    ? (rawStrategy as RoutingStrategy)
+    : "first";
+
+  // Get per-provider configs for cost/preferred data
+  const providerConfigs = centralConfig.get().providers ?? {};
+
+  const selected = selectProvider(routable, model, strategy, providerConfigs);
+  if (!selected) return null;
+
+  // If the selected provider's ID matches the model, no model override needed
+  if (selected.id === model) {
+    return { name: selected.id };
+  }
+  return { name: selected.id, model };
 }
 
 /**
@@ -251,7 +273,8 @@ openaiRouter.post(
     }
 
     // Resolve provider
-    const providerConfig = resolveProviderConfig(body.model);
+    const routingStrategy = c.req.header("X-Routing-Strategy");
+    const providerConfig = resolveProviderConfig(body.model, routingStrategy);
     if (!providerConfig) {
       return c.json(
         {

--- a/tests/unit/openai-compat.test.ts
+++ b/tests/unit/openai-compat.test.ts
@@ -14,6 +14,21 @@ vi.mock("../../src/core/providers.js", () => {
       { id: "anthropic", name: "Anthropic", available: true, lastChecked: Date.now() },
       { id: "openai", name: "OpenAI", available: false, lastChecked: Date.now() },
     ]),
+    getProvider: vi.fn((id: string) => {
+      if (id === "anthropic") {
+        return {
+          provider: {
+            id: "anthropic",
+            name: "Anthropic",
+            defaultModel: "claude-sonnet-4-5-20250929",
+            supportedModels: ["claude-sonnet-4-5-20250929"],
+          },
+          available: true,
+          lastChecked: Date.now(),
+        };
+      }
+      return undefined;
+    }),
     getCredential: vi.fn(() => ({ providerId: "anthropic", credential: "sk-test" })),
     resolveProvider: vi.fn(async () => ({
       name: "anthropic",
@@ -31,6 +46,16 @@ vi.mock("../../src/core/providers.js", () => {
     ProviderRegistry: { getInstance: () => registry },
   };
 });
+
+// Mock config
+vi.mock("../../src/core/config.js", () => ({
+  config: {
+    get: vi.fn(() => ({
+      routingStrategy: undefined,
+      providers: {},
+    })),
+  },
+}));
 
 // Mock sessions
 vi.mock("../../src/core/sessions.js", () => ({
@@ -68,6 +93,7 @@ import { Hono } from "hono";
 import { openaiRouter } from "../../src/daemon/routes/openai.js";
 import { deleteSession, inject, setSessionContext, setSessionProvider } from "../../src/core/sessions.js";
 import { providerRegistry } from "../../src/core/providers.js";
+import { config as centralConfig } from "../../src/core/config.js";
 
 function createTestApp() {
   const app = new Hono();
@@ -84,6 +110,25 @@ describe("OpenAI Compatibility Layer", () => {
       { id: "anthropic", name: "Anthropic", available: true, lastChecked: Date.now() },
       { id: "openai", name: "OpenAI", available: false, lastChecked: Date.now() },
     ]);
+    vi.mocked(providerRegistry.getProvider).mockImplementation((id: string) => {
+      if (id === "anthropic") {
+        return {
+          provider: {
+            id: "anthropic",
+            name: "Anthropic",
+            defaultModel: "claude-sonnet-4-5-20250929",
+            supportedModels: ["claude-sonnet-4-5-20250929"],
+          } as any,
+          available: true,
+          lastChecked: Date.now(),
+        };
+      }
+      return undefined;
+    });
+    vi.mocked(centralConfig.get).mockReturnValue({
+      routingStrategy: undefined,
+      providers: {},
+    } as any);
     vi.mocked(providerRegistry.resolveProvider).mockResolvedValue({
       name: "anthropic",
       provider: { id: "anthropic", name: "Anthropic", defaultModel: "claude-sonnet-4-5-20250929" } as any,
@@ -794,6 +839,87 @@ describe("OpenAI Compatibility Layer", () => {
       expect(res.status).toBe(400);
       const data = await res.json();
       expect(data.error.message).toContain("messages[1]");
+    });
+  });
+
+  // ==========================================================================
+  // Routing strategy
+  // ==========================================================================
+
+  describe("routing strategy", () => {
+    it("respects X-Routing-Strategy header for capable routing", async () => {
+      // Set up two available providers
+      vi.mocked(providerRegistry.listProviders).mockReturnValue([
+        { id: "anthropic", name: "Anthropic", available: true, lastChecked: Date.now() },
+        { id: "openai", name: "OpenAI", available: true, lastChecked: Date.now() },
+      ]);
+      vi.mocked(providerRegistry.getProvider).mockImplementation((id: string) => {
+        if (id === "anthropic") {
+          return {
+            provider: {
+              id: "anthropic",
+              name: "Anthropic",
+              defaultModel: "claude-sonnet-4-5-20250929",
+              supportedModels: ["claude-sonnet-4-5-20250929"],
+            } as any,
+            available: true,
+            lastChecked: Date.now(),
+          };
+        }
+        if (id === "openai") {
+          return {
+            provider: {
+              id: "openai",
+              name: "OpenAI",
+              defaultModel: "gpt-4o",
+              supportedModels: ["gpt-4o", "gpt-4o-mini"],
+            } as any,
+            available: true,
+            lastChecked: Date.now(),
+          };
+        }
+        return undefined;
+      });
+
+      const app = createTestApp();
+      const res = await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Routing-Strategy": "capable",
+        },
+        body: JSON.stringify({
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(setSessionProvider).toHaveBeenCalledWith(
+        expect.stringMatching(/^openai-/),
+        expect.objectContaining({ name: "openai" }),
+      );
+    });
+
+    it("ignores invalid X-Routing-Strategy and falls back to first", async () => {
+      const app = createTestApp();
+      await app.request("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Routing-Strategy": "invalid-strategy",
+        },
+        body: JSON.stringify({
+          model: "gpt-4o",
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      });
+
+      // Falls back to first available: anthropic
+      expect(setSessionProvider).toHaveBeenCalledWith(
+        expect.stringMatching(/^openai-/),
+        expect.objectContaining({ name: "anthropic" }),
+      );
     });
   });
 

--- a/tests/unit/openai-routing.test.ts
+++ b/tests/unit/openai-routing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { selectProvider, type RoutingStrategy, type RoutableProvider } from "../../src/daemon/routes/openai-routing.js";
+
+describe("selectProvider", () => {
+  const providers: RoutableProvider[] = [
+    { id: "anthropic", name: "Anthropic", available: true, supportedModels: ["claude-sonnet-4-5-20250929"] },
+    { id: "openai", name: "OpenAI", available: true, supportedModels: ["gpt-4o", "gpt-4o-mini"] },
+    { id: "kilo", name: "Kilo", available: false, supportedModels: ["kilo-1"] },
+  ];
+
+  it("first: returns first available provider", () => {
+    const result = selectProvider(providers, "gpt-4o", "first", {});
+    expect(result?.id).toBe("anthropic");
+  });
+
+  it("capable: returns provider that supports the requested model", () => {
+    const result = selectProvider(providers, "gpt-4o", "capable", {});
+    expect(result?.id).toBe("openai");
+  });
+
+  it("capable: falls back to first if no model match", () => {
+    const result = selectProvider(providers, "nonexistent-model", "capable", {});
+    expect(result?.id).toBe("anthropic");
+  });
+
+  it("cheapest: returns provider with lowest costPerToken", () => {
+    const costs = { anthropic: { costPerToken: 0.01 }, openai: { costPerToken: 0.005 } };
+    const result = selectProvider(providers, "gpt-4o", "cheapest", costs);
+    expect(result?.id).toBe("openai");
+  });
+
+  it("cheapest: providers without cost data sort last", () => {
+    const costs = { openai: { costPerToken: 0.005 } };
+    const result = selectProvider(providers, "gpt-4o", "cheapest", costs);
+    expect(result?.id).toBe("openai");
+  });
+
+  it("preferred: returns provider marked preferred", () => {
+    const providerConfigs = { openai: { preferred: true } };
+    const result = selectProvider(providers, "gpt-4o", "preferred", providerConfigs);
+    expect(result?.id).toBe("openai");
+  });
+
+  it("preferred: falls back to first if none marked", () => {
+    const result = selectProvider(providers, "gpt-4o", "preferred", {});
+    expect(result?.id).toBe("anthropic");
+  });
+
+  it("returns null when no providers available", () => {
+    const result = selectProvider([], "gpt-4o", "first", {});
+    expect(result).toBeNull();
+  });
+
+  it("skips unavailable providers", () => {
+    const onlyUnavailable: RoutableProvider[] = [
+      { id: "kilo", name: "Kilo", available: false, supportedModels: ["kilo-1"] },
+    ];
+    const result = selectProvider(onlyUnavailable, "kilo-1", "first", {});
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Closes WOP-1476

- Add `src/daemon/routes/openai-routing.ts` with pure `selectProvider()` function supporting `first`, `capable`, `cheapest`, and `preferred` routing strategies
- Wire `X-Routing-Strategy` request header and `config.routingStrategy` config field into `resolveProviderConfig()` in `openai.ts`
- Add `costPerToken` and `preferred` fields to `ProviderDefaults` in `src/core/config.ts` for cheapest/preferred strategy support
- Routing decision uses header > config > default `first` precedence; invalid header values fall back to `first`

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` passes (tsc clean)
- [x] `npx vitest run tests/unit/openai-routing.test.ts` — 9 unit tests for all 4 strategies
- [x] `npx vitest run tests/unit/openai-compat.test.ts` — 37 integration tests including X-Routing-Strategy header test

Generated with Claude Code

## Summary by Sourcery

Introduce pluggable inference routing strategies for the OpenAI-compatible API and hook them into provider resolution based on request headers and configuration.

New Features:
- Add a pluggable routing module with support for first, capable, cheapest, and preferred provider selection strategies for OpenAI-compatible requests.
- Allow routing strategy selection per request via the X-Routing-Strategy header and globally via a routingStrategy configuration option.
- Extend provider configuration to include costPerToken and preferred flags to support cheapest and preferred routing strategies.

Enhancements:
- Refine OpenAI compatibility provider resolution to use a centralized routing function that considers provider capabilities, costs, and preference flags before falling back to the first available provider.

Tests:
- Add unit tests for the routing strategy selection logic and extend OpenAI compatibility tests to cover header-based routing behavior and invalid strategy fallback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pluggable inference routing strategies to OpenAI-compatible chat endpoint to honor header and config-driven provider selection (WOP-1476)
> Introduce `routingStrategy` support with strategies `first`, `cheapest`, `capable`, and `preferred`, add per-provider `costPerToken` and `preferred` config fields, implement `selectProvider` in [openai-routing.ts](https://github.com/wopr-network/wopr/pull/1830/files#diff-f0e03475f0b758c31550a3a68bfe0c37ff1ff99c9324d9a380bb1cff142c3783), and route via `X-Routing-Strategy` in [openai.ts](https://github.com/wopr-network/wopr/pull/1830/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09).
>
> #### 📍Where to Start
> Start with `resolveProviderConfig` in [openai.ts](https://github.com/wopr-network/wopr/pull/1830/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09), then review `selectProvider` in [openai-routing.ts](https://github.com/wopr-network/wopr/pull/1830/files#diff-f0e03475f0b758c31550a3a68bfe0c37ff1ff99c9324d9a380bb1cff142c3783).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c400fd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added configurable provider routing strategies: first, cheapest, capable, and preferred—optimizing provider selection based on cost, availability, and user preferences
- Introduced configuration options for provider cost tracking and preference marking
- Enabled per-request routing strategy override via request headers

**Tests**
- Added comprehensive test coverage for routing logic and provider selection strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->