### PR TITLE
test: replace toBeDefined() with exact value assertions in temporal filter tests (WOP-1597)

### DIFF
--- a/tests/core/a2a-base-temporal.test.ts
+++ b/tests/core/a2a-base-temporal.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseTemporalFilter } from "../../src/core/a2a-tools/_base.js";
 
 describe("parseTemporalFilter", () => {
+  const FIXED_NOW = new Date("2024-03-15T12:00:00.000Z").getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("parses ISO datetime with uppercase T", () => {
     const result = parseTemporalFilter("2024-01-01T10:00:00");
     expect(result).not.toBeNull();
@@ -30,17 +41,10 @@ describe("parseTemporalFilter", () => {
   });
 
   it("parses relative expressions", () => {
-    const fixedNow = new Date("2024-06-15T12:00:00.000Z").getTime();
-    vi.useFakeTimers();
-    vi.setSystemTime(fixedNow);
-    try {
-      const result = parseTemporalFilter("last 7 days");
-      expect(result).not.toBeNull();
-      const expected7d = 7 * 24 * 60 * 60 * 1000;
-      expect(result?.after).toBe(fixedNow - expected7d);
-    } finally {
-      vi.useRealTimers();
-    }
+    const result = parseTemporalFilter("last 7 days");
+    expect(result).not.toBeNull();
+    const expected7d = 7 * 24 * 60 * 60 * 1000;
+    expect(result?.after).toBe(FIXED_NOW - expected7d);
   });
 
   it("parses single date", () => {


### PR DESCRIPTION
## Summary
- Replaces weak `toBeDefined()` assertions with specific value checks in `tests/core/a2a-base-temporal.test.ts`
- Ensures parsed temporal values are correct, not just defined

Closes WOP-1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Strengthen temporal filter tests for relative and single-date expressions by validating computed timestamp ranges and exact start/end-of-day values.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `toBeDefined()` with exact millisecond assertions and freeze system time in [a2a-base-temporal.test.ts](https://github.com/wopr-network/wopr/pull/2040/files#diff-92c3c5395c0db1e61c84acf94a64eebe1570ee30e10b20ff363445cc5ce1d7d7) to validate temporal filter parsing for last 7 days and a single date
> Introduce Vitest fake timers with a fixed `Date` (2024-03-15T12:00:00.000Z) and assert exact `after`/`before` millisecond values for relative (last 7 days) and single-date cases in [a2a-base-temporal.test.ts](https://github.com/wopr-network/wopr/pull/2040/files#diff-92c3c5395c0db1e61c84acf94a64eebe1570ee30e10b20ff363445cc5ce1d7d7).
>
> #### 🖇️ Linked Issues
> This pull request addresses [WOP-1597](https://linear.app/wopr/issue/WOP-1597) by replacing loose temporal assertions with exact millisecond checks.
>
> #### 📍Where to Start
> Start with the `parseTemporalFilter` describe block setup and updated tests in [a2a-base-temporal.test.ts](https://github.com/wopr-network/wopr/pull/2040/files#diff-92c3c5395c0db1e61c84acf94a64eebe1570ee30e10b20ff363445cc5ce1d7d7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c7f7b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for temporal expressions with fixed time references and controlled timer behavior.
  * Enhanced date-range calculations testing to verify accurate boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->