### PR TITLE
security: add requireAuth() to plugin-mounted routes (WOP-1546)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -410,6 +410,12 @@ export async function startDaemon(config: DaemonConfig = {}): Promise<void> {
 
   daemonLog(`[heap] after plugins: ${heapMB()}`);
 
+  // Require auth context for plugin-mounted routes (WOP-1546)
+  app.use("/skills/*", requireAuth());
+  app.use("/crons/*", requireAuth());
+  app.use("/canvas/*", requireAuth());
+  app.use("/observability/*", requireAuth());
+
   // Mount plugin-provided REST routers
   const { getPluginExtension } = await import("../plugins/extensions.js");
   const maybeSkillsRouter = getPluginExtension("skills:router");

--- a/tests/daemon/plugin-routes-auth.test.ts
+++ b/tests/daemon/plugin-routes-auth.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("../../src/daemon/auth-token.js", () => ({
+  ensureToken: vi.fn(() => "test-token"),
+}));
+
+vi.mock("../../src/plugins/extensions.js", () => {
+  const skillsRouter = new Hono();
+  skillsRouter.get("/list", (c) => c.json({ skills: [] }));
+
+  const cronsRouter = new Hono();
+  cronsRouter.get("/list", (c) => c.json({ crons: [] }));
+
+  const canvasRouter = new Hono();
+  canvasRouter.get("/state", (c) => c.json({ canvas: {} }));
+
+  const metricsRouter = new Hono();
+  metricsRouter.get("/health", (c) => c.json({ healthy: true }));
+
+  return {
+    getPluginExtension: vi.fn((key: string) => {
+      const map: Record<string, Hono> = {
+        "skills:router": skillsRouter,
+        "crons:router": cronsRouter,
+        "canvas:router": canvasRouter,
+        "metrics:router": metricsRouter,
+      };
+      return map[key] ?? null;
+    }),
+  };
+});
+
+// Import requireAuth and create a minimal app that mirrors daemon setup
+import { requireAuth } from "../../src/daemon/middleware/auth.js";
+import { getPluginExtension } from "../../src/plugins/extensions.js";
+
+function buildTestApp() {
+  const app = new Hono();
+
+  // Apply requireAuth before mounting, same as production
+  app.use("/skills/*", requireAuth());
+  app.use("/crons/*", requireAuth());
+  app.use("/canvas/*", requireAuth());
+  app.use("/observability/*", requireAuth());
+
+  const skills = getPluginExtension("skills:router");
+  if (skills) app.route("/skills", skills as Hono);
+
+  const crons = getPluginExtension("crons:router");
+  if (crons) app.route("/crons", crons as Hono);
+
+  const canvas = getPluginExtension("canvas:router");
+  if (canvas) app.route("/canvas", canvas as Hono);
+
+  const metrics = getPluginExtension("metrics:router");
+  if (metrics) app.route("/observability", metrics as Hono);
+
+  return app;
+}
+
+describe("plugin-mounted routes require auth (WOP-1546)", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = buildTestApp();
+  });
+
+  const routes = [
+    { path: "/skills/list", name: "skills" },
+    { path: "/crons/list", name: "crons" },
+    { path: "/canvas/state", name: "canvas" },
+    { path: "/observability/health", name: "observability" },
+  ];
+
+  for (const { path, name } of routes) {
+    it(`${name}: rejects requests without auth header`, async () => {
+      const res = await app.request(path);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toContain("Authorization");
+    });
+
+    it(`${name}: rejects requests with invalid token`, async () => {
+      const res = await app.request(path, {
+        headers: { Authorization: "Bearer wrong-token" },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it(`${name}: accepts requests with valid daemon bearer token`, async () => {
+      const res = await app.request(path, {
+        headers: { Authorization: "Bearer test-token" },
+      });
+      expect(res.status).toBe(200);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
Closes WOP-1546

- Added `requireAuth()` middleware for `/skills/*`, `/crons/*`, `/canvas/*`, and `/observability/*` before plugin routers are mounted
- Follows the existing pattern at line 121 where `/api/keys/*` gets `requireAuth()`
- Added 12 tests covering unauthorized (no header), invalid token, and valid token scenarios for all 4 routes

## Test plan
- [x] `npm run check` passes (lint + tsc)
- [x] `npx vitest run tests/daemon/plugin-routes-auth.test.ts` — 12/12 pass

Generated with Claude Code

## Summary by Sourcery

Enforce authentication on plugin-mounted daemon routes and add tests verifying auth behavior for each route.

New Features:
- Protect plugin-mounted /skills, /crons, /canvas, and /observability routes with authentication middleware.

Tests:
- Add integration-style tests ensuring plugin-mounted routes reject missing or invalid auth tokens and accept valid daemon bearer tokens.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require auth on plugin-mounted routes by applying `requireAuth` in `daemon.startDaemon` for `/skills/*`, `/crons/*`, `/canvas/*`, and `/observability/*`
> Apply auth middleware before mounting plugin routers in `daemon.startDaemon`, and add tests verifying 401/403 behavior and valid token acceptance in [plugin-routes-auth.test.ts](https://github.com/wopr-network/wopr/pull/1945/files#diff-5feebfc981e51ad9c0d526599d7847c97c6709722cdb70593ebd192584237863).
>
> #### 🖇️ Linked Issues
> Resolves [WOP-1546](https://linear.app/wopr/issue/WOP-1546) by enforcing authentication on plugin-mounted routes.
>
> #### 📍Where to Start
> Start in `startDaemon` within [index.ts](https://github.com/wopr-network/wopr/pull/1945/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078) to see middleware registration for `/skills`, `/crons`, `/canvas`, and `/observability`, then review tests in [tests/daemon/plugin-routes-auth.test.ts](https://github.com/wopr-network/wopr/pull/1945/files#diff-5feebfc981e51ad9c0d526599d7847c97c6709722cdb70593ebd192584237863).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8dfac94. 1 file reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->