### PR TITLE
fix: always log in to GHCR so PR builds can pull private base image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
Remove the `if: github.event_name \!= 'pull_request'` condition on the GHCR login step. PR builds need to authenticate to pull `ghcr.io/wopr-network/base/node:24-bookworm-slim` since the package is private (org policy blocks public packages).

## Summary by Sourcery

Build:
- Update Docker GitHub Actions workflow to always authenticate with GHCR instead of skipping login on pull_request events.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the GHCR login step run on all GitHub Actions events in [.github/workflows/docker.yml](https://github.com/wopr-network/wopr/pull/1847/files#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94) so PR builds can pull the private base image
> Remove the `if: github.event_name != 'pull_request'` condition from the `docker/login-action` step in [.github/workflows/docker.yml](https://github.com/wopr-network/wopr/pull/1847/files#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94), causing GHCR authentication to execute on pull_request and other events.
>
> #### 📍Where to Start
> Begin in [.github/workflows/docker.yml](https://github.com/wopr-network/wopr/pull/1847/files#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94) at the `Log in to GHCR` step where the conditional is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fea6fba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->