### PR TITLE
fix: timer leak in Promise.race timeout patterns (WOP-1438)

### DIFF
--- a/src/plugins/loading.ts
+++ b/src/plugins/loading.ts
@@ -29,6 +29,18 @@ import { enablePlugin, getInstalledPlugins, installPlugin } from "./installation
 import { configSchemas, loadedPlugins, pluginManifests, pluginStates, resolvedA2ATools } from "./state.js";
 
 /**
+ * Race a promise against a timeout, clearing the timer when either settles.
+ * Prevents timer leaks when the primary promise resolves before the timeout.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
  * Validate plugin config against its declared configSchema.
  * Throws if any required field is missing or empty.
  */
@@ -89,12 +101,7 @@ async function initAndActivatePlugin(
       if (plugin.shutdown) {
         const shutdownTimeoutMs = manifest?.lifecycle?.shutdownTimeoutMs ?? 30_000;
         try {
-          await Promise.race([
-            plugin.shutdown(),
-            new Promise<void>((_, reject) =>
-              setTimeout(() => reject(new Error(`shutdown timeout after ${shutdownTimeoutMs}ms`)), shutdownTimeoutMs),
-            ),
-          ]);
+          await withTimeout(plugin.shutdown(), shutdownTimeoutMs, "shutdown");
         } catch (shutdownErr: unknown) {
           logger.warn(
             `[plugins] ${installed.name}: shutdown() during init cleanup also failed: ${shutdownErr instanceof Error ? shutdownErr.message : String(shutdownErr)}`,
@@ -504,12 +511,7 @@ async function deactivateAndShutdownPlugin(name: string, plugin: WOPRPlugin, dra
 
   if (plugin.onDeactivate) {
     try {
-      await Promise.race([
-        plugin.onDeactivate(),
-        new Promise<void>((_, reject) =>
-          setTimeout(() => reject(new Error(`onDeactivate timeout after ${drainTimeoutMs}ms`)), drainTimeoutMs),
-        ),
-      ]);
+      await withTimeout(plugin.onDeactivate(), drainTimeoutMs, "onDeactivate");
     } catch (err) {
       logger.error(`[plugins] ${name}: onDeactivate failed: ${err}`);
     }
@@ -517,12 +519,7 @@ async function deactivateAndShutdownPlugin(name: string, plugin: WOPRPlugin, dra
 
   if (plugin.shutdown) {
     try {
-      await Promise.race([
-        plugin.shutdown(),
-        new Promise<void>((_, reject) =>
-          setTimeout(() => reject(new Error(`shutdown timeout after ${drainTimeoutMs}ms`)), drainTimeoutMs),
-        ),
-      ]);
+      await withTimeout(plugin.shutdown(), drainTimeoutMs, "shutdown");
     } catch (err) {
       logger.error(`[plugins] ${name}: shutdown failed: ${err}`);
     }


### PR DESCRIPTION
## Summary
Closes WOP-1438

- Add `withTimeout<T>()` helper that races a promise against a timeout and clears the timer in `.finally()`, preventing timer leaks when the primary promise resolves first
- Replace three raw `Promise.race()` + bare `setTimeout` patterns in `src/plugins/loading.ts` with `withTimeout()`:
  - `initAndActivatePlugin`: shutdown during init cleanup
  - `deactivateAndShutdownPlugin`: `onDeactivate` timeout
  - `deactivateAndShutdownPlugin`: `shutdown` timeout
- The existing `drainPlugin` already handled cleanup correctly and was not changed

## Test plan
- [ ] `pnpm run check` passes (lint + tsc)
- [ ] No timer leaks when plugin resolves before timeout in init/deactivate/shutdown

Generated with Claude Code

## Summary by Sourcery

Prevent plugin lifecycle timeouts from leaking timers by centralizing timeout handling in a shared helper.

Bug Fixes:
- Eliminate timer leaks in plugin init, deactivate, and shutdown timeout races when the primary promise settles before the timeout.

Enhancements:
- Introduce a reusable withTimeout helper to standardize Promise timeout racing across plugin lifecycle operations.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix timer leak in plugin lifecycle by introducing `withTimeout` and updating `loading.ts` to wrap `Plugin.initAndActivatePlugin` shutdown and `Plugin.deactivateAndShutdownPlugin` deactivation/shutdown with standardized timeouts
> Introduce `withTimeout` to race a promise against a timeout and clear timers, and apply it in [loading.ts](https://github.com/wopr-network/wopr/pull/1834/files#diff-ba055517e71685b635ba42fef3dacd58a0adaa4305acf4a9d21f8c3dc95be42c) to wrap `plugin.onDeactivate()` and `plugin.shutdown()` with standardized timeout errors.
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1438](ticket:jira/WOP-1438) by removing Promise.race-based timer leaks and unifying timeout handling in plugin lifecycle.
>
> #### 📍Where to Start
> Start with the `withTimeout` helper and its first call sites in [loading.ts](https://github.com/wopr-network/wopr/pull/1834/files#diff-ba055517e71685b635ba42fef3dacd58a0adaa4305acf4a9d21f8c3dc95be42c), then review its use in `initAndActivatePlugin` and `deactivateAndShutdownPlugin`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f8eecdf. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/plugins/loading.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 514](https://github.com/wopr-network/wopr/blob/f8eecdfdf525c374af4bf9f22ee8cf7afefefc66/src/plugins/loading.ts#L514): `deactivateAndShutdownPlugin` applies the full `drainTimeoutMs` budget sequentially to both `onDeactivate` and `shutdown`. If both operations hang or run slowly, the function can block for up to `2 * drainTimeoutMs`, violating the intended timeout constraint. For example, if `drainTimeoutMs` is 30s, the process could wait 30s for `onDeactivate` and then another 30s for `shutdown`. The code should track elapsed time and pass only the remaining budget to the second operation. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Internal Improvements

* **Refactor**
  * Improved reliability of plugin loading and shutdown processes through optimization of timeout handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->