### PR TITLE
feat: expose session context APIs as plugin ctx extensions (WOP-1538)

### DIFF
--- a/src/plugin-types/context.ts
+++ b/src/plugin-types/context.ts
@@ -7,6 +7,7 @@
 
 import type { InjectionSource } from "../security/types.js";
 import type { StorageApi } from "../storage/api/plugin-storage.js";
+import type { ConversationEntry } from "../types.js";
 import type { A2AServerConfig, A2AToolResult } from "./a2a.js";
 import type { ChannelAdapter, ChannelProvider, ChannelRef } from "./channel.js";
 import type { ConfigSchema } from "./config.js";
@@ -272,4 +273,19 @@ export interface WOPRPluginContext {
 
   // Storage API - plugin-extensible database storage
   storage: StorageApi;
+
+  // Session context and conversation log APIs
+  session: SessionApi;
+}
+
+/**
+ * SQL-backed session APIs exposed to plugins via ctx.session.*
+ */
+export interface SessionApi {
+  /** Get a session context file by name and filename. Returns null if not found. */
+  getContext(sessionName: string, filename: string): Promise<string | null>;
+  /** Upsert a session context file. */
+  setContext(sessionName: string, filename: string, content: string, source: "global" | "session"): Promise<void>;
+  /** Read conversation log entries for a session, optionally limited to the last N entries. */
+  readConversationLog(sessionName: string, limit?: number): Promise<ConversationEntry[]>;
 }

--- a/src/plugins/context-factory.ts
+++ b/src/plugins/context-factory.ts
@@ -23,6 +23,8 @@ import {
   unregisterContextProvider as unregisterCtxProvider,
 } from "../core/context.js";
 import { providerRegistry } from "../core/providers.js";
+import { getSessionContext, setSessionContext } from "../core/session-context-repository.js";
+import { readConversationLogAsync } from "../core/session-repository.js";
 import { cancelInject as cancelSessionInject, logMessage as logMessageToSession } from "../core/sessions.js";
 import { resolveIdentity, resolveUserProfile } from "../core/workspace.js";
 import { logger } from "../logger.js";
