### PR TITLE
fix: guard SSE writes with aborted flag after client disconnect (WOP-1439)

### DIFF
--- a/src/daemon/routes/openai.ts
+++ b/src/daemon/routes/openai.ts
@@ -299,8 +299,11 @@ openaiRouter.post(
       c.header("Connection", "keep-alive");
 
       return stream(c, async (s) => {
+        let aborted = false;
+
         // Clean up the ephemeral session when the client disconnects
         s.onAbort(() => {
+          aborted = true;
           deleteSession(sessionName, "client-disconnect").catch(() => {});
         });
 
@@ -315,6 +318,7 @@ openaiRouter.post(
                 ? createInjectionSource("daemon", { trustLevel: "owner" })
                 : createInjectionSource("daemon"),
             onStream: (msg) => {
+              if (aborted) return;
               if (msg.type === "text" && msg.content) {
                 const chunk = {
                   id: requestId,
@@ -336,38 +340,42 @@ openaiRouter.post(
             },
           });
 
-          // Final chunk with finish_reason
-          const finalChunk: Record<string, unknown> = {
-            id: requestId,
-            object: "chat.completion.chunk",
-            created,
-            model: body.model,
-            choices: [
-              {
-                index: 0,
-                delta: {},
-                finish_reason: "stop",
-              },
-            ],
-          };
-          if (body.stream_options?.include_usage) {
-            finalChunk.usage = {
-              prompt_tokens: streamUsage?.inputTokens ?? 0,
-              completion_tokens: streamUsage?.outputTokens ?? 0,
-              total_tokens: (streamUsage?.inputTokens ?? 0) + (streamUsage?.outputTokens ?? 0),
+          if (!aborted) {
+            // Final chunk with finish_reason
+            const finalChunk: Record<string, unknown> = {
+              id: requestId,
+              object: "chat.completion.chunk",
+              created,
+              model: body.model,
+              choices: [
+                {
+                  index: 0,
+                  delta: {},
+                  finish_reason: "stop",
+                },
+              ],
             };
+            if (body.stream_options?.include_usage) {
+              finalChunk.usage = {
+                prompt_tokens: streamUsage?.inputTokens ?? 0,
+                completion_tokens: streamUsage?.outputTokens ?? 0,
+                total_tokens: (streamUsage?.inputTokens ?? 0) + (streamUsage?.outputTokens ?? 0),
+              };
+            }
+            s.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
+            s.write("data: [DONE]\n\n");
           }
-          s.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
-          s.write("data: [DONE]\n\n");
         } catch (err) {
-          const errorChunk = {
-            error: {
-              message: err instanceof Error ? err.message : "Internal server error",
-              type: "server_error",
-            },
-          };
-          s.write(`data: ${JSON.stringify(errorChunk)}\n\n`);
-          s.write("data: [DONE]\n\n");
+          if (!aborted) {
+            const errorChunk = {
+              error: {
+                message: err instanceof Error ? err.message : "Internal server error",
+                type: "server_error",
+              },
+            };
+            s.write(`data: ${JSON.stringify(errorChunk)}\n\n`);
+            s.write("data: [DONE]\n\n");
+          }
         } finally {
           // Clean up the ephemeral session after streaming completes
           await deleteSession(sessionName, "request-complete").catch(() => {});


### PR DESCRIPTION
## Summary
Closes WOP-1439

- Added `aborted` flag initialized to `false` before the stream callback
- Set `aborted = true` in `s.onAbort()` alongside the existing session cleanup
- Added `if (aborted) return;` at the start of the `onStream` callback to skip writes after disconnect
- Wrapped final chunk writes (`finish_reason: "stop"` and `[DONE]`) in `if (!aborted) { ... }`
- Wrapped error chunk writes in `if (!aborted) { ... }`

This prevents unhandled "write after end" errors when a client disconnects mid-stream from the OpenAI-compatible `/v1/chat/completions` endpoint.

## Test plan
- [ ] `npm run build` passes
- [ ] `npx vitest run src/daemon/routes/` passes (no existing tests for openai route, behavior is defensive)
- [ ] Manual: start a streaming request, disconnect mid-stream — no unhandled error in daemon logs

Generated with Claude Code

## Summary by Sourcery

Bug Fixes:
- Prevent write-after-end errors by tracking client aborts and skipping SSE writes once the streaming connection is closed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard SSE writes with an `aborted` flag in `openaiRouter.post('/chat/completions')` to stop sending chunks after client disconnect
> Add an `aborted` boolean and early-return guards in the SSE streaming path of `openaiRouter.post('/chat/completions')`, setting the flag in `s.onAbort` and conditionally suppressing chunk, final, and error writes in [openai.ts](https://github.com/wopr-network/wopr/pull/1841/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09).
>
> #### 📍Where to Start
> Start in the SSE branch of `openaiRouter.post('/chat/completions')` in [openai.ts](https://github.com/wopr-network/wopr/pull/1841/files#diff-8de641d2356a50ab016bb4b4eb37e3ef3623fb72a13943b1ba0def1412866f09), reviewing the `s.onAbort` handler and the `onStream` callback guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6b99da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->