### PR TITLE
test: fix session-cleaner start/stop tests hanging 24s in CI

### DIFF
--- a/tests/unit/session-cleaner.test.ts
+++ b/tests/unit/session-cleaner.test.ts
@@ -285,6 +285,9 @@ describe("SessionCleaner", () => {
 
   it("should start and stop the interval", async () => {
     const cleaner = new SessionCleaner({ ttlMs: 86400000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    // Spy on cleanup so start()'s fire-and-forget initial cleanup doesn't race with
+    // the next test's beforeEach resetting storage (which would cause a 24s hang).
+    vi.spyOn(cleaner, "cleanup").mockResolvedValue({ expiredRemoved: 0, lruEvicted: 0, lastCleanupAt: 0, isRunning: false });
 
     cleaner.start();
     expect(cleaner.getStats().isRunning).toBe(true);
@@ -295,6 +298,8 @@ describe("SessionCleaner", () => {
 
   it("should not start a second interval if already running", async () => {
     const cleaner = new SessionCleaner({ ttlMs: 86400000, maxCount: 1000, cleanupIntervalMs: 60000 });
+    // Same guard: prevent start()'s background cleanup from racing with storage reset.
+    vi.spyOn(cleaner, "cleanup").mockResolvedValue({ expiredRemoved: 0, lruEvicted: 0, lastCleanupAt: 0, isRunning: false });
 
     cleaner.start();
     const statsBefore = cleaner.getStats();


### PR DESCRIPTION
**Repo:** wopr-network/wopr

## Summary

- `start()` fires an initial `cleanup()` as a fire-and-forget promise
- When the next test's `beforeEach` calls `storage.resetStorage()`, the in-flight SQLite queries in `cleanup()` hang — causing the test to report 24s timeout in CI
- The start/stop lifecycle tests don't test cleanup behavior (separate tests cover that), so spy on `cleanup()` to make the background call a no-op

## Test plan
- [x] `npx vitest run tests/unit/session-cleaner.test.ts` — 20/20 pass in 52ms (was hanging 24s+)
- [x] `npm run check` passes

Unblocks WOP-1546 (#1945) and WOP-1603 (#1947) from merge queue.

Generated with Claude Code

## Summary by Sourcery

Tests:
- Stub SessionCleaner.cleanup in start/stop lifecycle tests to avoid races with storage reset that caused long-running CI timeouts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stub `SessionCleaner.cleanup` in unit tests to prevent 24s CI hangs when starting and stopping intervals in [session-cleaner.test.ts](https://github.com/wopr-network/wopr/pull/2008/files#diff-2565a035b7d6108f4327da81e2948a34a88b51bb7b64d5b3a91db8e81ccdfae1)
> Add `vi.spyOn(cleaner, "cleanup").mockResolvedValue(...)` in two `SessionCleaner` tests to stub the initial cleanup invoked by `start()`, returning a resolved stats object and avoiding real execution.
>
> #### 📍Where to Start
> Begin with the modified tests in [session-cleaner.test.ts](https://github.com/wopr-network/wopr/pull/2008/files#diff-2565a035b7d6108f4327da81e2948a34a88b51bb7b64d5b3a91db8e81ccdfae1), focusing on the `"should start and stop the interval"` and `"should not start a second interval if already running"` blocks where `cleanup` is mocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81193e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->