### PR TITLE
fix: exclude rate-limited providers from auto-select (WOP-1475)

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -41,7 +41,9 @@ export async function executeQuery(request: QueryRequest): Promise<ModelResponse
     config = request.providerConfig;
   } else {
     // Auto-detect: use first available provider
-    const available = providerRegistry.listProviders().filter((p) => p.available);
+    const available = providerRegistry
+      .listProviders()
+      .filter((p) => p.available && !rateLimitTracker.isRateLimited(p.id));
     if (available.length === 0) {
       throw new Error("No providers available. Configure at least one provider (anthropic, kimi, openai, etc.)");
     }
@@ -131,8 +133,11 @@ export async function executeQuery(request: QueryRequest): Promise<ModelResponse
     // excluded — they produce false positives on unrelated errors and would
     // mark healthy providers as rate-limited unnecessarily.
     // Note: RateLimitError always has statusCode=429, so it is caught below.
+    // Guard against null/undefined errors before property access.
     const is429 =
-      (error as { status?: number }).status === 429 || (error as { statusCode?: number }).statusCode === 429;
+      error != null &&
+      typeof error === "object" &&
+      ((error as { status?: number }).status === 429 || (error as { statusCode?: number }).statusCode === 429);
 
     if (is429 && resolved) {
       const retryAfter = (error as { retryAfterSeconds?: number }).retryAfterSeconds;

--- a/src/core/rate-limit-tracker.ts
+++ b/src/core/rate-limit-tracker.ts
@@ -15,6 +15,7 @@ export interface RateLimitEntry {
 
 export class RateLimitTracker {
   private limits = new Map<string, RateLimitEntry>();
+
   /** Base delay in ms for exponential backoff */
   private readonly baseDelayMs: number;
   /** Maximum backoff cap in ms */
@@ -32,10 +33,15 @@ export class RateLimitTracker {
    */
   markRateLimited(providerId: string, retryAfterSeconds?: number): void {
     const existing = this.limits.get(providerId);
-    const hits = (existing?.consecutiveHits ?? 0) + 1;
+    // Reset the hit counter when the previous backoff has already expired —
+    // a 429 after recovery is not "consecutive" and should not escalate backoff.
+    const isStillLimited = existing !== undefined && Date.now() < existing.retryAfter;
+    const hits = isStillLimited ? (existing.consecutiveHits ?? 0) + 1 : 1;
+
     let backoffMs: number;
     if (retryAfterSeconds !== undefined && retryAfterSeconds > 0) {
-      // Respect Retry-After header, capped to maxDelayMs to avoid locking out a provider indefinitely
+      // Respect Retry-After header, but cap to maxDelayMs to prevent a
+      // misbehaving or malicious provider from forcing unbounded backoff.
       backoffMs = Math.min(retryAfterSeconds * 1000, this.maxDelayMs);
     } else {
       // Exponential backoff with jitter: base * 2^(hits-1) + random jitter.
@@ -44,6 +50,7 @@ export class RateLimitTracker {
       const exp = Math.min(hits - 1, 30);
       backoffMs = Math.min(this.baseDelayMs * 2 ** exp + Math.random() * 500, this.maxDelayMs);
     }
+
     this.limits.set(providerId, {
       retryAfter: Date.now() + backoffMs,
       consecutiveHits: hits,
@@ -52,7 +59,8 @@ export class RateLimitTracker {
 
   /**
    * Check if a provider is currently rate-limited.
-   * Clears expired entries automatically.
+   * Expired entries are retained so consecutive-hit counts survive until
+   * a successful request calls {@link clearProvider}.
    */
   isRateLimited(providerId: string): boolean {
     const entry = this.limits.get(providerId);

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -435,8 +435,10 @@ async function executeInjectInternal(
     // Reuse early provider config (fetched above for context windowing)
     let providerConfig = earlyProviderConfig;
     if (!providerConfig) {
-      // Auto-detect: use first available provider
-      const available = providerRegistry.listProviders().filter((p) => p.available);
+      // Auto-detect: use first available, non-rate-limited provider
+      const available = providerRegistry
+        .listProviders()
+        .filter((p) => p.available && !rateLimitTracker.isRateLimited(p.id));
       if (available.length > 0) {
         providerConfig = {
           name: available[0].id,


### PR DESCRIPTION
Closes WOP-1475

## Summary by Sourcery

Track provider rate limiting and exclude rate-limited providers from automatic selection and fallback while updating base Docker images to use an internally mirrored Node image.

Bug Fixes:
- Skip providers that are currently rate-limited when auto-selecting or resolving providers so 429 responses do not repeatedly hit the same provider.

Enhancements:
- Introduce an in-memory rate limit tracker with exponential backoff to record 429 responses per provider and clear state on successful requests.
- Add a dedicated RateLimitError type to carry HTTP 429 metadata from providers.

Build:
- Update Dockerfile base images to use ghcr.io/wopr-network/base/node:24-bookworm-slim instead of the public node image.

CI:
- Add a GitHub Actions workflow to regularly mirror the upstream Node base image into the internal GHCR registry.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude rate‑limited providers from auto‑select and adjust rate limiting behavior in `src/core/query.ts` and `src/core/rate-limit-tracker.ts` to address WOP-1475
> Auto-detection now filters out providers flagged by `RateLimitTracker.isRateLimited`; 429 detection adds a guard for non-object errors; `RateLimitTracker.markRateLimited` resets consecutive hits after cooldown and caps `Retry-After` to `maxDelayMs`; `RateLimitTracker.isRateLimited` retains expired entries while returning false.
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1475](ticket:jira/WOP-1475) by excluding rate-limited providers from auto-select and tightening 429 handling.
>
> #### 📍Where to Start
> Start with provider filtering in `executeQuery` in [src/core/query.ts](https://github.com/wopr-network/wopr/pull/1938/files#diff-cde5dd1e237027b6cd074c19a82ea24370bf0da0834a22a1e524223be349f0fd), then review rate limit state changes in `RateLimitTracker` in [src/core/rate-limit-tracker.ts](https://github.com/wopr-network/wopr/pull/1938/files#diff-d707989614c1938eb12c9a2e5d2d4e2a3dcabb46ac4c075df83ff74341778e43).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4c1439.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rate limit detection with improved error handling
  * Provider auto-detection now excludes rate-limited providers for better reliability
  * Implemented exponential backoff strategy with jitter for intelligent retry timing of rate-limited providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->