### PR TITLE
fix: use setSessionProviderAsync instead of writing .provider.json to disk (WOP-1534)

### DIFF
--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -27,9 +27,8 @@ export async function sessionCommand(subcommand: string | undefined, args: strin
           name: flags.provider as string,
           fallback: flags.fallback ? (flags.fallback as string).split(",").map((s) => s.trim()) : undefined,
         };
-        const { SESSIONS_DIR } = await import("../paths.js");
-        const providerFile = (await import("node:path")).join(SESSIONS_DIR, `${name}.provider.json`);
-        await (await import("node:fs/promises")).writeFile(providerFile, JSON.stringify(providerConfig, null, 2));
+        const { setSessionProviderAsync } = await import("../core/session-repository.js");
+        await setSessionProviderAsync(name, providerConfig);
 
         logger.info(
           `Created session "${name}" with provider: ${flags.provider}${
@@ -71,9 +70,8 @@ export async function sessionCommand(subcommand: string | undefined, args: strin
       }
 
       // Save provider config
-      const { SESSIONS_DIR } = await import("../paths.js");
-      const providerFile = (await import("node:path")).join(SESSIONS_DIR, `${sessionName}.provider.json`);
-      await (await import("node:fs/promises")).writeFile(providerFile, JSON.stringify(providerConfig, null, 2));
+      const { setSessionProviderAsync } = await import("../core/session-repository.js");
+      await setSessionProviderAsync(sessionName, providerConfig);
 
       const extras: string[] = [];
       if (flags.model) extras.push(`model: ${flags.model}`);


### PR DESCRIPTION
## Summary
Closes WOP-1534

- Replaces two direct `writeFile` calls in `src/commands/session.ts` with `setSessionProviderAsync()` from `src/core/session-repository.ts`
- Both `wopr session create --provider` and `wopr session set-provider` now write provider config through SQL instead of `.provider.json` files on disk
- Removes unused dynamic imports of `node:path`, `node:fs/promises`, and `../paths.js`

## Test plan
- [ ] `npm run check` passes (lint + tsc --noEmit)
- [ ] `wopr session create <name> --provider <id>` stores provider in SQL
- [ ] `wopr session set-provider <name> <id>` stores provider in SQL

Generated with Claude Code

## Summary by Sourcery

Bug Fixes:
- Ensure session provider settings for created and updated sessions are stored consistently in the SQL-backed repository rather than separate JSON files on disk.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route session provider persistence in `src/commands/session.ts` to `core/session-repository.setSessionProviderAsync` for `create` and provider update subcommands (WOP-1534)
> Replace manual `.provider.json` writes with `core/session-repository.setSessionProviderAsync` and remove path/fs dynamic imports in [src/commands/session.ts](https://github.com/wopr-network/wopr/pull/1856/files#diff-02434a297b8d90c1257040f0cc223b7ad478d6ad8c2b696b28151cf6188c2f00).
>
> #### 📍Where to Start
> Start at the `sessionCommand` handler branches for `create` and provider update in [src/commands/session.ts](https://github.com/wopr-network/wopr/pull/1856/files#diff-02434a297b8d90c1257040f0cc223b7ad478d6ad8c2b696b28151cf6188c2f00).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcc6c56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->