### PR TITLE
security: enforce API key scope on WebSocket topic subscriptions (WOP-1712)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -299,41 +299,44 @@ export async function startDaemon(config: DaemonConfig = {}): Promise<void> {
   // WebSocket handler factory (shared by /ws and /api/ws)
   // bearerAuth() middleware has already validated the token during the HTTP upgrade
   // request, so all connections reaching here are pre-authenticated (WOP-1407)
-  const wsHandler = upgradeWebSocket(() => ({
-    onOpen(_event, ws) {
-      setupWebSocket(ws as unknown as { send(data: string): void }, { preAuthenticated: true });
-    },
-    onMessage(event, ws) {
-      const data = event.data;
-      if (data == null) return;
-      let message: string;
-      if (typeof data === "string") {
-        message = data;
-      } else if (Buffer.isBuffer(data)) {
-        message = data.toString("utf-8");
-      } else if (data instanceof ArrayBuffer) {
-        message = Buffer.from(data).toString("utf-8");
-      } else if (Array.isArray(data)) {
-        message = Buffer.concat(data).toString("utf-8");
-      } else {
-        message = String(data);
-      }
-      try {
-        handleWebSocketMessage(ws as unknown as { send(data: string): void }, message);
-      } catch (err) {
-        winstonLogger.error(
-          `[daemon] WebSocket message handler error: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    },
-    onClose(_event, ws) {
-      handleWebSocketClose(ws as unknown as { send(data: string): void });
-    },
-  }));
+  // Scope is threaded from the auth middleware for topic subscription enforcement (WOP-1712)
+  const createWsHandler = () =>
+    upgradeWebSocket((c) => ({
+      onOpen(_event, ws) {
+        const scope = c.get("apiKeyScope") as string | undefined;
+        setupWebSocket(ws as unknown as { send(data: string): void }, { preAuthenticated: true, scope });
+      },
+      onMessage(event, ws) {
+        const data = event.data;
+        if (data == null) return;
+        let message: string;
+        if (typeof data === "string") {
+          message = data;
+        } else if (Buffer.isBuffer(data)) {
+          message = data.toString("utf-8");
+        } else if (data instanceof ArrayBuffer) {
+          message = Buffer.from(data).toString("utf-8");
+        } else if (Array.isArray(data)) {
+          message = Buffer.concat(data).toString("utf-8");
+        } else {
+          message = String(data);
+        }
+        try {
+          handleWebSocketMessage(ws as unknown as { send(data: string): void }, message);
+        } catch (err) {
+          winstonLogger.error(
+            `[daemon] WebSocket message handler error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      },
+      onClose(_event, ws) {
+        handleWebSocketClose(ws as unknown as { send(data: string): void });
+      },
+    }));
 
   // WebSocket endpoints (WOP-204: /api/ws is the canonical path; /ws kept for backward compat)
-  app.get("/ws", wsHandler);
-  app.get("/api/ws", wsHandler);
+  app.get("/ws", createWsHandler());
+  app.get("/api/ws", createWsHandler());
 
   // Create injectors for plugins
   const injectors = {

--- a/src/daemon/ws.ts
+++ b/src/daemon/ws.ts
@@ -55,6 +55,8 @@ interface ClientState {
   topics: Set<string>;
   /** Whether this client has authenticated (ticket-based auth) */
   authenticated: boolean;
+  /** API key scope — undefined means unrestricted (daemon bearer token) */
+  scope?: string;
   /** Messages sent since last heartbeat tick (for backpressure detection) */
   messagesSinceHeartbeat: number;
   /** Whether this client is experiencing backpressure */
@@ -62,6 +64,26 @@ interface ClientState {
   /** Last time we received a pong or message from this client */
   lastActivity: number;
 }
+
+/**
+ * Check whether a topic is allowed for the given API key scope.
+ * - undefined/full/read-only scope: all topics allowed
+ * - instance:<id> scope: only instance:<id> and instance:<id>:* topics allowed
+ */
+function isTopicAllowedForScope(topic: string, scope: string | undefined): boolean {
+  if (!scope || scope === "full" || scope === "read-only") return true;
+
+  if (scope.startsWith("instance:")) {
+    if (topic === scope) return true;
+    if (topic.startsWith(`${scope}:`)) return true;
+    return false;
+  }
+
+  return false;
+}
+
+/** @internal Exported for testing only */
+export { isTopicAllowedForScope as _isTopicAllowedForScope };
 
 /** Auth timeout: close unauthenticated connections after 2 seconds (WOP-1407) */
 const AUTH_TIMEOUT_MS = 2_000;
@@ -73,6 +95,8 @@ const authTimeouts = new Map<WS, ReturnType<typeof setTimeout>>();
 export interface SetupWebSocketOptions {
   /** When true, skip the auth timeout — the HTTP upgrade already validated the token */
   preAuthenticated?: boolean;
+  /** API key scope from auth middleware — undefined = unrestricted */
+  scope?: string;
 }
 
 /** Maximum messages per heartbeat interval before disconnecting as slow consumer */
@@ -98,6 +122,7 @@ export function setupWebSocket(ws: WS, options?: SetupWebSocketOptions): void {
     ws,
     topics: new Set(),
     authenticated: preAuth,
+    scope: options?.scope,
     messagesSinceHeartbeat: 0,
     backpressured: false,
     lastActivity: Date.now(),
@@ -189,28 +214,73 @@ function handleMessage(state: ClientState, msg: Record<string, unknown>): void {
         break;
       }
 
-      // Topic-based subscriptions (WOP-204)
+      // Topic-based subscriptions (WOP-204, scope enforcement WOP-1712)
       const topics = msg.topics as string[] | undefined;
       if (topics && Array.isArray(topics)) {
+        const allowed: string[] = [];
+        const rejected: string[] = [];
         for (const t of topics) {
           if (typeof t === "string" && t.length > 0) {
-            state.topics.add(t);
+            if (isTopicAllowedForScope(t, state.scope)) {
+              state.topics.add(t);
+              allowed.push(t);
+            } else {
+              rejected.push(t);
+            }
           }
         }
-        safeSend(state, { type: "subscribed", topics: Array.from(state.topics) });
+        if (rejected.length > 0) {
+          safeSend(state, {
+            type: "error",
+            message: `Topic subscription denied: scope "${state.scope}" does not permit: ${rejected.join(", ")}`,
+            code: "SCOPE_DENIED",
+            rejected,
+          });
+        }
+        if (allowed.length > 0) {
+          safeSend(state, { type: "subscribed", topics: Array.from(state.topics) });
+        }
         break;
       }
 
       // Legacy: session-based subscriptions (map to topic pattern)
       const sessions = msg.sessions as string[] | undefined;
       if (sessions && Array.isArray(sessions)) {
+        const allowed: string[] = [];
+        const rejected: string[] = [];
         for (const s of sessions) {
-          if (typeof s === "string") state.topics.add(s);
+          if (typeof s === "string") {
+            if (isTopicAllowedForScope(s, state.scope)) {
+              state.topics.add(s);
+              allowed.push(s);
+            } else {
+              rejected.push(s);
+            }
+          }
         }
-        safeSend(state, { type: "subscribed", sessions, topics: Array.from(state.topics) });
+        if (rejected.length > 0) {
+          safeSend(state, {
+            type: "error",
+            message: `Topic subscription denied: scope "${state.scope}" does not permit: ${rejected.join(", ")}`,
+            code: "SCOPE_DENIED",
+            rejected,
+          });
+        }
+        if (allowed.length > 0) {
+          safeSend(state, { type: "subscribed", sessions: allowed, topics: Array.from(state.topics) });
+        }
       } else if (typeof msg.session === "string") {
-        state.topics.add(msg.session);
-        safeSend(state, { type: "subscribed", sessions: [msg.session], topics: Array.from(state.topics) });
+        if (isTopicAllowedForScope(msg.session, state.scope)) {
+          state.topics.add(msg.session);
+          safeSend(state, { type: "subscribed", sessions: [msg.session], topics: Array.from(state.topics) });
+        } else {
+          safeSend(state, {
+            type: "error",
+            message: `Topic subscription denied: scope "${state.scope}" does not permit: ${msg.session}`,
+            code: "SCOPE_DENIED",
+            rejected: [msg.session],
+          });
+        }
       }
       break;
     }

--- a/tests/unit/ws.test.ts
+++ b/tests/unit/ws.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CLIENT_TIMEOUT_MS,
   HEARTBEAT_INTERVAL_MS,
+  _isTopicAllowedForScope,
   _resetForTesting,
   _setTokenVerifier,
   broadcast,
@@ -746,5 +747,157 @@ describe("Multiple clients", () => {
     handleWebSocketMessage(ws1, JSON.stringify({ type: "subscribe", topics: ["*"] }));
     emitInstanceStatus("a", "ok");
     expect(ws1.allMessages().filter((m) => m.type === "instance:status")).toHaveLength(1);
+  });
+});
+
+describe("Topic scope enforcement (WOP-1712)", () => {
+  describe("isTopicAllowedForScope", () => {
+    it("should allow all topics when scope is undefined", () => {
+      expect(_isTopicAllowedForScope("instance:def:logs", undefined)).toBe(true);
+      expect(_isTopicAllowedForScope("*", undefined)).toBe(true);
+    });
+
+    it("should allow all topics for full scope", () => {
+      expect(_isTopicAllowedForScope("instance:def:logs", "full")).toBe(true);
+      expect(_isTopicAllowedForScope("*", "full")).toBe(true);
+    });
+
+    it("should allow all topics for read-only scope", () => {
+      expect(_isTopicAllowedForScope("instance:def:logs", "read-only")).toBe(true);
+      expect(_isTopicAllowedForScope("*", "read-only")).toBe(true);
+    });
+
+    it("should allow matching instance topic", () => {
+      expect(_isTopicAllowedForScope("instance:abc", "instance:abc")).toBe(true);
+      expect(_isTopicAllowedForScope("instance:abc:logs", "instance:abc")).toBe(true);
+      expect(_isTopicAllowedForScope("instance:abc:status", "instance:abc")).toBe(true);
+    });
+
+    it("should deny non-matching instance topic", () => {
+      expect(_isTopicAllowedForScope("instance:def:logs", "instance:abc")).toBe(false);
+      expect(_isTopicAllowedForScope("instance:def", "instance:abc")).toBe(false);
+    });
+
+    it("should deny wildcard for instance scope", () => {
+      expect(_isTopicAllowedForScope("*", "instance:abc")).toBe(false);
+    });
+
+    it("should deny 'instances' topic for instance scope", () => {
+      expect(_isTopicAllowedForScope("instances", "instance:abc")).toBe(false);
+    });
+
+    it("should deny unknown scope by default", () => {
+      expect(_isTopicAllowedForScope("anything", "custom-scope")).toBe(false);
+    });
+  });
+
+  it("should reject out-of-scope topic for instance-scoped key", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instance:def:logs"] }));
+    const msgs = ws.allMessages();
+    const errorMsg = msgs.find((m) => m.type === "error" && typeof m.message === "string" && m.message.includes("scope"));
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg?.code).toBe("SCOPE_DENIED");
+  });
+
+  it("should allow in-scope topic for instance-scoped key", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instance:abc:logs"] }));
+    const msgs = ws.allMessages();
+    const subMsg = msgs.find((m) => m.type === "subscribed");
+    expect(subMsg).toBeDefined();
+    expect(subMsg?.topics).toContain("instance:abc:logs");
+  });
+
+  it("should block wildcard subscription for instance-scoped key", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["*"] }));
+    const msgs = ws.allMessages();
+    const errorMsg = msgs.find((m) => m.type === "error" && m.code === "SCOPE_DENIED");
+    expect(errorMsg).toBeDefined();
+  });
+
+  it("should block 'instances' topic for instance-scoped key", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instances"] }));
+    const msgs = ws.allMessages();
+    const errorMsg = msgs.find((m) => m.type === "error" && m.code === "SCOPE_DENIED");
+    expect(errorMsg).toBeDefined();
+  });
+
+  it("should allow all topics for full-scope key", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "full" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instance:def:logs", "*"] }));
+    const subMsg = ws.allMessages().find((m) => m.type === "subscribed");
+    expect(subMsg).toBeDefined();
+    expect(subMsg?.topics).toContain("*");
+  });
+
+  it("should allow all topics for read-only scope", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "read-only" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instance:def:logs", "*"] }));
+    const subMsg = ws.allMessages().find((m) => m.type === "subscribed");
+    expect(subMsg).toBeDefined();
+    expect(subMsg?.topics).toContain("*");
+  });
+
+  it("should allow all topics when no scope (daemon bearer token)", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instance:def:logs", "*"] }));
+    const subMsg = ws.allMessages().find((m) => m.type === "subscribed");
+    expect(subMsg).toBeDefined();
+    expect(subMsg?.topics).toContain("*");
+  });
+
+  it("should allow instance:abc base topic for instance:abc scoped key", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", topics: ["instance:abc"] }));
+    const subMsg = ws.allMessages().find((m) => m.type === "subscribed");
+    expect(subMsg).toBeDefined();
+    expect(subMsg?.topics).toContain("instance:abc");
+  });
+
+  it("should enforce scope on legacy session-based subscriptions", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", sessions: ["def"] }));
+    const msgs = ws.allMessages();
+    const errorMsg = msgs.find((m) => m.type === "error" && m.code === "SCOPE_DENIED");
+    expect(errorMsg).toBeDefined();
+  });
+
+  it("should enforce scope on legacy single session subscription", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({ type: "subscribe", session: "def" }));
+    const msgs = ws.allMessages();
+    const errorMsg = msgs.find((m) => m.type === "error" && m.code === "SCOPE_DENIED");
+    expect(errorMsg).toBeDefined();
+  });
+
+  it("should partially subscribe only allowed topics from a mixed list", () => {
+    const ws = createMockWs();
+    setupWebSocket(ws, { preAuthenticated: true, scope: "instance:abc" });
+    handleWebSocketMessage(ws, JSON.stringify({
+      type: "subscribe",
+      topics: ["instance:abc:logs", "instance:def:logs", "instance:abc:status"],
+    }));
+    const msgs = ws.allMessages();
+    const errorMsg = msgs.find((m) => m.type === "error" && m.code === "SCOPE_DENIED");
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg?.rejected).toContain("instance:def:logs");
+    const subMsg = msgs.find((m) => m.type === "subscribed");
+    expect(subMsg).toBeDefined();
+    expect(subMsg?.topics).toContain("instance:abc:logs");
+    expect(subMsg?.topics).toContain("instance:abc:status");
+    expect(subMsg?.topics).not.toContain("instance:def:logs");
   });
 });


