### PR TITLE
fix: allow better-sqlite3 native build in pnpm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "vitest": "^4.0.18"
   },
   "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3"],
     "overrides": {
       "rollup": "^4.59.0"
     }


### PR DESCRIPTION
## Summary

Fixes pre-existing CI failures blocking all open PRs.

- Root cause: `better-sqlite3` was missing from `pnpm.onlyBuiltDependencies` in `package.json`. pnpm skips build scripts for packages not listed there, so the native `.node` binding was never compiled during `pnpm install`.
- Fix: Added `"better-sqlite3"` to `pnpm.onlyBuiltDependencies` so `pnpm install` compiles the native binding on CI.
- Result: All 7 affected database integration tests now pass (253 tests total across those files).

## Affected tests (all now green)

- `tests/unit/session-cleaner.test.ts`
- `tests/unit/drizzle-repository.test.ts`
- `tests/unit/api-keys.test.ts`
- `tests/unit/plugin-registry.test.ts`
- `tests/unit/session-context-repository.test.ts`
- `tests/unit/sessions.test.ts`
- `tests/unit/storage.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict `pnpm install` native builds to `better-sqlite3` by adding `onlyBuiltDependencies` in [package.json](https://github.com/wopr-network/wopr/pull/1833/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
> Add `onlyBuiltDependencies: ["better-sqlite3"]` to [package.json](https://github.com/wopr-network/wopr/pull/1833/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to scope native build steps to `better-sqlite3` during `pnpm install`.
>
> #### 📍Where to Start
> Start with the `onlyBuiltDependencies` addition in [package.json](https://github.com/wopr-network/wopr/pull/1833/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d71893.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->