### PR TITLE
fix: define concrete InjectionSource type for PluginInjectOptions.source (WOP-1498)

### DIFF
--- a/src/plugin-types/context.ts
+++ b/src/plugin-types/context.ts
@@ -5,6 +5,7 @@
  * this object during init() and use it to interact with the WOPR daemon.
  */
 
+import type { InjectionSource } from "../security/types.js";
 import type { StorageApi } from "../storage/api/plugin-storage.js";
 import type { A2AServerConfig, A2AToolResult } from "./a2a.js";
 import type { ChannelAdapter, ChannelProvider, ChannelRef } from "./channel.js";
@@ -62,9 +63,9 @@ export interface PluginInjectOptions {
   images?: string[];
   /**
    * Security source for this injection.
-   * Uses InjectionSource from security types when provided.
+   * Describes who is initiating the injection and their trust level.
    */
-  source?: unknown;
+  source?: InjectionSource;
   /** Control which context providers to use. */
   contextProviders?: string[];
   /** Priority level (higher = processed first within queue) */


### PR DESCRIPTION
## Summary
Closes WOP-1498

- Imports `InjectionSource` from `../security/types.js` into `src/plugin-types/context.ts`
- Replaces `unknown` with `InjectionSource` on `PluginInjectOptions.source`
- Plugin authors can now see the exact shape (type, trustLevel, identity, grantedCapabilities) without casting

## Test plan
- [x] `pnpm run check` passes (biome + tsc --noEmit)
- [x] No callers needed updating — the concrete type is a subtype of `unknown`, so all existing usages remain valid

Generated with Claude Code

## Summary by Sourcery

Enhancements:
- Replace PluginInjectOptions.source from unknown to the concrete InjectionSource type to expose initiator identity and trust metadata to plugin authors.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Define concrete `InjectionSource` type for `plugin-types.PluginInjectOptions.source` in [context.ts](https://github.com/wopr-network/wopr/pull/1848/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6) to align with WOP-1498
> Update `plugin-types.PluginInjectOptions` to type `source` as `InjectionSource` and add a type-only import from `../security/types.js` in [context.ts](https://github.com/wopr-network/wopr/pull/1848/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6).
>
> #### 📍Where to Start
> Start with the `PluginInjectOptions` interface change in [context.ts](https://github.com/wopr-network/wopr/pull/1848/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e668cff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced type safety for the plugin injection system by introducing more precise type definitions for the injection source field, improving compile-time validation and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->