### PR DESCRIPTION
## Summary
Closes WOP-1712

- Add `isTopicAllowedForScope()` to validate WebSocket topic subscriptions against API key scope
- Instance-scoped keys (`instance:<id>`) can only subscribe to `instance:<id>` and `instance:<id>:*` topics
- Wildcard (`*`), `instances`, and cross-instance topics are blocked for instance-scoped keys
- `full`, `read-only`, and daemon bearer token (no scope) remain unrestricted
- Thread `apiKeyScope` from Hono auth middleware into WebSocket setup via `SetupWebSocketOptions.scope`
- Scope enforcement applies to both topic-based and legacy session-based subscriptions
- Mixed topic lists are partially subscribed: allowed topics succeed, rejected topics return `SCOPE_DENIED` error

## Test plan
- [x] `npm run check` passes (lint + type check)
- [x] `npx vitest run tests/unit/ws.test.ts` — 67 tests pass
- [x] Tests cover: instance scope allow/deny, wildcard blocking, full/read-only/undefined scope passthrough, legacy session enforcement, partial subscription of mixed lists

Generated with Claude Code

## Summary by Sourcery

Enforce API key scope on WebSocket topic and session subscriptions and propagate scope from HTTP auth into the WebSocket layer.

Bug Fixes:
- Restrict instance-scoped API keys to subscribing only to their own instance topics and block wildcard, instances, and cross-instance topics, returning SCOPE_DENIED for violations.