@@ -314,5 +316,13 @@ export function createPluginContext(
 
     // Storage API - plugin-extensible database storage
     storage: getStorage(),
+
+    // Session context and conversation log APIs
+    session: {
+      getContext: (sessionName: string, filename: string) => getSessionContext(sessionName, filename),
+      setContext: (sessionName: string, filename: string, content: string, source: "global" | "session") =>
+        setSessionContext(sessionName, filename, content, source),
+      readConversationLog: (sessionName: string, limit?: number) => readConversationLogAsync(sessionName, limit),
+    },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -946,6 +946,13 @@ export interface WOPRPluginContext {
   // Setup context providers - plugins provide AI instructions for their own setup flow
   registerSetupContextProvider(fn: SetupContextProvider): void;
   unregisterSetupContextProvider(): void;
+
+  // Session context and conversation log APIs
+  session: {
+    getContext(sessionName: string, filename: string): Promise<string | null>;
+    setContext(sessionName: string, filename: string, content: string, source: "global" | "session"): Promise<void>;
+    readConversationLog(sessionName: string, limit?: number): Promise<ConversationEntry[]>;
+  };
 }
 
 /**

--- a/tests/plugins/context-factory-session.test.ts
+++ b/tests/plugins/context-factory-session.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests that ctx.session.* extensions are present and callable.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dependencies before importing the factory
+vi.mock("../../src/core/session-context-repository.js", () => ({
+  getSessionContext: vi.fn().mockResolvedValue("ctx-content"),
+  setSessionContext: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../src/core/session-repository.js", () => ({
+  readConversationLogAsync: vi.fn().mockResolvedValue([{ ts: 1, from: "user", content: "hi", type: "message" }]),
+}));
+vi.mock("../../src/core/sessions.js", () => ({
+  cancelInject: vi.fn().mockReturnValue(false),
+  logMessage: vi.fn(),
+}));
+vi.mock("../../src/core/a2a-mcp.js", () => ({ unregisterA2ATool: vi.fn().mockReturnValue(true) }));
+vi.mock("../../src/core/capability-health.js", () => ({ getCapabilityHealthProber: vi.fn().mockReturnValue({ registerProbe: vi.fn() }) }));
+vi.mock("../../src/core/capability-registry.js", () => ({ getCapabilityRegistry: vi.fn().mockReturnValue({ registerProvider: vi.fn(), unregisterProvider: vi.fn(), getProviders: vi.fn().mockReturnValue([]), hasProvider: vi.fn().mockReturnValue(false) }) }));
+vi.mock("../../src/core/capability-resolver.js", () => ({ resolveCapability: vi.fn().mockReturnValue(null), resolveAllProviders: vi.fn().mockReturnValue([]) }));
+vi.mock("../../src/core/channels.js", () => ({ getChannelProvider: vi.fn(), getChannelProviders: vi.fn().mockReturnValue([]), registerChannelProvider: vi.fn(), unregisterChannelProvider: vi.fn() }));
+vi.mock("../../src/core/config.js", () => ({ config: { get: vi.fn().mockReturnValue({ plugins: { data: {} } }), getValue: vi.fn(), load: vi.fn(), setValue: vi.fn(), save: vi.fn() } }));
+vi.mock("../../src/core/context.js", () => ({ getContextProvider: vi.fn(), registerContextProvider: vi.fn(), unregisterContextProvider: vi.fn() }));
+vi.mock("../../src/core/providers.js", () => ({ providerRegistry: { register: vi.fn(), getProvider: vi.fn() } }));
+vi.mock("../../src/core/workspace.js", () => ({ resolveIdentity: vi.fn().mockResolvedValue({}), resolveUserProfile: vi.fn().mockResolvedValue({}) }));
+vi.mock("../../src/logger.js", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } }));
+vi.mock("../../src/storage/index.js", () => ({ getStorage: vi.fn().mockReturnValue({}) }));
+vi.mock("../../src/plugins/event-bus.js", () => ({ createPluginEventBus: vi.fn().mockReturnValue({ on: vi.fn(), off: vi.fn(), emit: vi.fn(), once: vi.fn() }) }));
+vi.mock("../../src/plugins/extensions.js", () => ({ getPluginExtension: vi.fn(), listPluginExtensions: vi.fn().mockReturnValue([]), registerPluginExtension: vi.fn(), unregisterPluginExtension: vi.fn() }));
+vi.mock("../../src/plugins/hook-manager.js", () => ({ createPluginHookManager: vi.fn().mockReturnValue({ on: vi.fn(), off: vi.fn(), offByName: vi.fn(), list: vi.fn().mockReturnValue([]) }) }));
+vi.mock("../../src/plugins/plugin-logger.js", () => ({ createPluginLogger: vi.fn().mockReturnValue({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) }));
+vi.mock("../../src/plugins/schema-converter.js", () => ({ registerA2AServerImpl: vi.fn() }));
+vi.mock("../../src/plugins/state.js", () => ({
+  channelAdapters: new Map(),
+  channelKey: vi.fn().mockReturnValue("k"),
+  configSchemas: new Map(),
+  PLUGINS_DIR: "/tmp/plugins",
+  providerPlugins: new Map(),
+  resolvedA2ATools: new Map(),
+  setupContextProviders: new Map(),
+  uiComponents: new Map(),
+  webUiExtensions: new Map(),
+}));
+
+import { createPluginContext } from "../../src/plugins/context-factory.js";
+import { getSessionContext, setSessionContext } from "../../src/core/session-context-repository.js";
+import { readConversationLogAsync } from "../../src/core/session-repository.js";
+
+const makePlugin = () =>
+  ({
+    name: "test-plugin",
+    source: "local",
+    path: "/tmp/test-plugin",
+    manifest: {},
+  }) as Parameters<typeof createPluginContext>[0];
+
+const makeInjectors = () => ({
+  inject: vi.fn().mockResolvedValue("response"),
+  getSessions: vi.fn().mockReturnValue([]),
+});
+
+describe("ctx.session extensions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes a session namespace on the plugin context", () => {
+    const ctx = createPluginContext(makePlugin(), makeInjectors());
+    expect(ctx.session).toBeDefined();
+    expect(typeof ctx.session.getContext).toBe("function");
+    expect(typeof ctx.session.setContext).toBe("function");
+    expect(typeof ctx.session.readConversationLog).toBe("function");
+  });
+
+  it("ctx.session.getContext delegates to getSessionContext", async () => {
+    const ctx = createPluginContext(makePlugin(), makeInjectors());
+    const result = await ctx.session.getContext("my-session", "notes.md");
+    expect(getSessionContext).toHaveBeenCalledWith("my-session", "notes.md");
+    expect(result).toBe("ctx-content");
+  });
+
+  it("ctx.session.setContext delegates to setSessionContext", async () => {
+    const ctx = createPluginContext(makePlugin(), makeInjectors());
+    await ctx.session.setContext("my-session", "notes.md", "content", "global");
+    expect(setSessionContext).toHaveBeenCalledWith("my-session", "notes.md", "content", "global");
+  });
+
+  it("ctx.session.readConversationLog delegates to readConversationLogAsync", async () => {
+    const ctx = createPluginContext(makePlugin(), makeInjectors());
+    const entries = await ctx.session.readConversationLog("my-session", 10);
+    expect(readConversationLogAsync).toHaveBeenCalledWith("my-session", 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].content).toBe("hi");
+  });
+});


### PR DESCRIPTION
**Repo:** wopr-network/wopr

## Summary

Exposes SQL-backed session APIs to plugins via the `ctx.session.*` namespace so plugins can access session data without importing from core internals.

- `ctx.session.getContext(sessionName, filename)` → delegates to `getSessionContext()`
- `ctx.session.setContext(sessionName, filename, content, source)` → delegates to `setSessionContext()`
- `ctx.session.readConversationLog(sessionName, limit?)` → delegates to `readConversationLogAsync()`

Added `SessionApi` interface to `src/plugin-types/context.ts` and `session` property to `WOPRPluginContext` in both `src/plugin-types/context.ts` and `src/types.ts`.

Blocks: WOP-1535, WOP-1536, WOP-1537
Fixes WOP-1538.

## Test plan
- [x] `pnpm run check` passes (lint + tsc --noEmit)
- [x] `npx vitest run tests/plugins/context-factory-session.test.ts` — 4 tests pass
- [x] All three ctx.session.* methods verified to delegate to correct core functions

Generated with Claude Code

## Summary by Sourcery

Expose SQL-backed session context and conversation log APIs on the plugin context under ctx.session for plugin access.

New Features:
- Add SessionApi interface and session property to WOPRPluginContext to provide session context and conversation log operations to plugins via ctx.session.*

Tests:
- Add plugin context factory tests to verify ctx.session namespace exists and its methods delegate to the underlying session repositories.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose plugin session context and conversation log via `WOPRPluginContext.session` in [context-factory.ts](https://github.com/wopr-network/wopr/pull/1857/files#diff-d582617c48c761527d98598b3f7d23c1f39a18c7c3e14c950f14b7093a8505bc) to support WOP-1538
> Add `session` to `WOPRPluginContext` with `getContext`, `setContext`, and `readConversationLog`; implement delegations in [context-factory.ts](https://github.com/wopr-network/wopr/pull/1857/files#diff-d582617c48c761527d98598b3f7d23c1f39a18c7c3e14c950f14b7093a8505bc); define `SessionApi` in [context.ts](https://github.com/wopr-network/wopr/pull/1857/files#diff-a98eea93fca781f8167b34e78fd2ca273fddb6ead76acfd16c3fbf72d9b432c6); update types and add tests.
>
> #### 🖇️ Linked Issues
> Implements [WOP-1538](https://linear.app/wopr/issue/WOP-1538) by exposing session context APIs to plugins.
>
> #### 📍Where to Start
> Start with the `createPluginContext` factory in [src/plugins/context-factory.ts](https://github.com/wopr-network/wopr/pull/1857/files#diff-d582617c48c761527d98598b3f7d23c1f39a18c7c3e14c950f14b7093a8505bc) to review the new `session` methods and their delegations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11ae5ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->