### PR TITLE
ci: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,11 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    uses: wopr-network/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit
+


### PR DESCRIPTION
Adds the org-wide dependabot auto-merge reusable workflow. Patch/minor dependabot PRs will be auto-approved and merged when CI passes.

## Summary by Sourcery

CI:
- Add a reusable Dependabot auto-merge workflow that triggers on pull request events and delegates to the org-wide workflow configuration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Dependabot auto-merge GitHub Actions workflow to run on pull_request opened, synchronize, and reopened events in [.github/workflows/dependabot-auto-merge.yml](https://github.com/wopr-network/wopr/pull/2318/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1)
> Add a workflow that delegates to `wopr-network/.github/.github/workflows/dependabot-auto-merge.yml@main` with `secrets: inherit` and triggers on `pull_request` events: `opened`, `synchronize`, `reopened`.
>
> #### 📍Where to Start
> Start with the workflow definition in [.github/workflows/dependabot-auto-merge.yml](https://github.com/wopr-network/wopr/pull/2318/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9067a3b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->