Enhancements:
- Introduce a reusable topic-scope guard used by WebSocket subscriptions, with partial subscription support so allowed topics are subscribed while out-of-scope topics are rejected.
- Thread API key scope from the Hono auth middleware into WebSocket client state for consistent authorization across topic- and session-based subscriptions.

Tests:
- Add unit tests covering topic scope helper behavior and WebSocket subscription flows for different scopes, including instance, full, read-only, undefined, legacy session-based, and mixed allowed/denied topic lists.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce API key scope on WebSocket topic subscriptions by passing request `apiKeyScope` into `ws.setupWebSocket` for `/ws` and `/api/ws`
> Add per-client `scope` to WebSocket state, pass request scope from a new handler factory, and gate `subscribe` requests via `ws.isTopicAllowedForScope`, returning `SCOPE_DENIED` for out-of-scope topics or sessions. Tests cover predicate behavior and subscription acceptance/rejection.
>
> #### 🖇️ Linked Issues
> This pull request implements scope enforcement for [WOP-1712](ticket:jira/WOP-1712) by filtering WebSocket subscriptions based on API key scope.
>
> #### 📍Where to Start
> Start with the subscription gate in `subscribe` handling within `ws.handleMessage` in [ws.ts](https://github.com/wopr-network/wopr/pull/2136/files#diff-e665b94f790667d6f6d6dce3cca8b8e346313dde40345ed0afc0e97de1f9b520), then review the handler factory and scope plumbing in [index.ts](https://github.com/wopr-network/wopr/pull/2136/files#diff-b3105ffb52045f68c5260781fab9f524995a7dee64a8e2c9b9e92c01999db078).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e441065. 2 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->